### PR TITLE
env: add Rust feature to the DevContainer setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,11 +3,6 @@ ARG CLAUDE_CODE_VERSION=latest
 # Stage 1: nushell
 FROM ghcr.io/nushell/nushell:latest-bookworm AS nushell-stage
 
-# Stage 2: Rust tools
-FROM rust:1.88-bookworm AS rust-stage
-RUN rustup component add rustfmt clippy \
-    && cargo install cargo-watch cargo-expand
-
 # Stage 3: Elm compiler
 FROM debian:bookworm-slim AS elm-stage
 # https://github.com/elm/compiler/blob/master/installers/linux/README.md
@@ -42,21 +37,14 @@ FROM base-tools AS without-agent-cli
 
 # Copy tools from build stages
 COPY --from=nushell-stage /usr/bin/nu /usr/local/bin/nu
-COPY --from=rust-stage /usr/local/cargo /usr/local/cargo
-COPY --from=rust-stage /usr/local/rustup /usr/local/rustup
 COPY --from=elm-stage /usr/local/bin/elm /usr/local/bin/elm
-
-# Setup environment and tools
-ENV CARGO_HOME=/usr/local/cargo \
-    RUSTUP_HOME=/usr/local/rustup \
-    PATH=/usr/local/cargo/bin:$PATH
 
 ARG USERNAME=node
 
 RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && npm install -g elm-format elm-test elm-review elm-verify-examples elm-pages \
-    && mkdir -p /home/$USERNAME/.elm /home/$USERNAME/.cargo /home/$USERNAME/.rustup \
-    && chown -R $USERNAME:$USERNAME /home/$USERNAME /usr/local/cargo /usr/local/rustup
+    && mkdir -p /home/$USERNAME/.elm \
+    && chown -R $USERNAME:$USERNAME /home/$USERNAME
 
 # Create workspace and config directories and set permissions
 RUN mkdir -p /workspace /home/$USERNAME/.cursor && \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
 	"name": "Rust + Elm",
 	"dockerFile": "Dockerfile",
+	"features": {
+		"ghcr.io/devcontainers/features/rust:1": {}
+	},
 	"customizations": {
 		"vscode": {
 			"extensions": [
@@ -23,8 +26,7 @@
 	},
 	"remoteUser": "node",
 	"mounts": [
-		"source=elm-cache,target=/home/node/.elm,type=volume",
-		"source=cargo-cache,target=/home/node/.cargo,type=volume"
+		"source=elm-cache,target=/home/node/.elm,type=volume"
 	],
 	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
 	"workspaceFolder": "/workspace",


### PR DESCRIPTION
This pull request updates the development container setup by moving Rust tool installation from the Dockerfile to a Dev Container feature, simplifying the Dockerfile and configuration. The most important changes are grouped below.

**Devcontainer configuration improvements:**

* Added the `ghcr.io/devcontainers/features/rust:1` feature to `devcontainer.json` to install Rust using Dev Container features instead of building it manually in the Dockerfile.
* Removed the persistent mount for the Cargo cache (`.cargo`) in `devcontainer.json`, as Rust and its cache are now managed by the Dev Container feature.

**Dockerfile simplification:**

* Removed the Rust tools build stage and related environment setup from the Dockerfile, as Rust is now installed via the Dev Container feature. [[1]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L6-L10) [[2]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L45-R47)