### PR TITLE
Split error types and improve error chain display

### DIFF
--- a/cli/cli/src/args.rs
+++ b/cli/cli/src/args.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::FileTask;
-use crate::error::CliError;
+use crate::error::SetupError;
 
 /// 引数パース結果（ファイルシステム未検証）
 #[derive(Debug, PartialEq)]
@@ -12,7 +12,7 @@ struct RawArgs {
 
 impl RawArgs {
     /// 純粋な引数パース（I/O なし）
-    fn parse(mut args: impl Iterator<Item = String>) -> Result<Self, CliError> {
+    fn parse(mut args: impl Iterator<Item = String>) -> Result<Self, SetupError> {
         enum ParseState {
             Ready {
                 input: Option<String>,
@@ -40,7 +40,7 @@ impl RawArgs {
                 } if arg == "--output" => Ok(ParseState::ExpectingOutputValue { input }),
                 ParseState::Ready {
                     output: Some(_), ..
-                } if arg == "--output" => Err(CliError::DuplicateOutput),
+                } if arg == "--output" => Err(SetupError::DuplicateOutput),
                 ParseState::Ready {
                     input: None,
                     output,
@@ -50,7 +50,7 @@ impl RawArgs {
                 }),
                 ParseState::Ready {
                     input: Some(_), ..
-                } => Err(CliError::UnexpectedArgument(arg)),
+                } => Err(SetupError::UnexpectedArgument(arg)),
             },
         )?;
 
@@ -62,13 +62,13 @@ impl RawArgs {
                 input_path: PathBuf::from(input),
                 output_file: output,
             }),
-            ParseState::Ready { input: None, .. } => Err(CliError::MissingInputPath),
-            ParseState::ExpectingOutputValue { .. } => Err(CliError::MissingOutputValue),
+            ParseState::Ready { input: None, .. } => Err(SetupError::MissingInputPath),
+            ParseState::ExpectingOutputValue { .. } => Err(SetupError::MissingOutputValue),
         }
     }
 
     /// ファイルシステムを参照して検証済み FileTask のリストに変換
-    fn resolve(self) -> Result<Vec<FileTask>, CliError> {
+    fn resolve(self) -> Result<Vec<FileTask>, SetupError> {
         enum PathKind {
             NotFound,
             File,
@@ -91,21 +91,24 @@ impl RawArgs {
         let path = self.input_path;
 
         match classify_path(&path) {
-            PathKind::NotFound => Err(CliError::InputPathNotFound(path.display().to_string())),
+            PathKind::NotFound => Err(SetupError::InputPathNotFound(path)),
             PathKind::File => Ok(vec![FileTask::new(path, self.output_file)]),
             PathKind::Dir => resolve_dir(path, self.output_file),
-            PathKind::Other => Err(CliError::InvalidInputPath(path.display().to_string())),
+            PathKind::Other => Err(SetupError::InvalidInputPath(path)),
         }
     }
 }
 
-fn resolve_dir(path: PathBuf, output_file: Option<PathBuf>) -> Result<Vec<FileTask>, CliError> {
+fn resolve_dir(path: PathBuf, output_file: Option<PathBuf>) -> Result<Vec<FileTask>, SetupError> {
     if output_file.is_some() {
-        return Err(CliError::OutputWithDirectory);
+        return Err(SetupError::OutputWithDirectory);
     }
-    let csv_files = find_csv_files(&path).map_err(|e| CliError::WalkDir(e.to_string()))?;
+    let csv_files = find_csv_files(&path).map_err(|source| SetupError::WalkDir {
+        path: path.clone(),
+        source,
+    })?;
     if csv_files.is_empty() {
-        return Err(CliError::NoCsvFilesFound(path.display().to_string()));
+        return Err(SetupError::NoCsvFilesFound(path));
     }
     Ok(csv_files
         .into_iter()
@@ -114,7 +117,7 @@ fn resolve_dir(path: PathBuf, output_file: Option<PathBuf>) -> Result<Vec<FileTa
 }
 
 /// CLI 引数をパースし、検証済みの処理タスクリストを返す
-pub fn parse_args(args: impl Iterator<Item = String>) -> Result<Vec<FileTask>, CliError> {
+pub fn parse_args(args: impl Iterator<Item = String>) -> Result<Vec<FileTask>, SetupError> {
     RawArgs::parse(args)?.resolve()
 }
 

--- a/cli/cli/src/error.rs
+++ b/cli/cli/src/error.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 /// Errors raised during the setup phase: argv parsing and input-path
 /// resolution. Surfaced as `Err` from [`run`](crate::run).
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum SetupError {
     #[error("Missing required input path argument")]
     MissingInputPath,
@@ -42,6 +43,7 @@ pub enum SetupError {
 /// [`RunSummary`](crate::RunSummary) rather than bubbled up from
 /// [`run`](crate::run).
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum FileError {
     #[error("Failed to read input file '{}': {source}", path.display())]
     ReadFile {
@@ -63,4 +65,24 @@ pub enum FileError {
         #[source]
         source: serde_json::Error,
     },
+}
+
+/// Display adapter that renders an error and its full `source()` chain.
+///
+/// `thiserror`'s generated `Display` only prints the outermost error, so the
+/// underlying `io::Error` / `walkdir::Error` reason is invisible by default.
+/// Wrap an error in `WithChain` whenever it crosses a user-visible boundary
+/// (stderr, log) to surface the root cause.
+pub struct WithChain<'a, E: ?Sized>(pub &'a E);
+
+impl<E: std::error::Error + ?Sized> std::fmt::Display for WithChain<'_, E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)?;
+        let mut source = self.0.source();
+        while let Some(e) = source {
+            write!(f, "\n  caused by: {e}")?;
+            source = e.source();
+        }
+        Ok(())
+    }
 }

--- a/cli/cli/src/error.rs
+++ b/cli/cli/src/error.rs
@@ -31,7 +31,7 @@ pub enum SetupError {
     #[error("No CSV files found in directory: {}", .0.display())]
     NoCsvFilesFound(PathBuf),
 
-    #[error("Failed to walk directory '{}': {source}", path.display())]
+    #[error("Failed to walk directory '{}'", path.display())]
     WalkDir {
         path: PathBuf,
         #[source]
@@ -45,21 +45,21 @@ pub enum SetupError {
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum FileError {
-    #[error("Failed to read input file '{}': {source}", path.display())]
+    #[error("Failed to read input file '{}'", path.display())]
     ReadFile {
         path: PathBuf,
         #[source]
         source: std::io::Error,
     },
 
-    #[error("Failed to write file '{}': {source}", path.display())]
+    #[error("Failed to write file '{}'", path.display())]
     WriteFile {
         path: PathBuf,
         #[source]
         source: std::io::Error,
     },
 
-    #[error("Failed to serialize {context} to JSON: {source}")]
+    #[error("Failed to serialize {context} to JSON")]
     Serialize {
         context: &'static str,
         #[source]
@@ -73,6 +73,10 @@ pub enum FileError {
 /// underlying `io::Error` / `walkdir::Error` reason is invisible by default.
 /// Wrap an error in `WithChain` whenever it crosses a user-visible boundary
 /// (stderr, log) to surface the root cause.
+///
+/// The variants in this module deliberately omit `{source}` from their outer
+/// `#[error]` format strings — the chain is rendered exclusively by this
+/// adapter, so embedding the source in the outer message would duplicate it.
 pub struct WithChain<'a, E: ?Sized>(pub &'a E);
 
 impl<E: std::error::Error + ?Sized> std::fmt::Display for WithChain<'_, E> {
@@ -84,5 +88,46 @@ impl<E: std::error::Error + ?Sized> std::fmt::Display for WithChain<'_, E> {
             source = e.source();
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn with_chain_renders_io_source_once() {
+        let err = FileError::ReadFile {
+            path: PathBuf::from("/missing"),
+            source: std::io::Error::new(std::io::ErrorKind::NotFound, "no such file"),
+        };
+        let rendered = format!("{}", WithChain(&err));
+
+        assert!(rendered.starts_with("Failed to read input file '/missing'"));
+        assert!(rendered.contains("\n  caused by: no such file"));
+        // Outer Display must not embed the source — otherwise the chain
+        // walker would print it a second time.
+        assert_eq!(rendered.matches("no such file").count(), 1);
+    }
+
+    #[test]
+    fn with_chain_on_setup_error_without_source_prints_only_outer() {
+        let err = SetupError::MissingInputPath;
+        let rendered = format!("{}", WithChain(&err));
+        assert_eq!(rendered, "Missing required input path argument");
+    }
+
+    #[test]
+    fn with_chain_renders_serialize_source() {
+        // Build a serde_json::Error by deserializing invalid JSON.
+        let json_err = serde_json::from_str::<i32>("not json").unwrap_err();
+        let err = FileError::Serialize {
+            context: "metadata",
+            source: json_err,
+        };
+        let rendered = format!("{}", WithChain(&err));
+
+        assert!(rendered.starts_with("Failed to serialize metadata to JSON"));
+        assert!(rendered.contains("\n  caused by: "));
     }
 }

--- a/cli/cli/src/error.rs
+++ b/cli/cli/src/error.rs
@@ -1,19 +1,22 @@
+use std::path::PathBuf;
+
 use thiserror::Error;
 
+/// Errors raised during the setup phase: argv parsing and input-path
+/// resolution. Surfaced as `Err` from [`run`](crate::run).
 #[derive(Debug, Error)]
-pub enum CliError {
-    // Config errors
+pub enum SetupError {
     #[error("Missing required input path argument")]
     MissingInputPath,
 
     #[error("Unexpected argument: {0}")]
     UnexpectedArgument(String),
 
-    #[error("Input path does not exist: {0}")]
-    InputPathNotFound(String),
+    #[error("Input path does not exist: {}", .0.display())]
+    InputPathNotFound(PathBuf),
 
-    #[error("Input path is neither a file nor directory: {0}")]
-    InvalidInputPath(String),
+    #[error("Input path is neither a file nor directory: {}", .0.display())]
+    InvalidInputPath(PathBuf),
 
     #[error("--output requires a value")]
     MissingOutputValue,
@@ -24,28 +27,36 @@ pub enum CliError {
     #[error("--output specified more than once")]
     DuplicateOutput,
 
-    #[error("No CSV files found in directory: {0}")]
-    NoCsvFilesFound(String),
+    #[error("No CSV files found in directory: {}", .0.display())]
+    NoCsvFilesFound(PathBuf),
 
-    // I/O errors (with path context)
-    #[error("Failed to walk directory: {0}")]
-    WalkDir(String),
+    #[error("Failed to walk directory '{}': {source}", path.display())]
+    WalkDir {
+        path: PathBuf,
+        #[source]
+        source: walkdir::Error,
+    },
+}
 
-    #[error("Failed to read input file '{path}': {source}")]
+/// Errors raised while processing a single file. Logged and counted in
+/// [`RunSummary`](crate::RunSummary) rather than bubbled up from
+/// [`run`](crate::run).
+#[derive(Debug, Error)]
+pub enum FileError {
+    #[error("Failed to read input file '{}': {source}", path.display())]
     ReadFile {
-        path: String,
+        path: PathBuf,
         #[source]
         source: std::io::Error,
     },
 
-    #[error("Failed to write file '{path}': {source}")]
+    #[error("Failed to write file '{}': {source}", path.display())]
     WriteFile {
-        path: String,
+        path: PathBuf,
         #[source]
         source: std::io::Error,
     },
 
-    // Serialization
     #[error("Failed to serialize {context} to JSON: {source}")]
     Serialize {
         context: &'static str,

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -24,7 +24,7 @@ pub(crate) mod events;
 pub(crate) mod stages;
 
 pub use args::parse_args;
-pub use error::{FileError, SetupError};
+pub use error::{FileError, SetupError, WithChain};
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -119,20 +119,19 @@ pub fn run(args: impl Iterator<Item = String>) -> Result<RunSummary, SetupError>
     let mut summary = RunSummary::default();
 
     for task in tasks {
-        let input_path = task.input_path().to_path_buf();
         match process_file(&task) {
             Ok(report) => {
                 log::info!(
                     "Read {} cars from CSV '{}'",
                     report.car_count,
-                    input_path.display()
+                    task.input_path().display()
                 );
                 log::info!("Wrote metadata JSON to {}", report.metadata_path.display());
                 log::info!("Wrote laps JSON to {}", report.laps_path.display());
                 summary.processed += 1;
             }
             Err(error) => {
-                log::error!("Error processing '{}': {}", input_path.display(), error);
+                log::error!("{}", WithChain(&error));
                 summary.errors += 1;
             }
         }

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -4,7 +4,7 @@
 //! - `run`: TRPL-style entry that consumes argv and drives the whole program
 //! - `RunSummary`: success / error counts; `exit_code()` maps to an OS exit
 //! - `FileTask`: one-file unit of work
-//! - `parse_args` / `CliError`
+//! - `parse_args` / `SetupError` / `FileError`
 //!
 //! # Per-file pipeline
 //!
@@ -24,7 +24,7 @@ pub(crate) mod events;
 pub(crate) mod stages;
 
 pub use args::parse_args;
-pub use error::CliError;
+pub use error::{FileError, SetupError};
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -114,7 +114,7 @@ struct ProcessingReport {
 /// - Per-file failures do not bubble up: they are logged via `log::error!` and
 ///   counted in [`RunSummary::errors`]. Callers convert the summary to an OS
 ///   exit code via [`RunSummary::exit_code`].
-pub fn run(args: impl Iterator<Item = String>) -> Result<RunSummary, CliError> {
+pub fn run(args: impl Iterator<Item = String>) -> Result<RunSummary, SetupError> {
     let tasks = parse_args(args)?;
     let mut summary = RunSummary::default();
 
@@ -150,7 +150,7 @@ pub fn run(args: impl Iterator<Item = String>) -> Result<RunSummary, CliError> {
 // Per-file execution
 // ================================================================
 
-fn process_file(task: &FileTask) -> Result<ProcessingReport, CliError> {
+fn process_file(task: &FileTask) -> Result<ProcessingReport, FileError> {
     use stages::{csv_input, files, output, structure, transform};
 
     // Stage 1: read

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -4,7 +4,7 @@
 //! - `run`: TRPL-style entry that consumes argv and drives the whole program
 //! - `RunSummary`: success / error counts; `exit_code()` maps to an OS exit
 //! - `FileTask`: one-file unit of work
-//! - `parse_args` / `SetupError` / `FileError`
+//! - `parse_args` / `SetupError` / `FileError` / `WithChain`
 //!
 //! # Per-file pipeline
 //!

--- a/cli/cli/src/main.rs
+++ b/cli/cli/src/main.rs
@@ -10,7 +10,7 @@ fn main() -> ExitCode {
     match cli::run(env::args()) {
         Ok(summary) => summary.exit_code(),
         Err(err) => {
-            eprintln!("{err}");
+            eprintln!("{}", cli::WithChain(&err));
             ExitCode::FAILURE
         }
     }

--- a/cli/cli/src/stages/files.rs
+++ b/cli/cli/src/stages/files.rs
@@ -3,18 +3,18 @@
 use std::fs;
 use std::path::Path;
 
-use crate::error::CliError;
+use crate::error::FileError;
 
-pub fn read_csv(path: &Path) -> Result<String, CliError> {
-    fs::read_to_string(path).map_err(|source| CliError::ReadFile {
-        path: path.display().to_string(),
+pub fn read_csv(path: &Path) -> Result<String, FileError> {
+    fs::read_to_string(path).map_err(|source| FileError::ReadFile {
+        path: path.to_path_buf(),
         source,
     })
 }
 
-pub fn write_json(path: &Path, content: &str) -> Result<(), CliError> {
-    fs::write(path, content).map_err(|source| CliError::WriteFile {
-        path: path.display().to_string(),
+pub fn write_json(path: &Path, content: &str) -> Result<(), FileError> {
+    fs::write(path, content).map_err(|source| FileError::WriteFile {
+        path: path.to_path_buf(),
         source,
     })
 }

--- a/cli/cli/src/stages/output.rs
+++ b/cli/cli/src/stages/output.rs
@@ -6,11 +6,11 @@ use motorsport::{Car, TimelineEvent, car, duration};
 use serde::{Serialize, Serializer};
 
 use crate::domain::LapRecord;
-use crate::error::CliError;
+use crate::error::FileError;
 
 /// Pretty-prints a serializable value as JSON (Stage 5).
-pub fn to_json_pretty<T: Serialize>(value: &T, context: &'static str) -> Result<String, CliError> {
-    serde_json::to_string_pretty(value).map_err(|source| CliError::Serialize { context, source })
+pub fn to_json_pretty<T: Serialize>(value: &T, context: &'static str) -> Result<String, FileError> {
+    serde_json::to_string_pretty(value).map_err(|source| FileError::Serialize { context, source })
 }
 
 /// Formats a sector time. If the CSV cell was blank (`present = false`) the

--- a/cli/cli/tests/integration.rs
+++ b/cli/cli/tests/integration.rs
@@ -207,7 +207,7 @@ fn test_cli_run_reports_partial_failure() {
     // An "unreadable .csv" is represented by a **directory** whose name ends
     // in `.csv`. `parse_args`'s walkdir only filters by extension and doesn't
     // check `is_file`, so the directory is enumerated as a task. The
-    // downstream `files::read_csv` then fails with `CliError::ReadFile` when
+    // downstream `files::read_csv` then fails with `FileError::ReadFile` when
     // it tries to `read_to_string` a directory.
     let temp_dir = tempfile::tempdir().expect("create tempdir");
 


### PR DESCRIPTION
## Summary
Refactored error handling to distinguish between setup-phase errors and per-file processing errors, and added a `WithChain` display adapter to surface root causes in user-visible error messages.

## Key Changes

- **Split `CliError` into two types:**
  - `SetupError`: Errors during argv parsing and input-path resolution (bubbled up from `run()`)
  - `FileError`: Errors during per-file processing (logged and counted in `RunSummary`)

- **Improved error context:**
  - Changed error fields from `String` to `PathBuf` for type safety and consistent display via `.display()`
  - Enhanced `WalkDir` error to include the path and source `walkdir::Error` for better diagnostics
  - Removed redundant source embedding in outer `#[error]` format strings

- **Added `WithChain<E>` display adapter:**
  - Renders an error and its full `source()` chain (e.g., `io::Error`, `walkdir::Error`, `serde_json::Error`)
  - Prevents duplication by keeping outer error messages source-free
  - Used at user-visible boundaries (stderr, log) to surface root causes

- **Updated call sites:**
  - `main.rs`: Wrap setup error in `WithChain` before printing to stderr
  - `lib.rs`: Wrap per-file errors in `WithChain` before logging
  - `args.rs`, `files.rs`, `output.rs`: Updated to use new error types and `PathBuf` fields

- **Added comprehensive tests:**
  - Verify `WithChain` renders IO sources exactly once
  - Verify errors without sources print cleanly
  - Verify nested error chains (e.g., serde_json) are fully displayed

## Notable Details

- `#[non_exhaustive]` on both error enums allows future additions without breaking changes
- Error types are now semantically meaningful: callers know whether an error is recoverable (per-file) or fatal (setup)
- The `WithChain` adapter is generic and reusable for any `std::error::Error` type