### PR TITLE
refactor: restructure CLI architecture with typed errors, argument parsing, and pipeline separation

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -91,6 +91,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "walkdir",
 ]
 
 [[package]]
@@ -407,6 +408,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +528,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +587,15 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -3,6 +3,65 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,12 +84,20 @@ name = "cli"
 version = "0.1.0"
 dependencies = [
  "csv",
+ "env_logger",
+ "log",
  "motorsport",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "csv"
@@ -51,6 +118,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -134,10 +224,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -184,6 +304,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,6 +357,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustix"
@@ -340,6 +510,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wasip2"

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]
@@ -306,6 +307,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/cli/cli/Cargo.toml
+++ b/cli/cli/Cargo.toml
@@ -8,6 +8,8 @@ motorsport = { path = "../motorsport" }
 csv = "1.3"
 serde = { workspace = true }
 serde_json = { workspace = true }
+log = "0.4"
+env_logger = "0.11"
 thiserror = "2"
 
 [dev-dependencies]

--- a/cli/cli/Cargo.toml
+++ b/cli/cli/Cargo.toml
@@ -8,6 +8,7 @@ motorsport = { path = "../motorsport" }
 csv = "1.3"
 serde = { workspace = true }
 serde_json = { workspace = true }
+thiserror = "2"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/cli/cli/Cargo.toml
+++ b/cli/cli/Cargo.toml
@@ -11,6 +11,7 @@ serde_json = { workspace = true }
 log = "0.4"
 env_logger = "0.11"
 thiserror = "2"
+walkdir = "2"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/cli/cli/src/args.rs
+++ b/cli/cli/src/args.rs
@@ -68,31 +68,51 @@ impl RawArgs {
     fn resolve(self) -> Result<Vec<FileTask>, CliError> {
         let path = self.input_path;
 
-        if !path.exists() {
-            Err(CliError::InputPathNotFound(path.display().to_string()))
-        } else if path.is_dir() {
-            if self.output_file.is_some() {
-                return Err(CliError::OutputWithDirectory);
-            }
-            let csv_files = find_csv_files(&path)?;
-            if csv_files.is_empty() {
-                return Err(CliError::NoCsvFilesFound(path.display().to_string()));
-            }
-            Ok(csv_files
-                .into_iter()
-                .map(|f| FileTask::new(f, None))
-                .collect())
-        } else if path.is_file() {
-            Ok(vec![FileTask::new(path, self.output_file)])
-        } else {
-            Err(CliError::InvalidInputPath(path.display().to_string()))
+        match classify_path(&path) {
+            PathKind::NotFound => Err(CliError::InputPathNotFound(path.display().to_string())),
+            PathKind::File => Ok(vec![FileTask::new(path, self.output_file)]),
+            PathKind::Dir => resolve_dir(path, self.output_file),
+            PathKind::Other => Err(CliError::InvalidInputPath(path.display().to_string())),
         }
     }
+}
+
+fn resolve_dir(path: PathBuf, output_file: Option<PathBuf>) -> Result<Vec<FileTask>, CliError> {
+    if output_file.is_some() {
+        return Err(CliError::OutputWithDirectory);
+    }
+    let csv_files = find_csv_files(&path)?;
+    if csv_files.is_empty() {
+        return Err(CliError::NoCsvFilesFound(path.display().to_string()));
+    }
+    Ok(csv_files
+        .into_iter()
+        .map(|f| FileTask::new(f, None))
+        .collect())
 }
 
 /// CLI 引数をパースし、検証済みの処理タスクリストを返す
 pub fn parse_args(args: impl Iterator<Item = String>) -> Result<Vec<FileTask>, CliError> {
     RawArgs::parse(args)?.resolve()
+}
+
+enum PathKind {
+    NotFound,
+    File,
+    Dir,
+    Other,
+}
+
+fn classify_path(path: &Path) -> PathKind {
+    if !path.exists() {
+        PathKind::NotFound
+    } else if path.is_file() {
+        PathKind::File
+    } else if path.is_dir() {
+        PathKind::Dir
+    } else {
+        PathKind::Other
+    }
 }
 
 /// ディレクトリ内のCSVファイルを再帰的に検索

--- a/cli/cli/src/args.rs
+++ b/cli/cli/src/args.rs
@@ -14,27 +14,54 @@ struct RawArgs {
 impl RawArgs {
     /// 純粋な引数パース（I/O なし）
     fn parse(mut args: impl Iterator<Item = String>) -> Result<Self, CliError> {
+        enum ParseState {
+            Ready {
+                input: Option<String>,
+                output: Option<PathBuf>,
+            },
+            ExpectingOutputValue {
+                input: Option<String>,
+            },
+        }
         args.next();
 
-        let mut input_path = None;
-        let mut output_file: Option<PathBuf> = None;
+        let final_state = args.try_fold(
+            ParseState::Ready {
+                input: None,
+                output: None,
+            },
+            |state, arg| match state {
+                ParseState::ExpectingOutputValue { input } => Ok(ParseState::Ready {
+                    input,
+                    output: Some(PathBuf::from(arg)),
+                }),
+                ParseState::Ready { input, .. } if arg == "--output" => {
+                    Ok(ParseState::ExpectingOutputValue { input })
+                }
+                ParseState::Ready {
+                    input: None,
+                    output,
+                } => Ok(ParseState::Ready {
+                    input: Some(arg),
+                    output,
+                }),
+                ParseState::Ready {
+                    input: Some(_), ..
+                } => Err(CliError::UnexpectedArgument(arg)),
+            },
+        )?;
 
-        while let Some(arg) = args.next() {
-            if arg == "--output" {
-                output_file = Some(PathBuf::from(
-                    args.next().ok_or(CliError::MissingOutputValue)?,
-                ));
-            } else if input_path.is_none() {
-                input_path = Some(arg);
-            } else {
-                return Err(CliError::UnexpectedArgument(arg));
-            }
+        match final_state {
+            ParseState::Ready {
+                input: Some(input),
+                output,
+            } => Ok(RawArgs {
+                input_path: PathBuf::from(input),
+                output_file: output,
+            }),
+            ParseState::Ready { input: None, .. } => Err(CliError::MissingInputPath),
+            ParseState::ExpectingOutputValue { .. } => Err(CliError::MissingOutputValue),
         }
-
-        Ok(RawArgs {
-            input_path: PathBuf::from(input_path.ok_or(CliError::MissingInputPath)?),
-            output_file,
-        })
     }
 
     /// ファイルシステムを参照して検証済み FileTask のリストに変換

--- a/cli/cli/src/args.rs
+++ b/cli/cli/src/args.rs
@@ -34,9 +34,13 @@ impl RawArgs {
                     input,
                     output: Some(PathBuf::from(arg)),
                 }),
-                ParseState::Ready { input, .. } if arg == "--output" => {
-                    Ok(ParseState::ExpectingOutputValue { input })
-                }
+                ParseState::Ready {
+                    input,
+                    output: None,
+                } if arg == "--output" => Ok(ParseState::ExpectingOutputValue { input }),
+                ParseState::Ready {
+                    output: Some(_), ..
+                } if arg == "--output" => Err(CliError::DuplicateOutput),
                 ParseState::Ready {
                     input: None,
                     output,
@@ -65,6 +69,25 @@ impl RawArgs {
 
     /// ファイルシステムを参照して検証済み FileTask のリストに変換
     fn resolve(self) -> Result<Vec<FileTask>, CliError> {
+        enum PathKind {
+            NotFound,
+            File,
+            Dir,
+            Other,
+        }
+
+        fn classify_path(path: &Path) -> PathKind {
+            if !path.exists() {
+                PathKind::NotFound
+            } else if path.is_file() {
+                PathKind::File
+            } else if path.is_dir() {
+                PathKind::Dir
+            } else {
+                PathKind::Other
+            }
+        }
+
         let path = self.input_path;
 
         match classify_path(&path) {
@@ -95,36 +118,18 @@ pub fn parse_args(args: impl Iterator<Item = String>) -> Result<Vec<FileTask>, C
     RawArgs::parse(args)?.resolve()
 }
 
-enum PathKind {
-    NotFound,
-    File,
-    Dir,
-    Other,
-}
-
-fn classify_path(path: &Path) -> PathKind {
-    if !path.exists() {
-        PathKind::NotFound
-    } else if path.is_file() {
-        PathKind::File
-    } else if path.is_dir() {
-        PathKind::Dir
-    } else {
-        PathKind::Other
-    }
-}
-
 /// ディレクトリ内のCSVファイルを再帰的に検索
 fn find_csv_files(dir_path: &Path) -> Result<Vec<PathBuf>, walkdir::Error> {
-    let paths: Vec<PathBuf> = walkdir::WalkDir::new(dir_path)
+    walkdir::WalkDir::new(dir_path)
         .into_iter()
         .map(|entry| entry.map(|e| e.into_path()))
-        .collect::<Result<Vec<_>, _>>()?;
-
-    Ok(paths
-        .into_iter()
-        .filter(|p| p.extension().is_some_and(|ext| ext == "csv"))
-        .collect())
+        .collect::<Result<Vec<_>, _>>()
+        .map(|paths| {
+            paths
+                .into_iter()
+                .filter(|p| p.extension().is_some_and(|ext| ext == "csv"))
+                .collect()
+        })
 }
 
 #[cfg(test)]
@@ -207,6 +212,20 @@ mod tests {
             "program".to_string(),
             "input.csv".to_string(),
             "--output".to_string(),
+        ];
+        let result = RawArgs::parse(args.into_iter());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn raw_args_parse_duplicate_output() {
+        let args = vec![
+            "program".to_string(),
+            "--output".to_string(),
+            "a.json".to_string(),
+            "--output".to_string(),
+            "b.json".to_string(),
+            "input.csv".to_string(),
         ];
         let result = RawArgs::parse(args.into_iter());
         assert!(result.is_err());

--- a/cli/cli/src/args.rs
+++ b/cli/cli/src/args.rs
@@ -37,8 +37,8 @@ impl RawArgs {
         })
     }
 
-    /// ファイルシステムを参照して検証済み Config に変換
-    fn resolve(self) -> Result<Config, CliError> {
+    /// ファイルシステムを参照して検証済み FileTask のリストに変換
+    fn resolve(self) -> Result<Vec<FileTask>, CliError> {
         let path = self.input_path;
 
         if !path.exists() {
@@ -51,47 +51,21 @@ impl RawArgs {
             if csv_files.is_empty() {
                 return Err(CliError::NoCsvFilesFound(path.display().to_string()));
             }
-            Ok(Config::BatchDirectory { csv_files })
+            Ok(csv_files
+                .into_iter()
+                .map(|f| FileTask::new(f, None))
+                .collect())
         } else if path.is_file() {
-            Ok(Config::SingleFile {
-                file_path: path,
-                output_file: self.output_file,
-            })
+            Ok(vec![FileTask::new(path, self.output_file)])
         } else {
             Err(CliError::InvalidInputPath(path.display().to_string()))
         }
     }
 }
 
-#[derive(Debug)]
-pub enum Config {
-    SingleFile {
-        file_path: PathBuf,
-        output_file: Option<PathBuf>,
-    },
-    BatchDirectory {
-        csv_files: Vec<PathBuf>,
-    },
-}
-
-impl Config {
-    pub fn build(args: impl Iterator<Item = String>) -> Result<Config, CliError> {
-        RawArgs::parse(args)?.resolve()
-    }
-
-    /// Config を処理単位（FileTask）のリストに変換（純粋な変換）
-    pub fn into_tasks(self) -> Vec<FileTask> {
-        match self {
-            Config::SingleFile {
-                file_path,
-                output_file,
-            } => vec![FileTask::new(file_path, output_file)],
-            Config::BatchDirectory { csv_files } => csv_files
-                .into_iter()
-                .map(|csv_file| FileTask::new(csv_file, None))
-                .collect(),
-        }
-    }
+/// CLI 引数をパースし、検証済みの処理タスクリストを返す
+pub fn parse_args(args: impl Iterator<Item = String>) -> Result<Vec<FileTask>, CliError> {
+    RawArgs::parse(args)?.resolve()
 }
 
 /// ディレクトリ内のCSVファイルを再帰的に検索
@@ -205,14 +179,14 @@ mod tests {
     }
 
     #[test]
-    fn config_build_nonexistent_file() {
+    fn parse_args_nonexistent_file() {
         let args = vec!["program".to_string(), "nonexistent.csv".to_string()];
-        let result = Config::build(args.into_iter());
+        let result = parse_args(args.into_iter());
         assert!(result.is_err());
     }
 
     #[test]
-    fn config_build_single_file_without_output() {
+    fn parse_args_single_file_without_output() {
         let temp_dir = tempdir().unwrap();
         let input_path = temp_dir.path().join("input.csv");
 
@@ -226,23 +200,14 @@ mod tests {
             input_path.to_string_lossy().to_string(),
         ];
 
-        let config = Config::build(args.into_iter()).unwrap();
-        match &config {
-            Config::SingleFile {
-                file_path,
-                output_file,
-            } => {
-                assert_eq!(file_path, &input_path);
-                // output_file は --output 未指定なので None
-                // 名前解決は into_tasks() で行われる
-                assert_eq!(output_file, &None);
-            }
-            _ => panic!("Expected SingleFile config"),
-        }
+        let tasks = parse_args(args.into_iter()).unwrap();
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].input_path(), &input_path);
+        assert_eq!(tasks[0].output_path(), input_path.with_extension("json"));
     }
 
     #[test]
-    fn config_build_directory_with_output_is_error() {
+    fn parse_args_directory_with_output_is_error() {
         let temp_dir = tempdir().unwrap();
 
         let args = vec![
@@ -252,12 +217,12 @@ mod tests {
             "output.json".to_string(),
         ];
 
-        let result = Config::build(args.into_iter());
+        let result = parse_args(args.into_iter());
         assert!(result.is_err());
     }
 
     #[test]
-    fn config_build_empty_directory_is_error() {
+    fn parse_args_empty_directory_is_error() {
         let temp_dir = tempdir().unwrap();
 
         let args = vec![
@@ -265,12 +230,12 @@ mod tests {
             temp_dir.path().to_string_lossy().to_string(),
         ];
 
-        let result = Config::build(args.into_iter());
+        let result = parse_args(args.into_iter());
         assert!(result.is_err());
     }
 
     #[test]
-    fn config_build_with_directory() {
+    fn parse_args_with_directory() {
         let temp_dir = tempdir().unwrap();
         File::create(temp_dir.path().join("race.csv"))
             .unwrap()
@@ -282,13 +247,8 @@ mod tests {
             temp_dir.path().to_string_lossy().to_string(),
         ];
 
-        let config = Config::build(args.into_iter()).unwrap();
-        match &config {
-            Config::BatchDirectory { csv_files } => {
-                assert_eq!(csv_files.len(), 1);
-                assert_eq!(csv_files[0], temp_dir.path().join("race.csv"));
-            }
-            _ => panic!("Expected BatchDirectory config"),
-        }
+        let tasks = parse_args(args.into_iter()).unwrap();
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].input_path(), temp_dir.path().join("race.csv"));
     }
 }

--- a/cli/cli/src/args.rs
+++ b/cli/cli/src/args.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::error::CliError;
@@ -81,7 +80,7 @@ fn resolve_dir(path: PathBuf, output_file: Option<PathBuf>) -> Result<Vec<FileTa
     if output_file.is_some() {
         return Err(CliError::OutputWithDirectory);
     }
-    let csv_files = find_csv_files(&path)?;
+    let csv_files = find_csv_files(&path).map_err(|e| CliError::WalkDir(e.to_string()))?;
     if csv_files.is_empty() {
         return Err(CliError::NoCsvFilesFound(path.display().to_string()));
     }
@@ -116,28 +115,16 @@ fn classify_path(path: &Path) -> PathKind {
 }
 
 /// ディレクトリ内のCSVファイルを再帰的に検索
-fn find_csv_files(dir_path: &Path) -> Result<Vec<PathBuf>, CliError> {
-    let mut csv_files = Vec::new();
-    let entries = fs::read_dir(dir_path).map_err(|e| CliError::ReadDir {
-        path: dir_path.display().to_string(),
-        source: e,
-    })?;
+fn find_csv_files(dir_path: &Path) -> Result<Vec<PathBuf>, walkdir::Error> {
+    let paths: Vec<PathBuf> = walkdir::WalkDir::new(dir_path)
+        .into_iter()
+        .map(|entry| entry.map(|e| e.into_path()))
+        .collect::<Result<Vec<_>, _>>()?;
 
-    for entry in entries {
-        let entry = entry.map_err(CliError::ReadDirEntry)?;
-        let path = entry.path();
-
-        if path.is_dir() {
-            let mut subdir_files = find_csv_files(&path)?;
-            csv_files.append(&mut subdir_files);
-        } else if let Some(extension) = path.extension() {
-            if extension == "csv" {
-                csv_files.push(path);
-            }
-        }
-    }
-
-    Ok(csv_files)
+    Ok(paths
+        .into_iter()
+        .filter(|p| p.extension().is_some_and(|ext| ext == "csv"))
+        .collect())
 }
 
 #[cfg(test)]

--- a/cli/cli/src/args.rs
+++ b/cli/cli/src/args.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use crate::FileTask;
 use crate::error::CliError;
-use crate::pipeline::FileTask;
 
 /// 引数パース結果（ファイルシステム未検証）
 #[derive(Debug, PartialEq)]

--- a/cli/cli/src/config.rs
+++ b/cli/cli/src/config.rs
@@ -48,28 +48,10 @@ impl Config {
             return Err(format!("Input path is neither a file nor directory: {input_path}").into());
         };
 
-        // output_fileが指定されていない場合はデフォルト値を生成
-        let output_file = output_file.or_else(|| match &input_type {
-            InputType::File(file_path) => {
-                let (default_output, _) = Self::generate_output_names(file_path);
-                Some(default_output)
-            }
-            InputType::Directory(_) => None,
-        });
-
-        // event_nameは常にデフォルト値を使用
-        let event_name = match &input_type {
-            InputType::File(file_path) => {
-                let (_, default_event) = Self::generate_output_names(file_path);
-                Some(default_event)
-            }
-            InputType::Directory(_) => None,
-        };
-
         Ok(Config {
             input_type,
             output_file,
-            event_name,
+            event_name: None,
         })
     }
 
@@ -85,7 +67,6 @@ impl Config {
                 }])
             }
             InputType::Directory(dir_path) => {
-                println!("Scanning directory '{}' for CSV files...", dir_path);
                 let csv_files = pipeline::find_csv_files(&dir_path)?;
                 let tasks = csv_files
                     .into_iter()
@@ -178,7 +159,6 @@ mod tests {
     fn config_build_file_auto_names() {
         let temp_dir = tempdir().unwrap();
         let input_path = temp_dir.path().join("input.csv");
-        let expected_output = temp_dir.path().join("input.json");
 
         File::create(&input_path)
             .unwrap()
@@ -197,12 +177,10 @@ mod tests {
             }
             _ => panic!("Expected File input type"),
         }
-        // 自動生成された名前が設定されていることを確認
-        assert_eq!(
-            config.output_file,
-            Some(expected_output.to_string_lossy().to_string())
-        );
-        assert_eq!(config.event_name, Some("input".to_string()));
+        // output_file は --output 未指定なので None、event_name は常に None
+        // 名前解決は into_tasks() で行われる
+        assert_eq!(config.output_file, None);
+        assert_eq!(config.event_name, None);
     }
 
     #[test]

--- a/cli/cli/src/config.rs
+++ b/cli/cli/src/config.rs
@@ -6,15 +6,14 @@ use crate::error::CliError;
 use crate::pipeline::FileTask;
 
 #[derive(Debug)]
-pub enum InputType {
-    File(PathBuf),
-    Directory(PathBuf),
-}
-
-#[derive(Debug)]
-pub struct Config {
-    pub input_type: InputType,
-    pub output_file: Option<PathBuf>,
+pub enum Config {
+    SingleFile {
+        file_path: PathBuf,
+        output_file: Option<PathBuf>,
+    },
+    BatchDirectory {
+        dir_path: PathBuf,
+    },
 }
 
 impl Config {
@@ -36,38 +35,38 @@ impl Config {
 
         let path = PathBuf::from(input_path.ok_or(CliError::MissingInputPath)?);
 
-        let input_type = if !path.exists() {
-            return Err(CliError::InputPathNotFound(path.display().to_string()));
+        if !path.exists() {
+            Err(CliError::InputPathNotFound(path.display().to_string()))
         } else if path.is_dir() {
-            InputType::Directory(path)
+            if output_file.is_some() {
+                return Err(CliError::OutputWithDirectory);
+            }
+            Ok(Config::BatchDirectory { dir_path: path })
         } else if path.is_file() {
-            InputType::File(path)
+            Ok(Config::SingleFile {
+                file_path: path,
+                output_file,
+            })
         } else {
-            return Err(CliError::InvalidInputPath(path.display().to_string()));
-        };
-
-        if output_file.is_some() && matches!(input_type, InputType::Directory(_)) {
-            return Err(CliError::OutputWithDirectory);
+            Err(CliError::InvalidInputPath(path.display().to_string()))
         }
-
-        Ok(Config {
-            input_type,
-            output_file,
-        })
     }
 
     /// Config を処理単位（FileTask）のリストに変換
     pub fn into_tasks(self) -> Result<Vec<FileTask>, CliError> {
-        match self.input_type {
-            InputType::File(file_path) => {
+        match self {
+            Config::SingleFile {
+                file_path,
+                output_file,
+            } => {
                 let (default_output, event_name) = Self::generate_output_names(&file_path);
                 Ok(vec![FileTask {
                     input_path: file_path,
-                    output_path: self.output_file.unwrap_or(default_output),
+                    output_path: output_file.unwrap_or(default_output),
                     event_name,
                 }])
             }
-            InputType::Directory(dir_path) => {
+            Config::BatchDirectory { dir_path } => {
                 let csv_files = find_csv_files(&dir_path)?;
                 let tasks = csv_files
                     .into_iter()
@@ -199,15 +198,18 @@ mod tests {
         ];
 
         let config = Config::build(args.into_iter()).unwrap();
-        match &config.input_type {
-            InputType::File(file_path) => {
+        match &config {
+            Config::SingleFile {
+                file_path,
+                output_file,
+            } => {
                 assert_eq!(file_path, &input_path);
+                // output_file は --output 未指定なので None
+                // 名前解決は into_tasks() で行われる
+                assert_eq!(output_file, &None);
             }
-            _ => panic!("Expected File input type"),
+            _ => panic!("Expected SingleFile config"),
         }
-        // output_file は --output 未指定なので None
-        // 名前解決は into_tasks() で行われる
-        assert_eq!(config.output_file, None);
     }
 
     #[test]
@@ -235,13 +237,11 @@ mod tests {
         ];
 
         let config = Config::build(args.into_iter()).unwrap();
-        match &config.input_type {
-            InputType::Directory(dir_path) => {
+        match &config {
+            Config::BatchDirectory { dir_path } => {
                 assert_eq!(dir_path, temp_dir.path());
             }
-            _ => panic!("Expected Directory input type"),
+            _ => panic!("Expected BatchDirectory config"),
         }
-        // ディレクトリの場合はoutput_fileはNoneになる
-        assert_eq!(config.output_file, None);
     }
 }

--- a/cli/cli/src/config.rs
+++ b/cli/cli/src/config.rs
@@ -21,7 +21,9 @@ impl RawArgs {
 
         while let Some(arg) = args.next() {
             if arg == "--output" {
-                output_file = args.next().map(PathBuf::from);
+                output_file = Some(PathBuf::from(
+                    args.next().ok_or(CliError::MissingOutputValue)?,
+                ));
             } else if input_path.is_none() {
                 input_path = Some(arg);
             } else {
@@ -195,6 +197,17 @@ mod tests {
     }
 
     #[test]
+    fn raw_args_parse_output_without_value() {
+        let args = vec![
+            "program".to_string(),
+            "input.csv".to_string(),
+            "--output".to_string(),
+        ];
+        let result = RawArgs::parse(args.into_iter());
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn config_build_nonexistent_file() {
         let args = vec!["program".to_string(), "nonexistent.csv".to_string()];
         let result = Config::build(args.into_iter());
@@ -202,49 +215,7 @@ mod tests {
     }
 
     #[test]
-    fn file_task_default_output_basic() {
-        let task = FileTask::new(PathBuf::from("input.csv"), None);
-        assert_eq!(task.output_path(), Path::new("input.json"));
-        assert_eq!(task.event_name(), "input");
-    }
-
-    #[test]
-    fn file_task_default_output_with_path() {
-        let task = FileTask::new(PathBuf::from("/path/to/input.csv"), None);
-        assert_eq!(task.output_path(), Path::new("/path/to/input.json"));
-        assert_eq!(task.event_name(), "input");
-    }
-
-    #[test]
-    fn file_task_default_output_multiple_dots() {
-        let task = FileTask::new(PathBuf::from("my.test.file.csv"), None);
-        assert_eq!(task.output_path(), Path::new("my.test.file.json"));
-        assert_eq!(task.event_name(), "my.test.file");
-    }
-
-    #[test]
-    fn file_task_default_output_no_extension() {
-        let task = FileTask::new(PathBuf::from("input"), None);
-        assert_eq!(task.output_path(), Path::new("input.json"));
-        assert_eq!(task.event_name(), "input");
-    }
-
-    #[test]
-    fn file_task_default_output_relative_path() {
-        let task = FileTask::new(PathBuf::from("./data/input.csv"), None);
-        assert_eq!(task.output_path(), Path::new("./data/input.json"));
-        assert_eq!(task.event_name(), "input");
-    }
-
-    #[test]
-    fn file_task_with_output_override() {
-        let task = FileTask::new(PathBuf::from("input.csv"), Some(PathBuf::from("custom.json")));
-        assert_eq!(task.output_path(), Path::new("custom.json"));
-        assert_eq!(task.event_name(), "input");
-    }
-
-    #[test]
-    fn config_build_file_defers_name_resolution() {
+    fn config_build_single_file_without_output() {
         let temp_dir = tempdir().unwrap();
         let input_path = temp_dir.path().join("input.csv");
 

--- a/cli/cli/src/config.rs
+++ b/cli/cli/src/config.rs
@@ -2,6 +2,8 @@ use std::error::Error;
 use std::ffi::OsStr;
 use std::path::Path;
 
+use crate::pipeline::{self, FileTask};
+
 #[derive(Debug)]
 pub enum InputType {
     File(String),
@@ -69,6 +71,36 @@ impl Config {
             output_file,
             event_name,
         })
+    }
+
+    /// Config を処理単位（FileTask）のリストに変換
+    pub fn into_tasks(self) -> Result<Vec<FileTask>, Box<dyn Error>> {
+        match self.input_type {
+            InputType::File(file_path) => {
+                let (default_output, default_event) = Self::generate_output_names(&file_path);
+                Ok(vec![FileTask {
+                    input_path: file_path,
+                    output_path: self.output_file.unwrap_or(default_output),
+                    event_name: self.event_name.unwrap_or(default_event),
+                }])
+            }
+            InputType::Directory(dir_path) => {
+                println!("Scanning directory '{}' for CSV files...", dir_path);
+                let csv_files = pipeline::find_csv_files(&dir_path)?;
+                let tasks = csv_files
+                    .into_iter()
+                    .map(|csv_file| {
+                        let (output, event) = Self::generate_output_names(&csv_file);
+                        FileTask {
+                            input_path: csv_file,
+                            output_path: output,
+                            event_name: event,
+                        }
+                    })
+                    .collect();
+                Ok(tasks)
+            }
+        }
     }
 
     /// 入力ファイル名から出力ファイル名とイベント名を生成

--- a/cli/cli/src/config.rs
+++ b/cli/cli/src/config.rs
@@ -47,7 +47,11 @@ impl RawArgs {
             if self.output_file.is_some() {
                 return Err(CliError::OutputWithDirectory);
             }
-            Ok(Config::BatchDirectory { dir_path: path })
+            let csv_files = find_csv_files(&path)?;
+            if csv_files.is_empty() {
+                return Err(CliError::NoCsvFilesFound(path.display().to_string()));
+            }
+            Ok(Config::BatchDirectory { csv_files })
         } else if path.is_file() {
             Ok(Config::SingleFile {
                 file_path: path,
@@ -66,7 +70,7 @@ pub enum Config {
         output_file: Option<PathBuf>,
     },
     BatchDirectory {
-        dir_path: PathBuf,
+        csv_files: Vec<PathBuf>,
     },
 }
 
@@ -75,24 +79,17 @@ impl Config {
         RawArgs::parse(args)?.resolve()
     }
 
-    /// Config を処理単位（FileTask）のリストに変換
-    pub fn into_tasks(self) -> Result<Vec<FileTask>, CliError> {
+    /// Config を処理単位（FileTask）のリストに変換（純粋な変換）
+    pub fn into_tasks(self) -> Vec<FileTask> {
         match self {
             Config::SingleFile {
                 file_path,
                 output_file,
-            } => Ok(vec![FileTask::new(file_path, output_file)]),
-            Config::BatchDirectory { dir_path } => {
-                let csv_files = find_csv_files(&dir_path)?;
-                if csv_files.is_empty() {
-                    return Err(CliError::NoCsvFilesFound(dir_path.display().to_string()));
-                }
-                let tasks = csv_files
-                    .into_iter()
-                    .map(|csv_file| FileTask::new(csv_file, None))
-                    .collect();
-                Ok(tasks)
-            }
+            } => vec![FileTask::new(file_path, output_file)],
+            Config::BatchDirectory { csv_files } => csv_files
+                .into_iter()
+                .map(|csv_file| FileTask::new(csv_file, None))
+                .collect(),
         }
     }
 }
@@ -260,8 +257,25 @@ mod tests {
     }
 
     #[test]
+    fn config_build_empty_directory_is_error() {
+        let temp_dir = tempdir().unwrap();
+
+        let args = vec![
+            "program".to_string(),
+            temp_dir.path().to_string_lossy().to_string(),
+        ];
+
+        let result = Config::build(args.into_iter());
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn config_build_with_directory() {
         let temp_dir = tempdir().unwrap();
+        File::create(temp_dir.path().join("race.csv"))
+            .unwrap()
+            .write_all(b"test")
+            .unwrap();
 
         let args = vec![
             "program".to_string(),
@@ -270,8 +284,9 @@ mod tests {
 
         let config = Config::build(args.into_iter()).unwrap();
         match &config {
-            Config::BatchDirectory { dir_path } => {
-                assert_eq!(dir_path, temp_dir.path());
+            Config::BatchDirectory { csv_files } => {
+                assert_eq!(csv_files.len(), 1);
+                assert_eq!(csv_files[0], temp_dir.path().join("race.csv"));
             }
             _ => panic!("Expected BatchDirectory config"),
         }

--- a/cli/cli/src/config.rs
+++ b/cli/cli/src/config.rs
@@ -1,20 +1,20 @@
 use std::ffi::OsStr;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::error::CliError;
 use crate::pipeline::FileTask;
 
 #[derive(Debug)]
 pub enum InputType {
-    File(String),
-    Directory(String),
+    File(PathBuf),
+    Directory(PathBuf),
 }
 
 #[derive(Debug)]
 pub struct Config {
     pub input_type: InputType,
-    pub output_file: Option<String>,
+    pub output_file: Option<PathBuf>,
 }
 
 impl Config {
@@ -22,11 +22,11 @@ impl Config {
         args.next();
 
         let mut input_path = None;
-        let mut output_file = None;
+        let mut output_file: Option<PathBuf> = None;
 
         while let Some(arg) = args.next() {
             if arg == "--output" {
-                output_file = args.next();
+                output_file = args.next().map(PathBuf::from);
             } else if input_path.is_none() {
                 input_path = Some(arg);
             } else {
@@ -34,17 +34,16 @@ impl Config {
             }
         }
 
-        let input_path = input_path.ok_or(CliError::MissingInputPath)?;
+        let path = PathBuf::from(input_path.ok_or(CliError::MissingInputPath)?);
 
-        let path = Path::new(&input_path);
         let input_type = if !path.exists() {
-            return Err(CliError::InputPathNotFound(input_path));
+            return Err(CliError::InputPathNotFound(path.display().to_string()));
         } else if path.is_dir() {
-            InputType::Directory(input_path)
+            InputType::Directory(path)
         } else if path.is_file() {
-            InputType::File(input_path)
+            InputType::File(path)
         } else {
-            return Err(CliError::InvalidInputPath(input_path));
+            return Err(CliError::InvalidInputPath(path.display().to_string()));
         };
 
         if output_file.is_some() && matches!(input_type, InputType::Directory(_)) {
@@ -87,14 +86,13 @@ impl Config {
     }
 
     /// 入力ファイル名から出力ファイル名とイベント名を生成
-    pub fn generate_output_names(input_file: &str) -> (String, String) {
-        let path = Path::new(input_file);
-        let stem = path
+    pub fn generate_output_names(input_file: &Path) -> (PathBuf, String) {
+        let stem = input_file
             .file_stem()
             .unwrap_or_else(|| OsStr::new("output"))
             .to_string_lossy();
 
-        let output_file = path.with_extension("json").to_string_lossy().to_string();
+        let output_file = input_file.with_extension("json");
         let event_name = stem.to_string();
 
         (output_file, event_name)
@@ -102,10 +100,10 @@ impl Config {
 }
 
 /// ディレクトリ内のCSVファイルを再帰的に検索
-fn find_csv_files(dir_path: &str) -> Result<Vec<String>, CliError> {
+fn find_csv_files(dir_path: &Path) -> Result<Vec<PathBuf>, CliError> {
     let mut csv_files = Vec::new();
     let entries = fs::read_dir(dir_path).map_err(|e| CliError::ReadDir {
-        path: dir_path.to_string(),
+        path: dir_path.display().to_string(),
         source: e,
     })?;
 
@@ -114,12 +112,11 @@ fn find_csv_files(dir_path: &str) -> Result<Vec<String>, CliError> {
         let path = entry.path();
 
         if path.is_dir() {
-            let subdir_path = path.to_string_lossy().to_string();
-            let mut subdir_files = find_csv_files(&subdir_path)?;
+            let mut subdir_files = find_csv_files(&path)?;
             csv_files.append(&mut subdir_files);
         } else if let Some(extension) = path.extension() {
             if extension == "csv" {
-                csv_files.push(path.to_string_lossy().to_string());
+                csv_files.push(path);
             }
         }
     }
@@ -150,36 +147,39 @@ mod tests {
 
     #[test]
     fn generate_output_names_basic() {
-        let (output_file, event_name) = Config::generate_output_names("input.csv");
-        assert_eq!(output_file, "input.json");
+        let (output_file, event_name) = Config::generate_output_names(Path::new("input.csv"));
+        assert_eq!(output_file, PathBuf::from("input.json"));
         assert_eq!(event_name, "input");
     }
 
     #[test]
     fn generate_output_names_with_path() {
-        let (output_file, event_name) = Config::generate_output_names("/path/to/input.csv");
-        assert_eq!(output_file, "/path/to/input.json");
+        let (output_file, event_name) =
+            Config::generate_output_names(Path::new("/path/to/input.csv"));
+        assert_eq!(output_file, PathBuf::from("/path/to/input.json"));
         assert_eq!(event_name, "input");
     }
 
     #[test]
     fn generate_output_names_multiple_dots() {
-        let (output_file, event_name) = Config::generate_output_names("my.test.file.csv");
-        assert_eq!(output_file, "my.test.file.json");
+        let (output_file, event_name) =
+            Config::generate_output_names(Path::new("my.test.file.csv"));
+        assert_eq!(output_file, PathBuf::from("my.test.file.json"));
         assert_eq!(event_name, "my.test.file");
     }
 
     #[test]
     fn generate_output_names_no_extension() {
-        let (output_file, event_name) = Config::generate_output_names("input");
-        assert_eq!(output_file, "input.json");
+        let (output_file, event_name) = Config::generate_output_names(Path::new("input"));
+        assert_eq!(output_file, PathBuf::from("input.json"));
         assert_eq!(event_name, "input");
     }
 
     #[test]
     fn generate_output_names_relative_path() {
-        let (output_file, event_name) = Config::generate_output_names("./data/input.csv");
-        assert_eq!(output_file, "./data/input.json");
+        let (output_file, event_name) =
+            Config::generate_output_names(Path::new("./data/input.csv"));
+        assert_eq!(output_file, PathBuf::from("./data/input.json"));
         assert_eq!(event_name, "input");
     }
 
@@ -201,7 +201,7 @@ mod tests {
         let config = Config::build(args.into_iter()).unwrap();
         match &config.input_type {
             InputType::File(file_path) => {
-                assert_eq!(file_path, &input_path.to_string_lossy().to_string());
+                assert_eq!(file_path, &input_path);
             }
             _ => panic!("Expected File input type"),
         }
@@ -237,7 +237,7 @@ mod tests {
         let config = Config::build(args.into_iter()).unwrap();
         match &config.input_type {
             InputType::Directory(dir_path) => {
-                assert_eq!(dir_path, &temp_dir.path().to_string_lossy().to_string());
+                assert_eq!(dir_path, temp_dir.path());
             }
             _ => panic!("Expected Directory input type"),
         }

--- a/cli/cli/src/config.rs
+++ b/cli/cli/src/config.rs
@@ -15,7 +15,6 @@ pub enum InputType {
 pub struct Config {
     pub input_type: InputType,
     pub output_file: Option<String>,
-    pub event_name: Option<String>,
 }
 
 impl Config {
@@ -52,7 +51,6 @@ impl Config {
         Ok(Config {
             input_type,
             output_file,
-            event_name: None,
         })
     }
 
@@ -60,11 +58,11 @@ impl Config {
     pub fn into_tasks(self) -> Result<Vec<FileTask>, Box<dyn Error>> {
         match self.input_type {
             InputType::File(file_path) => {
-                let (default_output, default_event) = Self::generate_output_names(&file_path);
+                let (default_output, event_name) = Self::generate_output_names(&file_path);
                 Ok(vec![FileTask {
                     input_path: file_path,
                     output_path: self.output_file.unwrap_or(default_output),
-                    event_name: self.event_name.unwrap_or(default_event),
+                    event_name,
                 }])
             }
             InputType::Directory(dir_path) => {
@@ -202,10 +200,9 @@ mod tests {
             }
             _ => panic!("Expected File input type"),
         }
-        // output_file は --output 未指定なので None、event_name は常に None
+        // output_file は --output 未指定なので None
         // 名前解決は into_tasks() で行われる
         assert_eq!(config.output_file, None);
-        assert_eq!(config.event_name, None);
     }
 
     #[test]
@@ -226,6 +223,5 @@ mod tests {
         }
         // ディレクトリの場合はoutput_fileはNoneになる
         assert_eq!(config.output_file, None);
-        assert_eq!(config.event_name, None);
     }
 }

--- a/cli/cli/src/config.rs
+++ b/cli/cli/src/config.rs
@@ -47,6 +47,10 @@ impl Config {
             return Err(CliError::InvalidInputPath(input_path));
         };
 
+        if output_file.is_some() && matches!(input_type, InputType::Directory(_)) {
+            return Err(CliError::OutputWithDirectory);
+        }
+
         Ok(Config {
             input_type,
             output_file,
@@ -204,6 +208,21 @@ mod tests {
         // output_file は --output 未指定なので None
         // 名前解決は into_tasks() で行われる
         assert_eq!(config.output_file, None);
+    }
+
+    #[test]
+    fn config_build_directory_with_output_is_error() {
+        let temp_dir = tempdir().unwrap();
+
+        let args = vec![
+            "program".to_string(),
+            temp_dir.path().to_string_lossy().to_string(),
+            "--output".to_string(),
+            "output.json".to_string(),
+        ];
+
+        let result = Config::build(args.into_iter());
+        assert!(result.is_err());
     }
 
     #[test]

--- a/cli/cli/src/config.rs
+++ b/cli/cli/src/config.rs
@@ -1,8 +1,8 @@
-use std::error::Error;
 use std::ffi::OsStr;
 use std::fs;
 use std::path::Path;
 
+use crate::error::CliError;
 use crate::pipeline::FileTask;
 
 #[derive(Debug)]
@@ -18,7 +18,7 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn build(mut args: impl Iterator<Item = String>) -> Result<Config, Box<dyn Error>> {
+    pub fn build(mut args: impl Iterator<Item = String>) -> Result<Config, CliError> {
         args.next();
 
         let mut input_path = None;
@@ -30,22 +30,21 @@ impl Config {
             } else if input_path.is_none() {
                 input_path = Some(arg);
             } else {
-                return Err(format!("Unexpected argument: {arg}").into());
+                return Err(CliError::UnexpectedArgument(arg));
             }
         }
 
-        let input_path = input_path
-            .ok_or_else(|| -> Box<dyn Error> { "Missing required input path argument".into() })?;
+        let input_path = input_path.ok_or(CliError::MissingInputPath)?;
 
         let path = Path::new(&input_path);
         let input_type = if !path.exists() {
-            return Err(format!("Input path does not exist: {input_path}").into());
+            return Err(CliError::InputPathNotFound(input_path));
         } else if path.is_dir() {
             InputType::Directory(input_path)
         } else if path.is_file() {
             InputType::File(input_path)
         } else {
-            return Err(format!("Input path is neither a file nor directory: {input_path}").into());
+            return Err(CliError::InvalidInputPath(input_path));
         };
 
         Ok(Config {
@@ -55,7 +54,7 @@ impl Config {
     }
 
     /// Config を処理単位（FileTask）のリストに変換
-    pub fn into_tasks(self) -> Result<Vec<FileTask>, Box<dyn Error>> {
+    pub fn into_tasks(self) -> Result<Vec<FileTask>, CliError> {
         match self.input_type {
             InputType::File(file_path) => {
                 let (default_output, event_name) = Self::generate_output_names(&file_path);
@@ -99,13 +98,15 @@ impl Config {
 }
 
 /// ディレクトリ内のCSVファイルを再帰的に検索
-fn find_csv_files(dir_path: &str) -> Result<Vec<String>, Box<dyn Error>> {
+fn find_csv_files(dir_path: &str) -> Result<Vec<String>, CliError> {
     let mut csv_files = Vec::new();
-    let entries = fs::read_dir(dir_path)
-        .map_err(|e| format!("Failed to read directory '{}': {}", dir_path, e))?;
+    let entries = fs::read_dir(dir_path).map_err(|e| CliError::ReadDir {
+        path: dir_path.to_string(),
+        source: e,
+    })?;
 
     for entry in entries {
-        let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
+        let entry = entry.map_err(CliError::ReadDirEntry)?;
         let path = entry.path();
 
         if path.is_dir() {

--- a/cli/cli/src/config.rs
+++ b/cli/cli/src/config.rs
@@ -1,4 +1,3 @@
-use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -58,14 +57,7 @@ impl Config {
             Config::SingleFile {
                 file_path,
                 output_file,
-            } => {
-                let (default_output, event_name) = Self::generate_output_names(&file_path);
-                Ok(vec![FileTask {
-                    input_path: file_path,
-                    output_path: output_file.unwrap_or(default_output),
-                    event_name,
-                }])
-            }
+            } => Ok(vec![FileTask::new(file_path, output_file)]),
             Config::BatchDirectory { dir_path } => {
                 let csv_files = find_csv_files(&dir_path)?;
                 if csv_files.is_empty() {
@@ -73,31 +65,11 @@ impl Config {
                 }
                 let tasks = csv_files
                     .into_iter()
-                    .map(|csv_file| {
-                        let (output, event) = Self::generate_output_names(&csv_file);
-                        FileTask {
-                            input_path: csv_file,
-                            output_path: output,
-                            event_name: event,
-                        }
-                    })
+                    .map(|csv_file| FileTask::new(csv_file, None))
                     .collect();
                 Ok(tasks)
             }
         }
-    }
-
-    /// 入力ファイル名から出力ファイル名とイベント名を生成
-    pub fn generate_output_names(input_file: &Path) -> (PathBuf, String) {
-        let stem = input_file
-            .file_stem()
-            .unwrap_or_else(|| OsStr::new("output"))
-            .to_string_lossy();
-
-        let output_file = input_file.with_extension("json");
-        let event_name = stem.to_string();
-
-        (output_file, event_name)
     }
 }
 
@@ -148,41 +120,45 @@ mod tests {
     }
 
     #[test]
-    fn generate_output_names_basic() {
-        let (output_file, event_name) = Config::generate_output_names(Path::new("input.csv"));
-        assert_eq!(output_file, PathBuf::from("input.json"));
-        assert_eq!(event_name, "input");
+    fn file_task_default_output_basic() {
+        let task = FileTask::new(PathBuf::from("input.csv"), None);
+        assert_eq!(task.output_path(), Path::new("input.json"));
+        assert_eq!(task.event_name(), "input");
     }
 
     #[test]
-    fn generate_output_names_with_path() {
-        let (output_file, event_name) =
-            Config::generate_output_names(Path::new("/path/to/input.csv"));
-        assert_eq!(output_file, PathBuf::from("/path/to/input.json"));
-        assert_eq!(event_name, "input");
+    fn file_task_default_output_with_path() {
+        let task = FileTask::new(PathBuf::from("/path/to/input.csv"), None);
+        assert_eq!(task.output_path(), Path::new("/path/to/input.json"));
+        assert_eq!(task.event_name(), "input");
     }
 
     #[test]
-    fn generate_output_names_multiple_dots() {
-        let (output_file, event_name) =
-            Config::generate_output_names(Path::new("my.test.file.csv"));
-        assert_eq!(output_file, PathBuf::from("my.test.file.json"));
-        assert_eq!(event_name, "my.test.file");
+    fn file_task_default_output_multiple_dots() {
+        let task = FileTask::new(PathBuf::from("my.test.file.csv"), None);
+        assert_eq!(task.output_path(), Path::new("my.test.file.json"));
+        assert_eq!(task.event_name(), "my.test.file");
     }
 
     #[test]
-    fn generate_output_names_no_extension() {
-        let (output_file, event_name) = Config::generate_output_names(Path::new("input"));
-        assert_eq!(output_file, PathBuf::from("input.json"));
-        assert_eq!(event_name, "input");
+    fn file_task_default_output_no_extension() {
+        let task = FileTask::new(PathBuf::from("input"), None);
+        assert_eq!(task.output_path(), Path::new("input.json"));
+        assert_eq!(task.event_name(), "input");
     }
 
     #[test]
-    fn generate_output_names_relative_path() {
-        let (output_file, event_name) =
-            Config::generate_output_names(Path::new("./data/input.csv"));
-        assert_eq!(output_file, PathBuf::from("./data/input.json"));
-        assert_eq!(event_name, "input");
+    fn file_task_default_output_relative_path() {
+        let task = FileTask::new(PathBuf::from("./data/input.csv"), None);
+        assert_eq!(task.output_path(), Path::new("./data/input.json"));
+        assert_eq!(task.event_name(), "input");
+    }
+
+    #[test]
+    fn file_task_with_output_override() {
+        let task = FileTask::new(PathBuf::from("input.csv"), Some(PathBuf::from("custom.json")));
+        assert_eq!(task.output_path(), Path::new("custom.json"));
+        assert_eq!(task.event_name(), "input");
     }
 
     #[test]

--- a/cli/cli/src/config.rs
+++ b/cli/cli/src/config.rs
@@ -68,6 +68,9 @@ impl Config {
             }
             Config::BatchDirectory { dir_path } => {
                 let csv_files = find_csv_files(&dir_path)?;
+                if csv_files.is_empty() {
+                    return Err(CliError::NoCsvFilesFound(dir_path.display().to_string()));
+                }
                 let tasks = csv_files
                     .into_iter()
                     .map(|csv_file| {

--- a/cli/cli/src/config.rs
+++ b/cli/cli/src/config.rs
@@ -1,8 +1,9 @@
 use std::error::Error;
 use std::ffi::OsStr;
+use std::fs;
 use std::path::Path;
 
-use crate::pipeline::{self, FileTask};
+use crate::pipeline::FileTask;
 
 #[derive(Debug)]
 pub enum InputType {
@@ -67,7 +68,7 @@ impl Config {
                 }])
             }
             InputType::Directory(dir_path) => {
-                let csv_files = pipeline::find_csv_files(&dir_path)?;
+                let csv_files = find_csv_files(&dir_path)?;
                 let tasks = csv_files
                     .into_iter()
                     .map(|csv_file| {
@@ -97,6 +98,30 @@ impl Config {
 
         (output_file, event_name)
     }
+}
+
+/// ディレクトリ内のCSVファイルを再帰的に検索
+fn find_csv_files(dir_path: &str) -> Result<Vec<String>, Box<dyn Error>> {
+    let mut csv_files = Vec::new();
+    let entries = fs::read_dir(dir_path)
+        .map_err(|e| format!("Failed to read directory '{}': {}", dir_path, e))?;
+
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
+        let path = entry.path();
+
+        if path.is_dir() {
+            let subdir_path = path.to_string_lossy().to_string();
+            let mut subdir_files = find_csv_files(&subdir_path)?;
+            csv_files.append(&mut subdir_files);
+        } else if let Some(extension) = path.extension() {
+            if extension == "csv" {
+                csv_files.push(path.to_string_lossy().to_string());
+            }
+        }
+    }
+
+    Ok(csv_files)
 }
 
 #[cfg(test)]
@@ -156,7 +181,7 @@ mod tests {
     }
 
     #[test]
-    fn config_build_file_auto_names() {
+    fn config_build_file_defers_name_resolution() {
         let temp_dir = tempdir().unwrap();
         let input_path = temp_dir.path().join("input.csv");
 

--- a/cli/cli/src/config.rs
+++ b/cli/cli/src/config.rs
@@ -4,19 +4,16 @@ use std::path::{Path, PathBuf};
 use crate::error::CliError;
 use crate::pipeline::FileTask;
 
-#[derive(Debug)]
-pub enum Config {
-    SingleFile {
-        file_path: PathBuf,
-        output_file: Option<PathBuf>,
-    },
-    BatchDirectory {
-        dir_path: PathBuf,
-    },
+/// 引数パース結果（ファイルシステム未検証）
+#[derive(Debug, PartialEq)]
+struct RawArgs {
+    input_path: PathBuf,
+    output_file: Option<PathBuf>,
 }
 
-impl Config {
-    pub fn build(mut args: impl Iterator<Item = String>) -> Result<Config, CliError> {
+impl RawArgs {
+    /// 純粋な引数パース（I/O なし）
+    fn parse(mut args: impl Iterator<Item = String>) -> Result<Self, CliError> {
         args.next();
 
         let mut input_path = None;
@@ -32,23 +29,48 @@ impl Config {
             }
         }
 
-        let path = PathBuf::from(input_path.ok_or(CliError::MissingInputPath)?);
+        Ok(RawArgs {
+            input_path: PathBuf::from(input_path.ok_or(CliError::MissingInputPath)?),
+            output_file,
+        })
+    }
+
+    /// ファイルシステムを参照して検証済み Config に変換
+    fn resolve(self) -> Result<Config, CliError> {
+        let path = self.input_path;
 
         if !path.exists() {
             Err(CliError::InputPathNotFound(path.display().to_string()))
         } else if path.is_dir() {
-            if output_file.is_some() {
+            if self.output_file.is_some() {
                 return Err(CliError::OutputWithDirectory);
             }
             Ok(Config::BatchDirectory { dir_path: path })
         } else if path.is_file() {
             Ok(Config::SingleFile {
                 file_path: path,
-                output_file,
+                output_file: self.output_file,
             })
         } else {
             Err(CliError::InvalidInputPath(path.display().to_string()))
         }
+    }
+}
+
+#[derive(Debug)]
+pub enum Config {
+    SingleFile {
+        file_path: PathBuf,
+        output_file: Option<PathBuf>,
+    },
+    BatchDirectory {
+        dir_path: PathBuf,
+    },
+}
+
+impl Config {
+    pub fn build(args: impl Iterator<Item = String>) -> Result<Config, CliError> {
+        RawArgs::parse(args)?.resolve()
     }
 
     /// Config を処理単位（FileTask）のリストに変換
@@ -106,9 +128,69 @@ mod tests {
     use tempfile::tempdir;
 
     #[test]
-    fn config_build_no_input() {
+    fn raw_args_parse_no_input() {
         let args = vec!["program".to_string()];
-        let result = Config::build(args.into_iter());
+        let result = RawArgs::parse(args.into_iter());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn raw_args_parse_input_only() {
+        let args = vec!["program".to_string(), "input.csv".to_string()];
+        let result = RawArgs::parse(args.into_iter()).unwrap();
+        assert_eq!(
+            result,
+            RawArgs {
+                input_path: PathBuf::from("input.csv"),
+                output_file: None,
+            }
+        );
+    }
+
+    #[test]
+    fn raw_args_parse_with_output() {
+        let args = vec![
+            "program".to_string(),
+            "input.csv".to_string(),
+            "--output".to_string(),
+            "out.json".to_string(),
+        ];
+        let result = RawArgs::parse(args.into_iter()).unwrap();
+        assert_eq!(
+            result,
+            RawArgs {
+                input_path: PathBuf::from("input.csv"),
+                output_file: Some(PathBuf::from("out.json")),
+            }
+        );
+    }
+
+    #[test]
+    fn raw_args_parse_output_before_input() {
+        let args = vec![
+            "program".to_string(),
+            "--output".to_string(),
+            "out.json".to_string(),
+            "input.csv".to_string(),
+        ];
+        let result = RawArgs::parse(args.into_iter()).unwrap();
+        assert_eq!(
+            result,
+            RawArgs {
+                input_path: PathBuf::from("input.csv"),
+                output_file: Some(PathBuf::from("out.json")),
+            }
+        );
+    }
+
+    #[test]
+    fn raw_args_parse_unexpected_argument() {
+        let args = vec![
+            "program".to_string(),
+            "input.csv".to_string(),
+            "extra".to_string(),
+        ];
+        let result = RawArgs::parse(args.into_iter());
         assert!(result.is_err());
     }
 

--- a/cli/cli/src/error.rs
+++ b/cli/cli/src/error.rs
@@ -1,0 +1,50 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CliError {
+    // Config errors
+    #[error("Missing required input path argument")]
+    MissingInputPath,
+
+    #[error("Unexpected argument: {0}")]
+    UnexpectedArgument(String),
+
+    #[error("Input path does not exist: {0}")]
+    InputPathNotFound(String),
+
+    #[error("Input path is neither a file nor directory: {0}")]
+    InvalidInputPath(String),
+
+    // I/O errors (with path context)
+    #[error("Failed to read directory '{path}': {source}")]
+    ReadDir {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("Failed to read directory entry: {0}")]
+    ReadDirEntry(#[source] std::io::Error),
+
+    #[error("Failed to read input file '{path}': {source}")]
+    ReadFile {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("Failed to write file '{path}': {source}")]
+    WriteFile {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    // Serialization
+    #[error("Failed to serialize {context} to JSON: {source}")]
+    Serialize {
+        context: &'static str,
+        #[source]
+        source: serde_json::Error,
+    },
+}

--- a/cli/cli/src/error.rs
+++ b/cli/cli/src/error.rs
@@ -21,6 +21,9 @@ pub enum CliError {
     #[error("--output cannot be used with directory input")]
     OutputWithDirectory,
 
+    #[error("--output specified more than once")]
+    DuplicateOutput,
+
     #[error("No CSV files found in directory: {0}")]
     NoCsvFilesFound(String),
 

--- a/cli/cli/src/error.rs
+++ b/cli/cli/src/error.rs
@@ -25,15 +25,8 @@ pub enum CliError {
     NoCsvFilesFound(String),
 
     // I/O errors (with path context)
-    #[error("Failed to read directory '{path}': {source}")]
-    ReadDir {
-        path: String,
-        #[source]
-        source: std::io::Error,
-    },
-
-    #[error("Failed to read directory entry: {0}")]
-    ReadDirEntry(#[source] std::io::Error),
+    #[error("Failed to walk directory: {0}")]
+    WalkDir(String),
 
     #[error("Failed to read input file '{path}': {source}")]
     ReadFile {

--- a/cli/cli/src/error.rs
+++ b/cli/cli/src/error.rs
@@ -18,6 +18,9 @@ pub enum CliError {
     #[error("--output cannot be used with directory input")]
     OutputWithDirectory,
 
+    #[error("No CSV files found in directory: {0}")]
+    NoCsvFilesFound(String),
+
     // I/O errors (with path context)
     #[error("Failed to read directory '{path}': {source}")]
     ReadDir {

--- a/cli/cli/src/error.rs
+++ b/cli/cli/src/error.rs
@@ -15,6 +15,9 @@ pub enum CliError {
     #[error("Input path is neither a file nor directory: {0}")]
     InvalidInputPath(String),
 
+    #[error("--output cannot be used with directory input")]
+    OutputWithDirectory,
+
     // I/O errors (with path context)
     #[error("Failed to read directory '{path}': {source}")]
     ReadDir {

--- a/cli/cli/src/error.rs
+++ b/cli/cli/src/error.rs
@@ -15,6 +15,9 @@ pub enum CliError {
     #[error("Input path is neither a file nor directory: {0}")]
     InvalidInputPath(String),
 
+    #[error("--output requires a value")]
+    MissingOutputValue,
+
     #[error("--output cannot be used with directory input")]
     OutputWithDirectory,
 

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -1,15 +1,15 @@
-use std::error::Error;
-
 pub mod config;
+pub mod error;
 pub mod output;
 pub mod pipeline;
 pub mod preprocess;
 
 pub use config::{Config, InputType};
+pub use error::CliError;
 pub use output::{MetadataOutput, create_laps_output, create_metadata_output};
 pub use preprocess::{LapWithMetadata, group_laps_by_car, parse_laps_from_csv};
 
-pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
+pub fn run(config: Config) -> Result<(), CliError> {
     if let InputType::Directory(dir) = &config.input_type {
         println!("Scanning directory '{}' for CSV files...", dir);
     }

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -7,12 +7,61 @@ pub mod preprocess;
 pub use args::parse_args;
 pub use error::CliError;
 pub use output::{MetadataOutput, create_laps_output, create_metadata_output};
-pub use pipeline::FileTask;
 pub use preprocess::{LapWithMetadata, group_laps_by_car, parse_laps_from_csv};
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use pipeline::ProcessingReport;
+
+/// 1ファイルの処理に必要な情報
+pub struct FileTask {
+    input_path: PathBuf,
+    output_path: PathBuf,
+    event_name: String,
+}
+
+impl FileTask {
+    /// 入力ファイルパスから FileTask を生成する。
+    /// output_override が None の場合、入力ファイルの拡張子を .json に置換したパスを使う。
+    pub fn new(input_path: PathBuf, output_override: Option<PathBuf>) -> Self {
+        let stem = input_path
+            .file_stem()
+            .unwrap_or_else(|| std::ffi::OsStr::new("output"))
+            .to_string_lossy();
+
+        let output_path = output_override
+            .unwrap_or_else(|| input_path.with_extension("json"));
+        let event_name = stem.to_string();
+
+        Self {
+            input_path,
+            output_path,
+            event_name,
+        }
+    }
+
+    pub fn input_path(&self) -> &Path {
+        &self.input_path
+    }
+
+    pub fn output_path(&self) -> &Path {
+        &self.output_path
+    }
+
+    pub fn event_name(&self) -> &str {
+        &self.event_name
+    }
+
+    pub fn laps_path(&self) -> PathBuf {
+        let stem = self
+            .output_path
+            .file_stem()
+            .unwrap_or_default()
+            .to_string_lossy();
+        self.output_path
+            .with_file_name(format!("{}_laps.json", stem))
+    }
+}
 
 pub struct FileOutcome {
     pub input_path: PathBuf,
@@ -25,4 +74,23 @@ pub fn run(tasks: Vec<FileTask>) -> impl Iterator<Item = FileOutcome> {
         let result = pipeline::process_file(&task);
         FileOutcome { input_path, result }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_task_default_output() {
+        let task = FileTask::new(PathBuf::from("input.csv"), None);
+        assert_eq!(task.output_path(), Path::new("input.json"));
+        assert_eq!(task.event_name(), "input");
+    }
+
+    #[test]
+    fn file_task_with_output_override() {
+        let task = FileTask::new(PathBuf::from("input.csv"), Some(PathBuf::from("custom.json")));
+        assert_eq!(task.output_path(), Path::new("custom.json"));
+        assert_eq!(task.event_name(), "input");
+    }
 }

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -14,21 +14,6 @@ pub struct RunSummary {
     pub errors: usize,
 }
 
-fn process_task(task: &pipeline::FileTask) -> bool {
-    match pipeline::process_file(task) {
-        Ok(report) => {
-            log::info!("Read {} cars from CSV '{}'", report.car_count, task.input_path);
-            log::info!("Wrote metadata JSON to {}", report.metadata_path);
-            log::info!("Wrote laps JSON to {}", report.laps_path);
-            true
-        }
-        Err(e) => {
-            log::error!("Error processing '{}': {}", task.input_path, e);
-            false
-        }
-    }
-}
-
 pub fn run(config: Config) -> Result<RunSummary, CliError> {
     if let InputType::Directory(dir) = &config.input_type {
         log::info!("Scanning directory '{}' for CSV files...", dir);
@@ -42,16 +27,26 @@ pub fn run(config: Config) -> Result<RunSummary, CliError> {
         log::info!("Found {} CSV file(s) to process", tasks.len());
     }
 
-    let processed = tasks
-        .iter()
-        .inspect(|task| {
-            if is_batch {
-                log::info!("Processing: {}", task.input_path);
+    let mut processed = 0;
+    let mut errors = 0;
+
+    for task in &tasks {
+        if is_batch {
+            log::info!("Processing: {}", task.input_path);
+        }
+        match pipeline::process_file(task) {
+            Ok(report) => {
+                log::info!("Read {} cars from CSV '{}'", report.car_count, task.input_path);
+                log::info!("Wrote metadata JSON to {}", report.metadata_path);
+                log::info!("Wrote laps JSON to {}", report.laps_path);
+                processed += 1;
             }
-        })
-        .filter(|task| process_task(task))
-        .count();
-    let errors = tasks.len() - processed;
+            Err(e) => {
+                log::error!("Error processing '{}': {}", task.input_path, e);
+                errors += 1;
+            }
+        }
+    }
 
     if is_batch {
         log::info!(

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -16,12 +16,12 @@ pub struct RunSummary {
 
 pub fn run(config: Config) -> Result<RunSummary, CliError> {
     if let InputType::Directory(dir) = &config.input_type {
-        println!("Scanning directory '{}' for CSV files...", dir);
+        log::info!("Scanning directory '{}' for CSV files...", dir);
     }
     let tasks = config.into_tasks()?;
 
     if tasks.is_empty() {
-        println!("No CSV files found to process");
+        log::info!("No CSV files found to process");
         return Ok(RunSummary {
             processed: 0,
             errors: 0,
@@ -30,7 +30,7 @@ pub fn run(config: Config) -> Result<RunSummary, CliError> {
 
     let is_batch = tasks.len() > 1;
     if is_batch {
-        println!("Found {} CSV file(s) to process", tasks.len());
+        log::info!("Found {} CSV file(s) to process", tasks.len());
     }
 
     let mut processed = 0;
@@ -38,24 +38,24 @@ pub fn run(config: Config) -> Result<RunSummary, CliError> {
 
     for task in &tasks {
         if is_batch {
-            println!("Processing: {}", task.input_path);
+            log::info!("Processing: {}", task.input_path);
         }
         match pipeline::process_file(task) {
             Ok(report) => {
-                println!("Read {} cars from CSV '{}'", report.car_count, task.input_path);
-                println!("Wrote metadata JSON to {}", report.metadata_path);
-                println!("Wrote laps JSON to {}", report.laps_path);
+                log::info!("Read {} cars from CSV '{}'", report.car_count, task.input_path);
+                log::info!("Wrote metadata JSON to {}", report.metadata_path);
+                log::info!("Wrote laps JSON to {}", report.laps_path);
                 processed += 1;
             }
             Err(e) => {
-                eprintln!("Error processing '{}': {}", task.input_path, e);
+                log::error!("Error processing '{}': {}", task.input_path, e);
                 errors += 1;
             }
         }
     }
 
     if is_batch {
-        println!(
+        log::info!(
             "Batch processing completed: {} processed, {} errors",
             processed, errors
         );

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -16,7 +16,7 @@ pub struct RunSummary {
 
 pub fn run(config: Config) -> Result<RunSummary, CliError> {
     if let InputType::Directory(dir) = &config.input_type {
-        log::info!("Scanning directory '{}' for CSV files...", dir);
+        log::info!("Scanning directory '{}' for CSV files...", dir.display());
     }
     let tasks = config.into_tasks()?;
 
@@ -31,16 +31,16 @@ pub fn run(config: Config) -> Result<RunSummary, CliError> {
     let mut errors = 0;
 
     for task in &tasks {
-        log::info!("Processing: {}", task.input_path);
+        log::info!("Processing: {}", task.input_path.display());
         match pipeline::process_file(task) {
             Ok(report) => {
-                log::info!("Read {} cars from CSV '{}'", report.car_count, task.input_path);
-                log::info!("Wrote metadata JSON to {}", report.metadata_path);
-                log::info!("Wrote laps JSON to {}", report.laps_path);
+                log::info!("Read {} cars from CSV '{}'", report.car_count, task.input_path.display());
+                log::info!("Wrote metadata JSON to {}", report.metadata_path.display());
+                log::info!("Wrote laps JSON to {}", report.laps_path.display());
                 processed += 1;
             }
             Err(e) => {
-                log::error!("Error processing '{}': {}", task.input_path, e);
+                log::error!("Error processing '{}': {}", task.input_path.display(), e);
                 errors += 1;
             }
         }

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -20,20 +20,18 @@ pub fn run(config: Config) -> Result<RunSummary, CliError> {
     }
     let tasks = config.into_tasks()?;
 
-    let is_batch = tasks.len() > 1;
     if tasks.is_empty() {
         log::info!("No CSV files found to process");
-    } else if is_batch {
-        log::info!("Found {} CSV file(s) to process", tasks.len());
+        return Ok(RunSummary { processed: 0, errors: 0 });
     }
+
+    log::info!("Found {} CSV file(s) to process", tasks.len());
 
     let mut processed = 0;
     let mut errors = 0;
 
     for task in &tasks {
-        if is_batch {
-            log::info!("Processing: {}", task.input_path);
-        }
+        log::info!("Processing: {}", task.input_path);
         match pipeline::process_file(task) {
             Ok(report) => {
                 log::info!("Read {} cars from CSV '{}'", report.car_count, task.input_path);
@@ -48,12 +46,10 @@ pub fn run(config: Config) -> Result<RunSummary, CliError> {
         }
     }
 
-    if is_batch {
-        log::info!(
-            "Batch processing completed: {} processed, {} errors",
-            processed, errors
-        );
-    }
+    log::info!(
+        "Processing completed: {} processed, {} errors",
+        processed, errors
+    );
 
     Ok(RunSummary { processed, errors })
 }

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -1,152 +1,48 @@
 use std::error::Error;
-use std::fs;
-use std::path::Path;
 
 pub mod config;
 pub mod output;
+pub mod pipeline;
 pub mod preprocess;
 
 pub use config::{Config, InputType};
 pub use output::{MetadataOutput, create_laps_output, create_metadata_output};
 pub use preprocess::{LapWithMetadata, group_laps_by_car, parse_laps_from_csv};
 
-/// Process a single CSV file and convert to JSON
-fn process_single_file(config: &Config) -> Result<(), Box<dyn Error>> {
-    // Extract input path and other parameters from config
-    let (input_path, output_path, event_name) = match &config.input_type {
-        InputType::File(file_path) => (
-            file_path.as_str(),
-            config.output_file.clone(),
-            config.event_name.as_deref(),
-        ),
-        InputType::Directory(_) => {
-            unreachable!("Directory config should not reach process_single_file")
+pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
+    let tasks = config.into_tasks()?;
+
+    if tasks.is_empty() {
+        println!("No CSV files found to process");
+        return Ok(());
+    }
+
+    let is_batch = tasks.len() > 1;
+    if is_batch {
+        println!("Found {} CSV file(s) to process", tasks.len());
+    }
+
+    let mut processed = 0;
+    let mut errors = 0;
+
+    for task in &tasks {
+        if is_batch {
+            println!("Processing: {}", task.input_path);
         }
-    };
-
-    let csv_content = fs::read_to_string(input_path)
-        .map_err(|e| format!("Failed to read input file '{}': {}", input_path, e))?;
-
-    let laps_with_metadata = parse_laps_from_csv(&csv_content);
-    let cars = group_laps_by_car(laps_with_metadata.clone());
-    println!("Read {} cars from CSV '{}'", cars.len(), input_path);
-
-    let event_name = event_name
-        .or_else(|| Path::new(input_path).file_stem().and_then(|s| s.to_str()))
-        .unwrap_or("test_event");
-
-    let output_metadata = create_metadata_output(event_name, &cars);
-    let output_laps = create_laps_output(&laps_with_metadata);
-
-    let metadata_json = serde_json::to_string_pretty(&output_metadata)
-        .map_err(|e| format!("Failed to serialize metadata to JSON: {e}"))?;
-
-    let laps_json = serde_json::to_string_pretty(&output_laps)
-        .map_err(|e| format!("Failed to serialize laps to JSON: {e}"))?;
-
-    let base_output_path = output_path.unwrap_or_else(|| {
-        Path::new(input_path)
-            .with_extension("json")
-            .to_string_lossy()
-            .into_owned()
-    });
-
-    fs::write(&base_output_path, &metadata_json)
-        .map_err(|e| format!("Failed to write output file '{}': {e}", base_output_path))?;
-
-    let base_path = Path::new(&base_output_path);
-    let laps_output_path = {
-        let stem = base_path.file_stem().unwrap_or_default().to_string_lossy();
-        let parent = base_path.parent().unwrap_or_else(|| Path::new(""));
-        parent
-            .join(format!("{}_laps.json", stem))
-            .to_string_lossy()
-            .into_owned()
-    };
-    fs::write(&laps_output_path, &laps_json)
-        .map_err(|e| format!("Failed to write laps file '{}': {e}", laps_output_path))?;
-
-    println!("Wrote metadata JSON to {}", base_output_path);
-    println!("Wrote laps JSON to {}", laps_output_path);
-    Ok(())
-}
-
-/// Find all CSV files in a directory recursively
-fn find_csv_files(dir_path: &str) -> Result<Vec<String>, Box<dyn Error>> {
-    let mut csv_files = Vec::new();
-    let entries = fs::read_dir(dir_path)
-        .map_err(|e| format!("Failed to read directory '{}': {}", dir_path, e))?;
-
-    for entry in entries {
-        let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
-        let path = entry.path();
-
-        if path.is_dir() {
-            // Recursively search subdirectories
-            let subdir_path = path.to_string_lossy().to_string();
-            let mut subdir_files = find_csv_files(&subdir_path)?;
-            csv_files.append(&mut subdir_files);
-        } else if let Some(extension) = path.extension() {
-            if extension == "csv" {
-                csv_files.push(path.to_string_lossy().to_string());
+        match pipeline::process_file(task) {
+            Ok(_) => processed += 1,
+            Err(e) => {
+                eprintln!("Error processing '{}': {}", task.input_path, e);
+                errors += 1;
             }
         }
     }
 
-    Ok(csv_files)
-}
-
-pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
-    match &config.input_type {
-        InputType::File(_) => {
-            process_single_file(&config)?;
-        }
-        InputType::Directory(dir_path) => {
-            println!("Scanning directory '{}' for CSV files...", dir_path);
-            let csv_files = find_csv_files(dir_path)?;
-
-            if csv_files.is_empty() {
-                println!("No CSV files found in directory '{}'", dir_path);
-                return Ok(());
-            }
-
-            println!("Found {} CSV file(s) to process", csv_files.len());
-
-            let mut processed = 0;
-            let mut errors = 0;
-
-            for csv_file in &csv_files {
-                println!("Processing: {}", csv_file);
-
-                // Create a file-specific config for each CSV file
-                let file_config = Config {
-                    input_type: InputType::File(csv_file.clone()),
-                    output_file: Some(
-                        Path::new(csv_file)
-                            .with_extension("json")
-                            .to_string_lossy()
-                            .into_owned(),
-                    ),
-                    event_name: Path::new(csv_file)
-                        .file_stem()
-                        .and_then(|s| s.to_str())
-                        .map(|s| s.to_string()),
-                };
-
-                match process_single_file(&file_config) {
-                    Ok(_) => processed += 1,
-                    Err(e) => {
-                        eprintln!("Error processing '{}': {}", csv_file, e);
-                        errors += 1;
-                    }
-                }
-            }
-
-            println!(
-                "Batch processing completed: {} processed, {} errors",
-                processed, errors
-            );
-        }
+    if is_batch {
+        println!(
+            "Batch processing completed: {} processed, {} errors",
+            processed, errors
+        );
     }
 
     Ok(())

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -19,12 +19,6 @@ pub fn run(config: Config) -> Result<RunSummary, CliError> {
         log::info!("Scanning directory '{}' for CSV files...", dir_path.display());
     }
     let tasks = config.into_tasks()?;
-
-    if tasks.is_empty() {
-        log::info!("No CSV files found to process");
-        return Ok(RunSummary { processed: 0, errors: 0 });
-    }
-
     log::info!("Found {} CSV file(s) to process", tasks.len());
 
     let mut processed = 0;

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -14,26 +14,15 @@ use std::path::PathBuf;
 
 use pipeline::ProcessingReport;
 
-pub enum FileResult {
-    Processed {
-        input_path: PathBuf,
-        report: ProcessingReport,
-    },
-    Failed {
-        input_path: PathBuf,
-        error: CliError,
-    },
+pub struct FileOutcome {
+    pub input_path: PathBuf,
+    pub result: Result<ProcessingReport, CliError>,
 }
 
-pub fn run(tasks: Vec<FileTask>) -> impl Iterator<Item = FileResult> {
+pub fn run(tasks: Vec<FileTask>) -> impl Iterator<Item = FileOutcome> {
     tasks.into_iter().map(|task| {
         let input_path = task.input_path().to_path_buf();
-        match pipeline::process_file(&task) {
-            Ok(report) => FileResult::Processed {
-                input_path,
-                report,
-            },
-            Err(error) => FileResult::Failed { input_path, error },
-        }
+        let result = pipeline::process_file(&task);
+        FileOutcome { input_path, result }
     })
 }

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -33,7 +33,12 @@ pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
             println!("Processing: {}", task.input_path);
         }
         match pipeline::process_file(task) {
-            Ok(_) => processed += 1,
+            Ok(report) => {
+                println!("Read {} cars from CSV '{}'", report.car_count, task.input_path);
+                println!("Wrote metadata JSON to {}", report.metadata_path);
+                println!("Wrote laps JSON to {}", report.laps_path);
+                processed += 1;
+            }
             Err(e) => {
                 eprintln!("Error processing '{}': {}", task.input_path, e);
                 errors += 1;

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -14,45 +14,44 @@ pub struct RunSummary {
     pub errors: usize,
 }
 
+fn process_task(task: &pipeline::FileTask) -> bool {
+    match pipeline::process_file(task) {
+        Ok(report) => {
+            log::info!("Read {} cars from CSV '{}'", report.car_count, task.input_path);
+            log::info!("Wrote metadata JSON to {}", report.metadata_path);
+            log::info!("Wrote laps JSON to {}", report.laps_path);
+            true
+        }
+        Err(e) => {
+            log::error!("Error processing '{}': {}", task.input_path, e);
+            false
+        }
+    }
+}
+
 pub fn run(config: Config) -> Result<RunSummary, CliError> {
     if let InputType::Directory(dir) = &config.input_type {
         log::info!("Scanning directory '{}' for CSV files...", dir);
     }
     let tasks = config.into_tasks()?;
 
+    let is_batch = tasks.len() > 1;
     if tasks.is_empty() {
         log::info!("No CSV files found to process");
-        return Ok(RunSummary {
-            processed: 0,
-            errors: 0,
-        });
-    }
-
-    let is_batch = tasks.len() > 1;
-    if is_batch {
+    } else if is_batch {
         log::info!("Found {} CSV file(s) to process", tasks.len());
     }
 
-    let mut processed = 0;
-    let mut errors = 0;
-
-    for task in &tasks {
-        if is_batch {
-            log::info!("Processing: {}", task.input_path);
-        }
-        match pipeline::process_file(task) {
-            Ok(report) => {
-                log::info!("Read {} cars from CSV '{}'", report.car_count, task.input_path);
-                log::info!("Wrote metadata JSON to {}", report.metadata_path);
-                log::info!("Wrote laps JSON to {}", report.laps_path);
-                processed += 1;
+    let processed = tasks
+        .iter()
+        .inspect(|task| {
+            if is_batch {
+                log::info!("Processing: {}", task.input_path);
             }
-            Err(e) => {
-                log::error!("Error processing '{}': {}", task.input_path, e);
-                errors += 1;
-            }
-        }
-    }
+        })
+        .filter(|task| process_task(task))
+        .count();
+    let errors = tasks.len() - processed;
 
     if is_batch {
         log::info!(

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -54,7 +54,15 @@ fn process_single_file(config: &Config) -> Result<(), Box<dyn Error>> {
     fs::write(&base_output_path, &metadata_json)
         .map_err(|e| format!("Failed to write output file '{}': {e}", base_output_path))?;
 
-    let laps_output_path = base_output_path.replace(".json", "_laps.json");
+    let base_path = Path::new(&base_output_path);
+    let laps_output_path = {
+        let stem = base_path.file_stem().unwrap_or_default().to_string_lossy();
+        let parent = base_path.parent().unwrap_or_else(|| Path::new(""));
+        parent
+            .join(format!("{}_laps.json", stem))
+            .to_string_lossy()
+            .into_owned()
+    };
     fs::write(&laps_output_path, &laps_json)
         .map_err(|e| format!("Failed to write laps file '{}': {e}", laps_output_path))?;
 

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -9,38 +9,30 @@ pub use error::CliError;
 pub use output::{MetadataOutput, create_laps_output, create_metadata_output};
 pub use preprocess::{LapWithMetadata, group_laps_by_car, parse_laps_from_csv};
 
-pub struct RunSummary {
-    pub processed: usize,
-    pub errors: usize,
+use std::path::PathBuf;
+
+use pipeline::ProcessingReport;
+
+pub enum FileResult {
+    Processed {
+        input_path: PathBuf,
+        report: ProcessingReport,
+    },
+    Failed {
+        input_path: PathBuf,
+        error: CliError,
+    },
 }
 
-pub fn run(config: Config) -> RunSummary {
-    let tasks = config.into_tasks();
-    log::info!("Found {} CSV file(s) to process", tasks.len());
-
-    let mut processed = 0;
-    let mut errors = 0;
-
-    for task in &tasks {
-        log::info!("Processing: {}", task.input_path().display());
-        match pipeline::process_file(task) {
-            Ok(report) => {
-                log::info!("Read {} cars from CSV '{}'", report.car_count, task.input_path().display());
-                log::info!("Wrote metadata JSON to {}", report.metadata_path.display());
-                log::info!("Wrote laps JSON to {}", report.laps_path.display());
-                processed += 1;
-            }
-            Err(e) => {
-                log::error!("Error processing '{}': {}", task.input_path().display(), e);
-                errors += 1;
-            }
+pub fn run(config: Config) -> impl Iterator<Item = FileResult> {
+    config.into_tasks().into_iter().map(|task| {
+        let input_path = task.input_path().to_path_buf();
+        match pipeline::process_file(&task) {
+            Ok(report) => FileResult::Processed {
+                input_path,
+                report,
+            },
+            Err(error) => FileResult::Failed { input_path, error },
         }
-    }
-
-    log::info!(
-        "Processing completed: {} processed, {} errors",
-        processed, errors
-    );
-
-    RunSummary { processed, errors }
+    })
 }

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -25,16 +25,16 @@ pub fn run(config: Config) -> Result<RunSummary, CliError> {
     let mut errors = 0;
 
     for task in &tasks {
-        log::info!("Processing: {}", task.input_path.display());
+        log::info!("Processing: {}", task.input_path().display());
         match pipeline::process_file(task) {
             Ok(report) => {
-                log::info!("Read {} cars from CSV '{}'", report.car_count, task.input_path.display());
+                log::info!("Read {} cars from CSV '{}'", report.car_count, task.input_path().display());
                 log::info!("Wrote metadata JSON to {}", report.metadata_path.display());
                 log::info!("Wrote laps JSON to {}", report.laps_path.display());
                 processed += 1;
             }
             Err(e) => {
-                log::error!("Error processing '{}': {}", task.input_path.display(), e);
+                log::error!("Error processing '{}': {}", task.input_path().display(), e);
                 errors += 1;
             }
         }

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -14,11 +14,8 @@ pub struct RunSummary {
     pub errors: usize,
 }
 
-pub fn run(config: Config) -> Result<RunSummary, CliError> {
-    if let Config::BatchDirectory { dir_path } = &config {
-        log::info!("Scanning directory '{}' for CSV files...", dir_path.display());
-    }
-    let tasks = config.into_tasks()?;
+pub fn run(config: Config) -> RunSummary {
+    let tasks = config.into_tasks();
     log::info!("Found {} CSV file(s) to process", tasks.len());
 
     let mut processed = 0;
@@ -45,5 +42,5 @@ pub fn run(config: Config) -> Result<RunSummary, CliError> {
         processed, errors
     );
 
-    Ok(RunSummary { processed, errors })
+    RunSummary { processed, errors }
 }

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -10,6 +10,9 @@ pub use output::{MetadataOutput, create_laps_output, create_metadata_output};
 pub use preprocess::{LapWithMetadata, group_laps_by_car, parse_laps_from_csv};
 
 pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
+    if let InputType::Directory(dir) = &config.input_type {
+        println!("Scanning directory '{}' for CSV files...", dir);
+    }
     let tasks = config.into_tasks()?;
 
     if tasks.is_empty() {

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -9,7 +9,12 @@ pub use error::CliError;
 pub use output::{MetadataOutput, create_laps_output, create_metadata_output};
 pub use preprocess::{LapWithMetadata, group_laps_by_car, parse_laps_from_csv};
 
-pub fn run(config: Config) -> Result<(), CliError> {
+pub struct RunSummary {
+    pub processed: usize,
+    pub errors: usize,
+}
+
+pub fn run(config: Config) -> Result<RunSummary, CliError> {
     if let InputType::Directory(dir) = &config.input_type {
         println!("Scanning directory '{}' for CSV files...", dir);
     }
@@ -17,7 +22,10 @@ pub fn run(config: Config) -> Result<(), CliError> {
 
     if tasks.is_empty() {
         println!("No CSV files found to process");
-        return Ok(());
+        return Ok(RunSummary {
+            processed: 0,
+            errors: 0,
+        });
     }
 
     let is_batch = tasks.len() > 1;
@@ -53,5 +61,5 @@ pub fn run(config: Config) -> Result<(), CliError> {
         );
     }
 
-    Ok(())
+    Ok(RunSummary { processed, errors })
 }

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -1,12 +1,13 @@
-pub mod config;
+pub mod args;
 pub mod error;
 pub mod output;
 pub mod pipeline;
 pub mod preprocess;
 
-pub use config::Config;
+pub use args::parse_args;
 pub use error::CliError;
 pub use output::{MetadataOutput, create_laps_output, create_metadata_output};
+pub use pipeline::FileTask;
 pub use preprocess::{LapWithMetadata, group_laps_by_car, parse_laps_from_csv};
 
 use std::path::PathBuf;
@@ -24,8 +25,8 @@ pub enum FileResult {
     },
 }
 
-pub fn run(config: Config) -> impl Iterator<Item = FileResult> {
-    config.into_tasks().into_iter().map(|task| {
+pub fn run(tasks: Vec<FileTask>) -> impl Iterator<Item = FileResult> {
+    tasks.into_iter().map(|task| {
         let input_path = task.input_path().to_path_buf();
         match pipeline::process_file(&task) {
             Ok(report) => FileResult::Processed {

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -4,7 +4,7 @@ pub mod output;
 pub mod pipeline;
 pub mod preprocess;
 
-pub use config::{Config, InputType};
+pub use config::Config;
 pub use error::CliError;
 pub use output::{MetadataOutput, create_laps_output, create_metadata_output};
 pub use preprocess::{LapWithMetadata, group_laps_by_car, parse_laps_from_csv};
@@ -15,8 +15,8 @@ pub struct RunSummary {
 }
 
 pub fn run(config: Config) -> Result<RunSummary, CliError> {
-    if let InputType::Directory(dir) = &config.input_type {
-        log::info!("Scanning directory '{}' for CSV files...", dir.display());
+    if let Config::BatchDirectory { dir_path } = &config {
+        log::info!("Scanning directory '{}' for CSV files...", dir_path.display());
     }
     let tasks = config.into_tasks()?;
 

--- a/cli/cli/src/main.rs
+++ b/cli/cli/src/main.rs
@@ -9,8 +9,14 @@ fn main() {
         process::exit(1);
     });
 
-    if let Err(e) = cli::run(config) {
-        eprintln!("Application error: {e}");
-        process::exit(1);
+    match cli::run(config) {
+        Ok(summary) if summary.errors > 0 => {
+            process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("Application error: {e}");
+            process::exit(1);
+        }
+        _ => {}
     }
 }

--- a/cli/cli/src/main.rs
+++ b/cli/cli/src/main.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::process;
 
-use cli::{FileResult, parse_args};
+use cli::parse_args;
 
 fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
@@ -14,29 +14,28 @@ fn main() {
         process::exit(1);
     });
 
-    let mut processed = 0;
-    let mut errors = 0;
-    for result in cli::run(tasks) {
-        match result {
-            FileResult::Processed {
-                input_path,
-                report,
-            } => {
+    let (processed, errors) = cli::run(tasks).fold((0u32, 0u32), |(processed, errors), outcome| {
+        match &outcome.result {
+            Ok(report) => {
                 log::info!(
                     "Read {} cars from CSV '{}'",
                     report.car_count,
-                    input_path.display()
+                    outcome.input_path.display()
                 );
                 log::info!("Wrote metadata JSON to {}", report.metadata_path.display());
                 log::info!("Wrote laps JSON to {}", report.laps_path.display());
-                processed += 1;
+                (processed + 1, errors)
             }
-            FileResult::Failed { input_path, error } => {
-                log::error!("Error processing '{}': {}", input_path.display(), error);
-                errors += 1;
+            Err(error) => {
+                log::error!(
+                    "Error processing '{}': {}",
+                    outcome.input_path.display(),
+                    error
+                );
+                (processed, errors + 1)
             }
         }
-    }
+    });
 
     log::info!(
         "Processing completed: {} processed, {} errors",

--- a/cli/cli/src/main.rs
+++ b/cli/cli/src/main.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::process;
 
-use cli::Config;
+use cli::{Config, FileResult};
 
 fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
@@ -14,8 +14,36 @@ fn main() {
         process::exit(1);
     });
 
-    let summary = cli::run(config);
-    if summary.errors > 0 {
+    let mut processed = 0;
+    let mut errors = 0;
+    for result in cli::run(config) {
+        match result {
+            FileResult::Processed {
+                input_path,
+                report,
+            } => {
+                log::info!(
+                    "Read {} cars from CSV '{}'",
+                    report.car_count,
+                    input_path.display()
+                );
+                log::info!("Wrote metadata JSON to {}", report.metadata_path.display());
+                log::info!("Wrote laps JSON to {}", report.laps_path.display());
+                processed += 1;
+            }
+            FileResult::Failed { input_path, error } => {
+                log::error!("Error processing '{}': {}", input_path.display(), error);
+                errors += 1;
+            }
+        }
+    }
+
+    log::info!(
+        "Processing completed: {} processed, {} errors",
+        processed, errors
+    );
+
+    if errors > 0 {
         process::exit(1);
     }
 }

--- a/cli/cli/src/main.rs
+++ b/cli/cli/src/main.rs
@@ -14,14 +14,8 @@ fn main() {
         process::exit(1);
     });
 
-    match cli::run(config) {
-        Ok(summary) if summary.errors > 0 => {
-            process::exit(1);
-        }
-        Err(e) => {
-            eprintln!("Application error: {e}");
-            process::exit(1);
-        }
-        _ => {}
+    let summary = cli::run(config);
+    if summary.errors > 0 {
+        process::exit(1);
     }
 }

--- a/cli/cli/src/main.rs
+++ b/cli/cli/src/main.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::process;
 
-use cli::{Config, FileResult};
+use cli::{FileResult, parse_args};
 
 fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
@@ -9,14 +9,14 @@ fn main() {
         .format_target(false)
         .init();
 
-    let config = Config::build(env::args()).unwrap_or_else(|err| {
+    let tasks = parse_args(env::args()).unwrap_or_else(|err| {
         eprintln!("Problem parsing arguments: {err}");
         process::exit(1);
     });
 
     let mut processed = 0;
     let mut errors = 0;
-    for result in cli::run(config) {
+    for result in cli::run(tasks) {
         match result {
             FileResult::Processed {
                 input_path,

--- a/cli/cli/src/main.rs
+++ b/cli/cli/src/main.rs
@@ -4,6 +4,11 @@ use std::process;
 use cli::Config;
 
 fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .format_timestamp(None)
+        .format_target(false)
+        .init();
+
     let config = Config::build(env::args()).unwrap_or_else(|err| {
         eprintln!("Problem parsing arguments: {err}");
         process::exit(1);

--- a/cli/cli/src/output.rs
+++ b/cli/cli/src/output.rs
@@ -177,7 +177,7 @@ pub fn map_event_name(event_id: &str) -> &str {
         "bahrain_8h" => "8 Hours of Bahrain",
         "sao_paulo_6h" => "6 Hours of São Paulo",
         other => {
-            eprintln!("Unknown event ID '{}', using as-is", other);
+            log::warn!("Unknown event ID '{}', using as-is", other);
             other
         }
     }

--- a/cli/cli/src/output.rs
+++ b/cli/cli/src/output.rs
@@ -176,7 +176,10 @@ pub fn map_event_name(event_id: &str) -> &str {
         "fuji_6h" => "6 Hours of Fuji",
         "bahrain_8h" => "8 Hours of Bahrain",
         "sao_paulo_6h" => "6 Hours of São Paulo",
-        _ => "Encoding Error",
+        other => {
+            eprintln!("Unknown event ID '{}', using as-is", other);
+            other
+        }
     }
 }
 
@@ -233,7 +236,7 @@ mod tests {
         assert_eq!(map_event_name("fuji_6h"), "6 Hours of Fuji");
         assert_eq!(map_event_name("bahrain_8h"), "8 Hours of Bahrain");
         assert_eq!(map_event_name("sao_paulo_6h"), "6 Hours of São Paulo");
-        assert_eq!(map_event_name("unknown_event"), "Encoding Error");
+        assert_eq!(map_event_name("unknown_event"), "unknown_event");
     }
 
     #[test]

--- a/cli/cli/src/pipeline.rs
+++ b/cli/cli/src/pipeline.rs
@@ -7,9 +7,42 @@ use crate::preprocess;
 
 /// 1ファイルの処理に必要な情報
 pub struct FileTask {
-    pub input_path: PathBuf,
-    pub output_path: PathBuf,
-    pub event_name: String,
+    input_path: PathBuf,
+    output_path: PathBuf,
+    event_name: String,
+}
+
+impl FileTask {
+    /// 入力ファイルパスから FileTask を生成する。
+    /// output_override が None の場合、入力ファイルの拡張子を .json に置換したパスを使う。
+    pub fn new(input_path: PathBuf, output_override: Option<PathBuf>) -> Self {
+        let stem = input_path
+            .file_stem()
+            .unwrap_or_else(|| std::ffi::OsStr::new("output"))
+            .to_string_lossy();
+
+        let output_path = output_override
+            .unwrap_or_else(|| input_path.with_extension("json"));
+        let event_name = stem.to_string();
+
+        Self {
+            input_path,
+            output_path,
+            event_name,
+        }
+    }
+
+    pub fn input_path(&self) -> &Path {
+        &self.input_path
+    }
+
+    pub fn output_path(&self) -> &Path {
+        &self.output_path
+    }
+
+    pub fn event_name(&self) -> &str {
+        &self.event_name
+    }
 }
 
 /// 変換・直列化の結果（純粋な変換の出力）
@@ -28,8 +61,8 @@ pub struct ProcessingReport {
 
 /// パイプライン: read → transform+serialize → write
 pub fn process_file(task: &FileTask) -> Result<ProcessingReport, CliError> {
-    let csv_content = read_csv(&task.input_path)?;
-    let output = transform_and_serialize(&csv_content, &task.event_name)?;
+    let csv_content = read_csv(task.input_path())?;
+    let output = transform_and_serialize(&csv_content, task.event_name())?;
     let written = write_files(task, &output)?;
     Ok(ProcessingReport {
         car_count: output.car_count,
@@ -79,19 +112,18 @@ struct WrittenFiles {
 }
 
 fn write_files(task: &FileTask, output: &SerializedOutput) -> Result<WrittenFiles, CliError> {
-    fs::write(&task.output_path, &output.metadata_json).map_err(|e| CliError::WriteFile {
-        path: task.output_path.display().to_string(),
+    let output_path = task.output_path();
+    fs::write(output_path, &output.metadata_json).map_err(|e| CliError::WriteFile {
+        path: output_path.display().to_string(),
         source: e,
     })?;
 
     let laps_path = {
-        let stem = task
-            .output_path
+        let stem = output_path
             .file_stem()
             .unwrap_or_default()
             .to_string_lossy();
-        task.output_path
-            .with_file_name(format!("{}_laps.json", stem))
+        output_path.with_file_name(format!("{}_laps.json", stem))
     };
     fs::write(&laps_path, &output.laps_json).map_err(|e| CliError::WriteFile {
         path: laps_path.display().to_string(),
@@ -99,7 +131,7 @@ fn write_files(task: &FileTask, output: &SerializedOutput) -> Result<WrittenFile
     })?;
 
     Ok(WrittenFiles {
-        metadata_path: task.output_path.clone(),
+        metadata_path: output_path.to_path_buf(),
         laps_path,
     })
 }

--- a/cli/cli/src/pipeline.rs
+++ b/cli/cli/src/pipeline.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::Path;
 
 use crate::error::CliError;
 use crate::output;
@@ -29,10 +30,11 @@ pub struct ProcessingReport {
 pub fn process_file(task: &FileTask) -> Result<ProcessingReport, CliError> {
     let csv_content = read_csv(&task.input_path)?;
     let output = transform_and_serialize(&csv_content, &task.event_name)?;
-    let report = write_files(task, &output)?;
+    let written = write_files(task, &output)?;
     Ok(ProcessingReport {
         car_count: output.car_count,
-        ..report
+        metadata_path: written.metadata_path,
+        laps_path: written.laps_path,
     })
 }
 
@@ -71,23 +73,30 @@ fn transform_and_serialize(
     })
 }
 
-fn write_files(
-    task: &FileTask,
-    output: &SerializedOutput,
-) -> Result<ProcessingReport, CliError> {
+struct WrittenFiles {
+    metadata_path: String,
+    laps_path: String,
+}
+
+fn write_files(task: &FileTask, output: &SerializedOutput) -> Result<WrittenFiles, CliError> {
     fs::write(&task.output_path, &output.metadata_json).map_err(|e| CliError::WriteFile {
         path: task.output_path.clone(),
         source: e,
     })?;
 
-    let laps_path = task.output_path.replace(".json", "_laps.json");
+    let laps_path = {
+        let p = Path::new(&task.output_path);
+        let stem = p.file_stem().unwrap_or_default().to_string_lossy();
+        p.with_file_name(format!("{}_laps.json", stem))
+            .to_string_lossy()
+            .into_owned()
+    };
     fs::write(&laps_path, &output.laps_json).map_err(|e| CliError::WriteFile {
         path: laps_path.clone(),
         source: e,
     })?;
 
-    Ok(ProcessingReport {
-        car_count: output.car_count,
+    Ok(WrittenFiles {
         metadata_path: task.output_path.clone(),
         laps_path,
     })

--- a/cli/cli/src/pipeline.rs
+++ b/cli/cli/src/pipeline.rs
@@ -66,27 +66,3 @@ fn write_outputs(
     println!("Wrote laps JSON to {}", laps_output_path);
     Ok(())
 }
-
-/// ディレクトリ内のCSVファイルを再帰的に検索
-pub fn find_csv_files(dir_path: &str) -> Result<Vec<String>, Box<dyn Error>> {
-    let mut csv_files = Vec::new();
-    let entries = fs::read_dir(dir_path)
-        .map_err(|e| format!("Failed to read directory '{}': {}", dir_path, e))?;
-
-    for entry in entries {
-        let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
-        let path = entry.path();
-
-        if path.is_dir() {
-            let subdir_path = path.to_string_lossy().to_string();
-            let mut subdir_files = find_csv_files(&subdir_path)?;
-            csv_files.append(&mut subdir_files);
-        } else if let Some(extension) = path.extension() {
-            if extension == "csv" {
-                csv_files.push(path.to_string_lossy().to_string());
-            }
-        }
-    }
-
-    Ok(csv_files)
-}

--- a/cli/cli/src/pipeline.rs
+++ b/cli/cli/src/pipeline.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::error::CliError;
 use crate::output;
@@ -7,8 +7,8 @@ use crate::preprocess;
 
 /// 1ファイルの処理に必要な情報
 pub struct FileTask {
-    pub input_path: String,
-    pub output_path: String,
+    pub input_path: PathBuf,
+    pub output_path: PathBuf,
     pub event_name: String,
 }
 
@@ -22,8 +22,8 @@ struct SerializedOutput {
 /// 処理完了の報告（呼び出し元がログに使う）
 pub struct ProcessingReport {
     pub car_count: usize,
-    pub metadata_path: String,
-    pub laps_path: String,
+    pub metadata_path: PathBuf,
+    pub laps_path: PathBuf,
 }
 
 /// パイプライン: read → transform+serialize → write
@@ -38,9 +38,9 @@ pub fn process_file(task: &FileTask) -> Result<ProcessingReport, CliError> {
     })
 }
 
-fn read_csv(input_path: &str) -> Result<String, CliError> {
+fn read_csv(input_path: &Path) -> Result<String, CliError> {
     fs::read_to_string(input_path).map_err(|e| CliError::ReadFile {
-        path: input_path.to_string(),
+        path: input_path.display().to_string(),
         source: e,
     })
 }
@@ -74,25 +74,27 @@ fn transform_and_serialize(
 }
 
 struct WrittenFiles {
-    metadata_path: String,
-    laps_path: String,
+    metadata_path: PathBuf,
+    laps_path: PathBuf,
 }
 
 fn write_files(task: &FileTask, output: &SerializedOutput) -> Result<WrittenFiles, CliError> {
     fs::write(&task.output_path, &output.metadata_json).map_err(|e| CliError::WriteFile {
-        path: task.output_path.clone(),
+        path: task.output_path.display().to_string(),
         source: e,
     })?;
 
     let laps_path = {
-        let p = Path::new(&task.output_path);
-        let stem = p.file_stem().unwrap_or_default().to_string_lossy();
-        p.with_file_name(format!("{}_laps.json", stem))
-            .to_string_lossy()
-            .into_owned()
+        let stem = task
+            .output_path
+            .file_stem()
+            .unwrap_or_default()
+            .to_string_lossy();
+        task.output_path
+            .with_file_name(format!("{}_laps.json", stem))
     };
     fs::write(&laps_path, &output.laps_json).map_err(|e| CliError::WriteFile {
-        path: laps_path.clone(),
+        path: laps_path.display().to_string(),
         source: e,
     })?;
 

--- a/cli/cli/src/pipeline.rs
+++ b/cli/cli/src/pipeline.rs
@@ -43,6 +43,16 @@ impl FileTask {
     pub fn event_name(&self) -> &str {
         &self.event_name
     }
+
+    pub fn laps_path(&self) -> PathBuf {
+        let stem = self
+            .output_path
+            .file_stem()
+            .unwrap_or_default()
+            .to_string_lossy();
+        self.output_path
+            .with_file_name(format!("{}_laps.json", stem))
+    }
 }
 
 /// 変換・直列化の結果（純粋な変換の出力）
@@ -83,10 +93,10 @@ fn transform_and_serialize(
     event_name: &str,
 ) -> Result<SerializedOutput, CliError> {
     let laps_with_metadata = preprocess::parse_laps_from_csv(csv_content);
-    let cars = preprocess::group_laps_by_car(laps_with_metadata.clone());
+    let laps = output::create_laps_output(&laps_with_metadata);
+    let cars = preprocess::group_laps_by_car(laps_with_metadata);
     let car_count = cars.len();
     let metadata = output::create_metadata_output(event_name, &cars);
-    let laps = output::create_laps_output(&laps_with_metadata);
 
     let metadata_json = serde_json::to_string_pretty(&metadata).map_err(|e| {
         CliError::Serialize {
@@ -113,18 +123,12 @@ struct WrittenFiles {
 
 fn write_files(task: &FileTask, output: &SerializedOutput) -> Result<WrittenFiles, CliError> {
     let output_path = task.output_path();
+    let laps_path = task.laps_path();
+
     fs::write(output_path, &output.metadata_json).map_err(|e| CliError::WriteFile {
         path: output_path.display().to_string(),
         source: e,
     })?;
-
-    let laps_path = {
-        let stem = output_path
-            .file_stem()
-            .unwrap_or_default()
-            .to_string_lossy();
-        output_path.with_file_name(format!("{}_laps.json", stem))
-    };
     fs::write(&laps_path, &output.laps_json).map_err(|e| CliError::WriteFile {
         path: laps_path.display().to_string(),
         source: e,

--- a/cli/cli/src/pipeline.rs
+++ b/cli/cli/src/pipeline.rs
@@ -135,3 +135,50 @@ fn write_files(task: &FileTask, output: &SerializedOutput) -> Result<WrittenFile
         laps_path,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_task_default_output_basic() {
+        let task = FileTask::new(PathBuf::from("input.csv"), None);
+        assert_eq!(task.output_path(), Path::new("input.json"));
+        assert_eq!(task.event_name(), "input");
+    }
+
+    #[test]
+    fn file_task_default_output_with_path() {
+        let task = FileTask::new(PathBuf::from("/path/to/input.csv"), None);
+        assert_eq!(task.output_path(), Path::new("/path/to/input.json"));
+        assert_eq!(task.event_name(), "input");
+    }
+
+    #[test]
+    fn file_task_default_output_multiple_dots() {
+        let task = FileTask::new(PathBuf::from("my.test.file.csv"), None);
+        assert_eq!(task.output_path(), Path::new("my.test.file.json"));
+        assert_eq!(task.event_name(), "my.test.file");
+    }
+
+    #[test]
+    fn file_task_default_output_no_extension() {
+        let task = FileTask::new(PathBuf::from("input"), None);
+        assert_eq!(task.output_path(), Path::new("input.json"));
+        assert_eq!(task.event_name(), "input");
+    }
+
+    #[test]
+    fn file_task_default_output_relative_path() {
+        let task = FileTask::new(PathBuf::from("./data/input.csv"), None);
+        assert_eq!(task.output_path(), Path::new("./data/input.json"));
+        assert_eq!(task.event_name(), "input");
+    }
+
+    #[test]
+    fn file_task_with_output_override() {
+        let task = FileTask::new(PathBuf::from("input.csv"), Some(PathBuf::from("custom.json")));
+        assert_eq!(task.output_path(), Path::new("custom.json"));
+        assert_eq!(task.event_name(), "input");
+    }
+}

--- a/cli/cli/src/pipeline.rs
+++ b/cli/cli/src/pipeline.rs
@@ -141,37 +141,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn file_task_default_output_basic() {
+    fn file_task_default_output() {
         let task = FileTask::new(PathBuf::from("input.csv"), None);
         assert_eq!(task.output_path(), Path::new("input.json"));
-        assert_eq!(task.event_name(), "input");
-    }
-
-    #[test]
-    fn file_task_default_output_with_path() {
-        let task = FileTask::new(PathBuf::from("/path/to/input.csv"), None);
-        assert_eq!(task.output_path(), Path::new("/path/to/input.json"));
-        assert_eq!(task.event_name(), "input");
-    }
-
-    #[test]
-    fn file_task_default_output_multiple_dots() {
-        let task = FileTask::new(PathBuf::from("my.test.file.csv"), None);
-        assert_eq!(task.output_path(), Path::new("my.test.file.json"));
-        assert_eq!(task.event_name(), "my.test.file");
-    }
-
-    #[test]
-    fn file_task_default_output_no_extension() {
-        let task = FileTask::new(PathBuf::from("input"), None);
-        assert_eq!(task.output_path(), Path::new("input.json"));
-        assert_eq!(task.event_name(), "input");
-    }
-
-    #[test]
-    fn file_task_default_output_relative_path() {
-        let task = FileTask::new(PathBuf::from("./data/input.csv"), None);
-        assert_eq!(task.output_path(), Path::new("./data/input.json"));
         assert_eq!(task.event_name(), "input");
     }
 

--- a/cli/cli/src/pipeline.rs
+++ b/cli/cli/src/pipeline.rs
@@ -1,59 +1,10 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::FileTask;
 use crate::error::CliError;
 use crate::output;
 use crate::preprocess;
-
-/// 1ファイルの処理に必要な情報
-pub struct FileTask {
-    input_path: PathBuf,
-    output_path: PathBuf,
-    event_name: String,
-}
-
-impl FileTask {
-    /// 入力ファイルパスから FileTask を生成する。
-    /// output_override が None の場合、入力ファイルの拡張子を .json に置換したパスを使う。
-    pub fn new(input_path: PathBuf, output_override: Option<PathBuf>) -> Self {
-        let stem = input_path
-            .file_stem()
-            .unwrap_or_else(|| std::ffi::OsStr::new("output"))
-            .to_string_lossy();
-
-        let output_path = output_override
-            .unwrap_or_else(|| input_path.with_extension("json"));
-        let event_name = stem.to_string();
-
-        Self {
-            input_path,
-            output_path,
-            event_name,
-        }
-    }
-
-    pub fn input_path(&self) -> &Path {
-        &self.input_path
-    }
-
-    pub fn output_path(&self) -> &Path {
-        &self.output_path
-    }
-
-    pub fn event_name(&self) -> &str {
-        &self.event_name
-    }
-
-    pub fn laps_path(&self) -> PathBuf {
-        let stem = self
-            .output_path
-            .file_stem()
-            .unwrap_or_default()
-            .to_string_lossy();
-        self.output_path
-            .with_file_name(format!("{}_laps.json", stem))
-    }
-}
 
 /// 変換・直列化の結果（純粋な変換の出力）
 struct SerializedOutput {
@@ -140,21 +91,3 @@ fn write_files(task: &FileTask, output: &SerializedOutput) -> Result<WrittenFile
     })
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn file_task_default_output() {
-        let task = FileTask::new(PathBuf::from("input.csv"), None);
-        assert_eq!(task.output_path(), Path::new("input.json"));
-        assert_eq!(task.event_name(), "input");
-    }
-
-    #[test]
-    fn file_task_with_output_override() {
-        let task = FileTask::new(PathBuf::from("input.csv"), Some(PathBuf::from("custom.json")));
-        assert_eq!(task.output_path(), Path::new("custom.json"));
-        assert_eq!(task.event_name(), "input");
-    }
-}

--- a/cli/cli/src/pipeline.rs
+++ b/cli/cli/src/pipeline.rs
@@ -1,6 +1,6 @@
-use std::error::Error;
 use std::fs;
 
+use crate::error::CliError;
 use crate::output;
 use crate::preprocess;
 
@@ -26,7 +26,7 @@ pub struct ProcessingReport {
 }
 
 /// パイプライン: read → transform+serialize → write
-pub fn process_file(task: &FileTask) -> Result<ProcessingReport, Box<dyn Error>> {
+pub fn process_file(task: &FileTask) -> Result<ProcessingReport, CliError> {
     let csv_content = read_csv(&task.input_path)?;
     let output = transform_and_serialize(&csv_content, &task.event_name)?;
     let report = write_files(task, &output)?;
@@ -36,25 +36,33 @@ pub fn process_file(task: &FileTask) -> Result<ProcessingReport, Box<dyn Error>>
     })
 }
 
-fn read_csv(input_path: &str) -> Result<String, Box<dyn Error>> {
-    fs::read_to_string(input_path)
-        .map_err(|e| format!("Failed to read input file '{}': {}", input_path, e).into())
+fn read_csv(input_path: &str) -> Result<String, CliError> {
+    fs::read_to_string(input_path).map_err(|e| CliError::ReadFile {
+        path: input_path.to_string(),
+        source: e,
+    })
 }
 
 fn transform_and_serialize(
     csv_content: &str,
     event_name: &str,
-) -> Result<SerializedOutput, Box<dyn Error>> {
+) -> Result<SerializedOutput, CliError> {
     let laps_with_metadata = preprocess::parse_laps_from_csv(csv_content);
     let cars = preprocess::group_laps_by_car(laps_with_metadata.clone());
     let car_count = cars.len();
     let metadata = output::create_metadata_output(event_name, &cars);
     let laps = output::create_laps_output(&laps_with_metadata);
 
-    let metadata_json = serde_json::to_string_pretty(&metadata)
-        .map_err(|e| format!("Failed to serialize metadata to JSON: {e}"))?;
-    let laps_json = serde_json::to_string_pretty(&laps)
-        .map_err(|e| format!("Failed to serialize laps to JSON: {e}"))?;
+    let metadata_json = serde_json::to_string_pretty(&metadata).map_err(|e| {
+        CliError::Serialize {
+            context: "metadata",
+            source: e,
+        }
+    })?;
+    let laps_json = serde_json::to_string_pretty(&laps).map_err(|e| CliError::Serialize {
+        context: "laps",
+        source: e,
+    })?;
 
     Ok(SerializedOutput {
         metadata_json,
@@ -66,13 +74,17 @@ fn transform_and_serialize(
 fn write_files(
     task: &FileTask,
     output: &SerializedOutput,
-) -> Result<ProcessingReport, Box<dyn Error>> {
-    fs::write(&task.output_path, &output.metadata_json)
-        .map_err(|e| format!("Failed to write output file '{}': {e}", task.output_path))?;
+) -> Result<ProcessingReport, CliError> {
+    fs::write(&task.output_path, &output.metadata_json).map_err(|e| CliError::WriteFile {
+        path: task.output_path.clone(),
+        source: e,
+    })?;
 
     let laps_path = task.output_path.replace(".json", "_laps.json");
-    fs::write(&laps_path, &output.laps_json)
-        .map_err(|e| format!("Failed to write laps file '{}': {e}", laps_path))?;
+    fs::write(&laps_path, &output.laps_json).map_err(|e| CliError::WriteFile {
+        path: laps_path.clone(),
+        source: e,
+    })?;
 
     Ok(ProcessingReport {
         car_count: output.car_count,

--- a/cli/cli/src/pipeline.rs
+++ b/cli/cli/src/pipeline.rs
@@ -11,12 +11,19 @@ pub struct FileTask {
     pub event_name: String,
 }
 
+/// 変換結果
+struct TransformResult {
+    metadata: MetadataOutput,
+    laps: Vec<RawLap>,
+    car_count: usize,
+}
+
 /// パイプライン: read → transform → write
 pub fn process_file(task: &FileTask) -> Result<(), Box<dyn Error>> {
     let csv_content = read_csv(&task.input_path)?;
-    let (metadata, laps) = transform(&csv_content, &task.event_name);
-    println!("Read {} cars from CSV '{}'", metadata.starting_grid.len(), task.input_path);
-    write_outputs(task, &metadata, &laps)?;
+    let result = transform(&csv_content, &task.event_name);
+    println!("Read {} cars from CSV '{}'", result.car_count, task.input_path);
+    write_outputs(task, &result.metadata, &result.laps)?;
     Ok(())
 }
 
@@ -25,12 +32,17 @@ fn read_csv(input_path: &str) -> Result<String, Box<dyn Error>> {
         .map_err(|e| format!("Failed to read input file '{}': {}", input_path, e).into())
 }
 
-fn transform(csv_content: &str, event_name: &str) -> (MetadataOutput, Vec<RawLap>) {
+fn transform(csv_content: &str, event_name: &str) -> TransformResult {
     let laps_with_metadata = preprocess::parse_laps_from_csv(csv_content);
     let cars = preprocess::group_laps_by_car(laps_with_metadata.clone());
+    let car_count = cars.len();
     let metadata = output::create_metadata_output(event_name, &cars);
     let laps = output::create_laps_output(&laps_with_metadata);
-    (metadata, laps)
+    TransformResult {
+        metadata,
+        laps,
+        car_count,
+    }
 }
 
 fn write_outputs(

--- a/cli/cli/src/pipeline.rs
+++ b/cli/cli/src/pipeline.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 use std::fs;
 
-use crate::output::{self, MetadataOutput, RawLap};
+use crate::output;
 use crate::preprocess;
 
 /// 1ファイルの処理に必要な情報
@@ -11,20 +11,29 @@ pub struct FileTask {
     pub event_name: String,
 }
 
-/// 変換結果
-struct TransformResult {
-    metadata: MetadataOutput,
-    laps: Vec<RawLap>,
+/// 変換・直列化の結果（純粋な変換の出力）
+struct SerializedOutput {
+    metadata_json: String,
+    laps_json: String,
     car_count: usize,
 }
 
-/// パイプライン: read → transform → write
-pub fn process_file(task: &FileTask) -> Result<(), Box<dyn Error>> {
+/// 処理完了の報告（呼び出し元がログに使う）
+pub struct ProcessingReport {
+    pub car_count: usize,
+    pub metadata_path: String,
+    pub laps_path: String,
+}
+
+/// パイプライン: read → transform+serialize → write
+pub fn process_file(task: &FileTask) -> Result<ProcessingReport, Box<dyn Error>> {
     let csv_content = read_csv(&task.input_path)?;
-    let result = transform(&csv_content, &task.event_name);
-    println!("Read {} cars from CSV '{}'", result.car_count, task.input_path);
-    write_outputs(task, &result.metadata, &result.laps)?;
-    Ok(())
+    let output = transform_and_serialize(&csv_content, &task.event_name)?;
+    let report = write_files(task, &output)?;
+    Ok(ProcessingReport {
+        car_count: output.car_count,
+        ..report
+    })
 }
 
 fn read_csv(input_path: &str) -> Result<String, Box<dyn Error>> {
@@ -32,37 +41,42 @@ fn read_csv(input_path: &str) -> Result<String, Box<dyn Error>> {
         .map_err(|e| format!("Failed to read input file '{}': {}", input_path, e).into())
 }
 
-fn transform(csv_content: &str, event_name: &str) -> TransformResult {
+fn transform_and_serialize(
+    csv_content: &str,
+    event_name: &str,
+) -> Result<SerializedOutput, Box<dyn Error>> {
     let laps_with_metadata = preprocess::parse_laps_from_csv(csv_content);
     let cars = preprocess::group_laps_by_car(laps_with_metadata.clone());
     let car_count = cars.len();
     let metadata = output::create_metadata_output(event_name, &cars);
     let laps = output::create_laps_output(&laps_with_metadata);
-    TransformResult {
-        metadata,
-        laps,
-        car_count,
-    }
-}
 
-fn write_outputs(
-    task: &FileTask,
-    metadata: &MetadataOutput,
-    laps: &[RawLap],
-) -> Result<(), Box<dyn Error>> {
-    let metadata_json = serde_json::to_string_pretty(metadata)
+    let metadata_json = serde_json::to_string_pretty(&metadata)
         .map_err(|e| format!("Failed to serialize metadata to JSON: {e}"))?;
-    let laps_json = serde_json::to_string_pretty(laps)
+    let laps_json = serde_json::to_string_pretty(&laps)
         .map_err(|e| format!("Failed to serialize laps to JSON: {e}"))?;
 
-    fs::write(&task.output_path, &metadata_json)
+    Ok(SerializedOutput {
+        metadata_json,
+        laps_json,
+        car_count,
+    })
+}
+
+fn write_files(
+    task: &FileTask,
+    output: &SerializedOutput,
+) -> Result<ProcessingReport, Box<dyn Error>> {
+    fs::write(&task.output_path, &output.metadata_json)
         .map_err(|e| format!("Failed to write output file '{}': {e}", task.output_path))?;
 
-    let laps_output_path = task.output_path.replace(".json", "_laps.json");
-    fs::write(&laps_output_path, &laps_json)
-        .map_err(|e| format!("Failed to write laps file '{}': {e}", laps_output_path))?;
+    let laps_path = task.output_path.replace(".json", "_laps.json");
+    fs::write(&laps_path, &output.laps_json)
+        .map_err(|e| format!("Failed to write laps file '{}': {e}", laps_path))?;
 
-    println!("Wrote metadata JSON to {}", task.output_path);
-    println!("Wrote laps JSON to {}", laps_output_path);
-    Ok(())
+    Ok(ProcessingReport {
+        car_count: output.car_count,
+        metadata_path: task.output_path.clone(),
+        laps_path,
+    })
 }

--- a/cli/cli/src/pipeline.rs
+++ b/cli/cli/src/pipeline.rs
@@ -1,0 +1,80 @@
+use std::error::Error;
+use std::fs;
+
+use crate::output::{self, MetadataOutput, RawLap};
+use crate::preprocess;
+
+/// 1ファイルの処理に必要な情報
+pub struct FileTask {
+    pub input_path: String,
+    pub output_path: String,
+    pub event_name: String,
+}
+
+/// パイプライン: read → transform → write
+pub fn process_file(task: &FileTask) -> Result<(), Box<dyn Error>> {
+    let csv_content = read_csv(&task.input_path)?;
+    let (metadata, laps) = transform(&csv_content, &task.event_name);
+    println!("Read {} cars from CSV '{}'", metadata.starting_grid.len(), task.input_path);
+    write_outputs(task, &metadata, &laps)?;
+    Ok(())
+}
+
+fn read_csv(input_path: &str) -> Result<String, Box<dyn Error>> {
+    fs::read_to_string(input_path)
+        .map_err(|e| format!("Failed to read input file '{}': {}", input_path, e).into())
+}
+
+fn transform(csv_content: &str, event_name: &str) -> (MetadataOutput, Vec<RawLap>) {
+    let laps_with_metadata = preprocess::parse_laps_from_csv(csv_content);
+    let cars = preprocess::group_laps_by_car(laps_with_metadata.clone());
+    let metadata = output::create_metadata_output(event_name, &cars);
+    let laps = output::create_laps_output(&laps_with_metadata);
+    (metadata, laps)
+}
+
+fn write_outputs(
+    task: &FileTask,
+    metadata: &MetadataOutput,
+    laps: &[RawLap],
+) -> Result<(), Box<dyn Error>> {
+    let metadata_json = serde_json::to_string_pretty(metadata)
+        .map_err(|e| format!("Failed to serialize metadata to JSON: {e}"))?;
+    let laps_json = serde_json::to_string_pretty(laps)
+        .map_err(|e| format!("Failed to serialize laps to JSON: {e}"))?;
+
+    fs::write(&task.output_path, &metadata_json)
+        .map_err(|e| format!("Failed to write output file '{}': {e}", task.output_path))?;
+
+    let laps_output_path = task.output_path.replace(".json", "_laps.json");
+    fs::write(&laps_output_path, &laps_json)
+        .map_err(|e| format!("Failed to write laps file '{}': {e}", laps_output_path))?;
+
+    println!("Wrote metadata JSON to {}", task.output_path);
+    println!("Wrote laps JSON to {}", laps_output_path);
+    Ok(())
+}
+
+/// ディレクトリ内のCSVファイルを再帰的に検索
+pub fn find_csv_files(dir_path: &str) -> Result<Vec<String>, Box<dyn Error>> {
+    let mut csv_files = Vec::new();
+    let entries = fs::read_dir(dir_path)
+        .map_err(|e| format!("Failed to read directory '{}': {}", dir_path, e))?;
+
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
+        let path = entry.path();
+
+        if path.is_dir() {
+            let subdir_path = path.to_string_lossy().to_string();
+            let mut subdir_files = find_csv_files(&subdir_path)?;
+            csv_files.append(&mut subdir_files);
+        } else if let Some(extension) = path.extension() {
+            if extension == "csv" {
+                csv_files.push(path.to_string_lossy().to_string());
+            }
+        }
+    }
+
+    Ok(csv_files)
+}

--- a/cli/cli/src/preprocess.rs
+++ b/cli/cli/src/preprocess.rs
@@ -712,7 +712,10 @@ fn class_from(class_str: &str) -> Class {
         "HYPERCAR" => Class::HYPERCAR,
         "LMP2" => Class::LMP2,
         "LMGT3" => Class::LMGT3,
-        _ => Class::HYPERCAR, // デフォルト
+        unknown => {
+            eprintln!("Unknown class '{}', falling back to None", unknown);
+            Class::None
+        }
     }
 }
 

--- a/cli/cli/src/preprocess.rs
+++ b/cli/cli/src/preprocess.rs
@@ -713,7 +713,7 @@ fn class_from(class_str: &str) -> Class {
         "LMP2" => Class::LMP2,
         "LMGT3" => Class::LMGT3,
         unknown => {
-            eprintln!("Unknown class '{}', falling back to None", unknown);
+            log::warn!("Unknown class '{}', falling back to None", unknown);
             Class::None
         }
     }

--- a/cli/cli/tests/integration.rs
+++ b/cli/cli/tests/integration.rs
@@ -90,8 +90,8 @@ fn test_cli_end_to_end_execution() {
     fs::copy("../test_data.csv", test_input).expect("Failed to copy test data");
 
     // Create CLI configuration
-    let config = Config {
-        input_type: cli::InputType::File(test_input.into()),
+    let config = Config::SingleFile {
+        file_path: test_input.into(),
         output_file: Some(test_output.into()),
     };
 

--- a/cli/cli/tests/integration.rs
+++ b/cli/cli/tests/integration.rs
@@ -93,7 +93,6 @@ fn test_cli_end_to_end_execution() {
     let config = Config {
         input_type: cli::InputType::File(test_input.to_string()),
         output_file: Some(test_output.to_string()),
-        event_name: Some("test_integration_output".to_string()),
     };
 
     // Execute CLI

--- a/cli/cli/tests/integration.rs
+++ b/cli/cli/tests/integration.rs
@@ -2,7 +2,8 @@ use std::fs;
 use std::path::Path;
 
 use cli::{
-    Config, create_laps_output, create_metadata_output, group_laps_by_car, parse_laps_from_csv, run,
+    Config, FileResult, create_laps_output, create_metadata_output, group_laps_by_car,
+    parse_laps_from_csv, run,
 };
 
 // =============================================================================
@@ -96,8 +97,13 @@ fn test_cli_end_to_end_execution() {
     };
 
     // Execute CLI
-    let summary = run(config);
-    assert_eq!(summary.errors, 0, "CLI should process without errors");
+    let results: Vec<_> = run(config).collect();
+    assert!(
+        results
+            .iter()
+            .all(|r| matches!(r, FileResult::Processed { .. })),
+        "CLI should process without errors"
+    );
 
     // Verify output file creation
     assert!(

--- a/cli/cli/tests/integration.rs
+++ b/cli/cli/tests/integration.rs
@@ -96,7 +96,7 @@ fn test_cli_end_to_end_execution() {
     };
 
     // Execute CLI
-    let summary = run(config).expect("CLI execution should succeed");
+    let summary = run(config);
     assert_eq!(summary.errors, 0, "CLI should process without errors");
 
     // Verify output file creation

--- a/cli/cli/tests/integration.rs
+++ b/cli/cli/tests/integration.rs
@@ -96,12 +96,8 @@ fn test_cli_end_to_end_execution() {
     };
 
     // Execute CLI
-    let result = run(config);
-    assert!(
-        result.is_ok(),
-        "CLI execution should succeed: {:?}",
-        result.err()
-    );
+    let summary = run(config).expect("CLI execution should succeed");
+    assert_eq!(summary.errors, 0, "CLI should process without errors");
 
     // Verify output file creation
     assert!(

--- a/cli/cli/tests/integration.rs
+++ b/cli/cli/tests/integration.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::Path;
 
 use cli::{
-    Config, FileResult, create_laps_output, create_metadata_output, group_laps_by_car,
+    FileResult, FileTask, create_laps_output, create_metadata_output, group_laps_by_car,
     parse_laps_from_csv, run,
 };
 
@@ -90,14 +90,11 @@ fn test_cli_end_to_end_execution() {
     // Copy test data to expected input filename
     fs::copy("../test_data.csv", test_input).expect("Failed to copy test data");
 
-    // Create CLI configuration
-    let config = Config::SingleFile {
-        file_path: test_input.into(),
-        output_file: Some(test_output.into()),
-    };
+    // Create task
+    let tasks = vec![FileTask::new(test_input.into(), Some(test_output.into()))];
 
     // Execute CLI
-    let results: Vec<_> = run(config).collect();
+    let results: Vec<_> = run(tasks).collect();
     assert!(
         results
             .iter()

--- a/cli/cli/tests/integration.rs
+++ b/cli/cli/tests/integration.rs
@@ -91,8 +91,8 @@ fn test_cli_end_to_end_execution() {
 
     // Create CLI configuration
     let config = Config {
-        input_type: cli::InputType::File(test_input.to_string()),
-        output_file: Some(test_output.to_string()),
+        input_type: cli::InputType::File(test_input.into()),
+        output_file: Some(test_output.into()),
     };
 
     // Execute CLI

--- a/cli/cli/tests/integration.rs
+++ b/cli/cli/tests/integration.rs
@@ -2,8 +2,8 @@ use std::fs;
 use std::path::Path;
 
 use cli::{
-    FileResult, FileTask, create_laps_output, create_metadata_output, group_laps_by_car,
-    parse_laps_from_csv, run,
+    FileTask, create_laps_output, create_metadata_output, group_laps_by_car, parse_laps_from_csv,
+    run,
 };
 
 // =============================================================================
@@ -96,9 +96,7 @@ fn test_cli_end_to_end_execution() {
     // Execute CLI
     let results: Vec<_> = run(tasks).collect();
     assert!(
-        results
-            .iter()
-            .all(|r| matches!(r, FileResult::Processed { .. })),
+        results.iter().all(|o| o.result.is_ok()),
         "CLI should process without errors"
     );
 

--- a/cli/motorsport/src/car.rs
+++ b/cli/motorsport/src/car.rs
@@ -80,13 +80,15 @@ impl Status {
     pub fn has_retired(&self) -> bool {
         matches!(self, Status::Retired)
     }
+}
 
-    pub fn to_string(&self) -> &'static str {
+impl std::fmt::Display for Status {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Status::PreRace => "Pre-Race",
-            Status::Racing => "Racing",
-            Status::Checkered => "Checkered",
-            Status::Retired => "Retired",
+            Status::PreRace => write!(f, "Pre-Race"),
+            Status::Racing => write!(f, "Racing"),
+            Status::Checkered => write!(f, "Checkered"),
+            Status::Retired => write!(f, "Retired"),
         }
     }
 }

--- a/cli/motorsport/src/class.rs
+++ b/cli/motorsport/src/class.rs
@@ -14,20 +14,6 @@ pub enum Class {
 }
 
 impl Class {
-    /// クラスを文字列に変換（ElmのtoStringと互換）
-    pub fn to_string(&self) -> &'static str {
-        match self {
-            Class::None => "None",
-            Class::HYPERCAR => "HYPERCAR",
-            Class::LMP1 => "LMP1",
-            Class::LMP2 => "LMP2",
-            Class::LMGTEPro => "LMGTE Pro",
-            Class::LMGTEAm => "LMGTE Am",
-            Class::LMGT3 => "LMGT3",
-            Class::InnovativeCar => "INNOVATIVE CAR",
-        }
-    }
-
     /// 文字列からクラスを生成（ElmのfromStringと互換）
     pub fn from_string(s: &str) -> Option<Self> {
         match s {
@@ -60,6 +46,21 @@ impl Class {
                 }
             }
             Class::InnovativeCar => "#00f",
+        }
+    }
+}
+
+impl std::fmt::Display for Class {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Class::None => write!(f, "None"),
+            Class::HYPERCAR => write!(f, "HYPERCAR"),
+            Class::LMP1 => write!(f, "LMP1"),
+            Class::LMP2 => write!(f, "LMP2"),
+            Class::LMGTEPro => write!(f, "LMGTE Pro"),
+            Class::LMGTEAm => write!(f, "LMGTE Am"),
+            Class::LMGT3 => write!(f, "LMGT3"),
+            Class::InnovativeCar => write!(f, "INNOVATIVE CAR"),
         }
     }
 }
@@ -118,7 +119,7 @@ mod tests {
 
         for class in classes {
             let string_repr = class.to_string();
-            let parsed_class = Class::from_string(string_repr);
+            let parsed_class = Class::from_string(&string_repr);
             assert_eq!(Some(class), parsed_class);
         }
     }

--- a/cli/motorsport/src/timeline.rs
+++ b/cli/motorsport/src/timeline.rs
@@ -190,7 +190,6 @@ mod tests {
 
     #[test]
     fn test_timeline_event_creation() {
-        // Red: TimelineEvent構造体がまだ存在しないため、このテストは失敗する
         let event = TimelineEvent {
             event_time: 0,
             event_type: EventType::RaceStart,
@@ -202,7 +201,6 @@ mod tests {
 
     #[test]
     fn test_event_type_variants() {
-        // Red: EventType enumがまだ存在しないため、このテストは失敗する
         let race_start = EventType::RaceStart;
         let car_event = EventType::CarEvent("12".to_string(), CarEventType::Retirement);
 
@@ -335,7 +333,6 @@ mod tests {
 
     #[test]
     fn test_calc_timeline_events_empty_cars() {
-        // Red: calc_timeline_events関数がまだ存在しないため、このテストは失敗する
         let cars = vec![];
         let time_limit = 7200000; // 2時間
 
@@ -349,7 +346,6 @@ mod tests {
 
     #[test]
     fn test_calc_timeline_events_single_car_with_laps() {
-        // Red: calc_timeline_events関数とテストヘルパーがないため、このテストは失敗する
         let car = create_test_car_with_laps();
         let cars = vec![car];
         let time_limit = 7200000; // 2時間


### PR DESCRIPTION
## Summary

  Incrementally restructure the Rust CLI architecture to improve maintainability and testability.

  - **Argument parsing separation**: Replace `config.rs` with `args.rs` featuring a `try_fold`-based state machine parser. Design
  `FileTask` as an opaque type, separating filesystem validation from argument parsing
  - **Typed error handling**: Replace `Box<dyn Error>` with a `thiserror`-based `CliError` type and introduce `RunSummary` to
  structure batch processing results
  - **Pipeline extraction**: Extract `pipeline.rs` and change `run()` to return an `Iterator`, isolating side effects from library
  code and replacing `println!`/`eprintln!` with the `log` crate
  - **Bug fixes**: Strengthen `--output` flag validation, reject empty directories, safely fall back for unknown class strings, and
  fix output path derivation

  ## Commits

  30 commits (refactor × 24, fix × 5, chore × 1)

  ## Test plan

  - [x] `nix run .#cli-test` passes
  - [x] Existing CSV → JSON conversion works correctly