### PR TITLE
feat: try Flix language

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,1 +1,2 @@
 /target
+*.json

--- a/flake.nix
+++ b/flake.nix
@@ -108,7 +108,6 @@
           cli-build            = { type = "app"; program = "${mkCargoApp "cli-build" "cargo build"}/bin/cli-build";                                                  meta.description = "Build Rust CLI"; };
           cli-test             = { type = "app"; program = "${mkCargoApp "cli-test"  "cargo test"}/bin/cli-test";                                                    meta.description = "Run Rust CLI tests"; };
           cli-run              = { type = "app"; program = "${mkCargoApp "cli-run"   "cargo run -p cli -- ../app/static/wec/2025"}/bin/cli-run";                     meta.description = "Run Rust CLI (CSV -> JSON)"; };
-          flix-init            = { type = "app"; program = "${mkFlixApp "flix-init"  "flix init"}/bin/flix-init";                                                     meta.description = "Initialize Flix project"; };
           flix-build           = { type = "app"; program = "${mkFlixApp "flix-build" "flix build"}/bin/flix-build";                                                   meta.description = "Build Flix project"; };
           flix-test            = { type = "app"; program = "${mkFlixApp "flix-test"  "flix test"}/bin/flix-test";                                                     meta.description = "Run Flix tests"; };
           flix-run             = { type = "app"; program = "${mkFlixApp "flix-run"   "flix run -- ../cli/test_data.csv"}/bin/flix-run";                               meta.description = "Run Flix project (CSV -> JSON)"; };

--- a/flake.nix
+++ b/flake.nix
@@ -73,9 +73,19 @@
             '';
           };
 
+        mkFlixApp = name: cmd:
+          pkgs.writeShellApplication {
+            inherit name;
+            runtimeInputs = [ pkgs.flix ];
+            text = ''
+              cd flix
+              ${cmd}
+            '';
+          };
+
       in {
         devShells.default = pkgs.mkShell (playwrightEnv // {
-          buildInputs = with pkgs; [ nodejs_24 pnpm rustc cargo rustfmt playwright-test ] ++ elmTools;
+          buildInputs = with pkgs; [ nodejs_24 pnpm rustc cargo rustfmt playwright-test flix ] ++ elmTools;
         });
 
         apps = {
@@ -90,6 +100,10 @@
           cli-build            = { type = "app"; program = "${mkCargoApp "cli-build" "cargo build"}/bin/cli-build";                                                  meta.description = "Build Rust CLI"; };
           cli-test             = { type = "app"; program = "${mkCargoApp "cli-test"  "cargo test"}/bin/cli-test";                                                    meta.description = "Run Rust CLI tests"; };
           cli-run              = { type = "app"; program = "${mkCargoApp "cli-run"   "cargo run -p cli -- ../app/static/wec/2025"}/bin/cli-run";                     meta.description = "Run Rust CLI (CSV -> JSON)"; };
+          flix-init            = { type = "app"; program = "${mkFlixApp "flix-init"  "flix init"}/bin/flix-init";                                                     meta.description = "Initialize Flix project"; };
+          flix-build           = { type = "app"; program = "${mkFlixApp "flix-build" "flix build"}/bin/flix-build";                                                   meta.description = "Build Flix project"; };
+          flix-test            = { type = "app"; program = "${mkFlixApp "flix-test"  "flix test"}/bin/flix-test";                                                     meta.description = "Run Flix tests"; };
+          flix-run             = { type = "app"; program = "${mkFlixApp "flix-run"   "flix run"}/bin/flix-run";                                                       meta.description = "Run Flix project"; };
         };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -111,7 +111,7 @@
           flix-init            = { type = "app"; program = "${mkFlixApp "flix-init"  "flix init"}/bin/flix-init";                                                     meta.description = "Initialize Flix project"; };
           flix-build           = { type = "app"; program = "${mkFlixApp "flix-build" "flix build"}/bin/flix-build";                                                   meta.description = "Build Flix project"; };
           flix-test            = { type = "app"; program = "${mkFlixApp "flix-test"  "flix test"}/bin/flix-test";                                                     meta.description = "Run Flix tests"; };
-          flix-run             = { type = "app"; program = "${mkFlixApp "flix-run"   "flix run"}/bin/flix-run";                                                       meta.description = "Run Flix project"; };
+          flix-run             = { type = "app"; program = "${mkFlixApp "flix-run"   "flix run -- ../cli/test_data.csv"}/bin/flix-run";                               meta.description = "Run Flix project (CSV -> JSON)"; };
         };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -73,10 +73,18 @@
             '';
           };
 
+        flix = pkgs.flix.overrideAttrs (old: rec {
+          version = "0.71.0";
+          src = pkgs.fetchurl {
+            url = "https://github.com/flix/flix/releases/download/v${version}/flix.jar";
+            hash = "sha256-Ha5oRDpQ7YuGsaF/ZNx8b+HjTSroxZEjzI3zR3g7NXI=";
+          };
+        });
+
         mkFlixApp = name: cmd:
           pkgs.writeShellApplication {
             inherit name;
-            runtimeInputs = [ pkgs.flix ];
+            runtimeInputs = [ flix ];
             text = ''
               cd flix
               ${cmd}
@@ -85,7 +93,7 @@
 
       in {
         devShells.default = pkgs.mkShell (playwrightEnv // {
-          buildInputs = with pkgs; [ nodejs_24 pnpm rustc cargo rustfmt playwright-test flix ] ++ elmTools;
+          buildInputs = with pkgs; [ nodejs_24 pnpm rustc cargo rustfmt playwright-test ] ++ [ flix ] ++ elmTools;
         });
 
         apps = {

--- a/flix/.gitignore
+++ b/flix/.gitignore
@@ -1,0 +1,7 @@
+*.fpkg
+*.jar
+.GITHUB_TOKEN
+artifact/
+build/
+lib/
+crash_report_*.txt

--- a/flix/LICENSE.md
+++ b/flix/LICENSE.md
@@ -1,0 +1,1 @@
+Enter license information here.

--- a/flix/README.md
+++ b/flix/README.md
@@ -1,0 +1,4 @@
+# flix
+
+Enter some useful information.
+

--- a/flix/flix.toml
+++ b/flix/flix.toml
@@ -1,0 +1,6 @@
+[package]
+name        = "flix"
+description = "test"
+version     = "0.1.0"
+flix        = "0.65.0"
+authors     = ["John Doe <john@example.com>"]

--- a/flix/flix.toml
+++ b/flix/flix.toml
@@ -2,5 +2,5 @@
 name        = "flix"
 description = "test"
 version     = "0.1.0"
-flix        = "0.65.0"
+flix        = "0.71.0"
 authors     = ["John Doe <john@example.com>"]

--- a/flix/src/Args.flix
+++ b/flix/src/Args.flix
@@ -9,7 +9,7 @@ mod Args {
 
     pub type alias ParsedArgs = {
         inputPath = String,
-        outputPath = String
+        outputFile = Option[String]
     }
 
     enum ParseState {
@@ -41,20 +41,12 @@ mod Args {
 
     def resolve(state: ParseState): Result[ArgsError, ParsedArgs] =
         match state {
-            case ParseState.Ready(Some(input), Some(output)) =>
-                Ok({ inputPath = input, outputPath = output })
-            case ParseState.Ready(Some(input), None) =>
-                Ok({ inputPath = input, outputPath = defaultOutputPath(input) })
+            case ParseState.Ready(Some(input), output) =>
+                Ok({ inputPath = input, outputFile = output })
             case ParseState.Ready(None, _) =>
                 Err(ArgsError.MissingInputPath)
             case ParseState.ExpectingOutputValue(_) =>
                 Err(ArgsError.MissingOutputValue)
         }
-
-    def defaultOutputPath(inputPath: String): String =
-        if (String.endsWith({suffix = ".csv"}, inputPath))
-            String.dropRight(4, inputPath) + ".json"
-        else
-            inputPath + ".json"
 
 }

--- a/flix/src/Args.flix
+++ b/flix/src/Args.flix
@@ -1,0 +1,60 @@
+mod Args {
+
+    pub enum ArgsError with ToString {
+        case MissingInputPath
+        case MissingOutputValue
+        case DuplicateOutput
+        case UnexpectedArgument(String)
+    }
+
+    pub type alias ParsedArgs = {
+        inputPath = String,
+        outputPath = String
+    }
+
+    enum ParseState {
+        case Ready(Option[String], Option[String])
+        case ExpectingOutputValue(Option[String])
+    }
+
+    pub def parse(args: List[String]): Result[ArgsError, ParsedArgs] =
+        let finalState = List.foldLeft((acc, arg) ->
+            Result.flatMap(st -> step(st, arg), acc),
+            Ok(ParseState.Ready(None, None)),
+            args
+        );
+        finalState |> Result.flatMap(resolve)
+
+    def step(state: ParseState, arg: String): Result[ArgsError, ParseState] =
+        match state {
+            case ParseState.ExpectingOutputValue(input) =>
+                Ok(ParseState.Ready(input, Some(arg)))
+            case ParseState.Ready(input, None) if arg == "--output" =>
+                Ok(ParseState.ExpectingOutputValue(input))
+            case ParseState.Ready(_, Some(_)) if arg == "--output" =>
+                Err(ArgsError.DuplicateOutput)
+            case ParseState.Ready(None, output) =>
+                Ok(ParseState.Ready(Some(arg), output))
+            case ParseState.Ready(Some(_), _) =>
+                Err(ArgsError.UnexpectedArgument(arg))
+        }
+
+    def resolve(state: ParseState): Result[ArgsError, ParsedArgs] =
+        match state {
+            case ParseState.Ready(Some(input), Some(output)) =>
+                Ok({ inputPath = input, outputPath = output })
+            case ParseState.Ready(Some(input), None) =>
+                Ok({ inputPath = input, outputPath = defaultOutputPath(input) })
+            case ParseState.Ready(None, _) =>
+                Err(ArgsError.MissingInputPath)
+            case ParseState.ExpectingOutputValue(_) =>
+                Err(ArgsError.MissingOutputValue)
+        }
+
+    def defaultOutputPath(inputPath: String): String =
+        if (String.endsWith({suffix = ".csv"}, inputPath))
+            String.dropRight(4, inputPath) + ".json"
+        else
+            inputPath + ".json"
+
+}

--- a/flix/src/Cli.flix
+++ b/flix/src/Cli.flix
@@ -1,0 +1,14 @@
+mod Cli {
+
+    pub enum CliError with ToString {
+        case PathNotFound(String)
+        case PathAccessError(String)
+        case ListDirError(String)
+        case NoCsvFiles(String)
+        case OutputWithDirectory
+        case ReadFile(String, String)
+        case EmptyFile(String)
+        case WriteFile(String, String)
+    }
+
+}

--- a/flix/src/Cli.flix
+++ b/flix/src/Cli.flix
@@ -13,9 +13,6 @@ mod Cli {
         case WriteFile(String, String)
     }
 
-    pub def eprintln(msg: String): Unit \ IO =
-        System.err.println(msg)
-
     /// JVM を即時終了。`def main(): Int32` で値を返しても stdout に印字
     /// されるだけで OS exit code にならないため、明示的に呼ぶ必要がある。
     pub def exit(code: Int32): Unit \ IO =

--- a/flix/src/Cli.flix
+++ b/flix/src/Cli.flix
@@ -1,5 +1,7 @@
 mod Cli {
 
+    import java.lang.System
+
     pub enum CliError with ToString {
         case PathNotFound(String)
         case PathAccessError(String)
@@ -10,5 +12,13 @@ mod Cli {
         case EmptyFile(String)
         case WriteFile(String, String)
     }
+
+    pub def eprintln(msg: String): Unit \ IO =
+        System.err.println(msg)
+
+    /// JVM を即時終了。`def main(): Int32` で値を返しても stdout に印字
+    /// されるだけで OS exit code にならないため、明示的に呼ぶ必要がある。
+    pub def exit(code: Int32): Unit \ IO =
+        System.exit(code)
 
 }

--- a/flix/src/Csv.flix
+++ b/flix/src/Csv.flix
@@ -1,16 +1,6 @@
 mod Csv {
 
-    pub type alias LapRecord = {
-        carNumber = String,
-        driverName = String,
-        lapNumber = String,
-        lapTime = String,
-        kph = String,
-        class = String,
-        team = String
-    }
-
-    pub def parseLine(line: String): Option[LapRecord] =
+    pub def parseLine(line: String): Option[Lap.LapRecord] =
         let fields = String.split({regex = ";"}, line);
         let len = List.length(fields);
         if (len >= 25)
@@ -34,19 +24,7 @@ mod Csv {
         else
             None
 
-    pub def parseLines(lines: List[String]): List[LapRecord] =
+    pub def parseLines(lines: List[String]): List[Lap.LapRecord] =
         lines |> List.filterMap(parseLine)
-
-    pub def formatTable(records: List[LapRecord]): String =
-        let header = formatRow("Car", "Driver", "Lap", "Time", "KPH", "Class", "Team");
-        let separator = String.repeat(100, "-");
-        let rows = records |> List.map(r ->
-            formatRow(r#carNumber, r#driverName, r#lapNumber, r#lapTime, r#kph, r#class, r#team)
-        );
-        List.join("\n", header :: separator :: rows)
-
-    def formatRow(car: String, driver: String, lap: String, time: String, kph: String, cls: String, team: String): String =
-        let pad = s -> String.padRight(5, ' ', s);
-        "${pad(car)} ${String.padRight(20, ' ', driver)} ${pad(lap)} ${String.padRight(12, ' ', time)} ${pad(kph)} ${String.padRight(12, ' ', cls)} ${team}"
 
 }

--- a/flix/src/Csv.flix
+++ b/flix/src/Csv.flix
@@ -1,0 +1,52 @@
+mod Csv {
+
+    pub type alias LapRecord = {
+        carNumber = String,
+        driverName = String,
+        lapNumber = String,
+        lapTime = String,
+        kph = String,
+        class = String,
+        team = String
+    }
+
+    pub def parseLine(line: String): Option[LapRecord] =
+        let fields = String.split({regex = ";"}, line);
+        let len = List.length(fields);
+        if (len >= 25)
+            forM(
+                carNumber   <- List.nth(0, fields);
+                driverName  <- List.nth(19, fields);
+                lapNumber   <- List.nth(2, fields);
+                lapTime     <- List.nth(3, fields);
+                kph         <- List.nth(12, fields);
+                class       <- List.nth(21, fields);
+                team        <- List.nth(23, fields)
+            ) yield {
+                carNumber   = carNumber,
+                driverName  = driverName,
+                lapNumber   = lapNumber,
+                lapTime     = lapTime,
+                kph         = kph,
+                class       = class,
+                team        = team
+            }
+        else
+            None
+
+    pub def parseLines(lines: List[String]): List[LapRecord] =
+        lines |> List.filterMap(parseLine)
+
+    pub def formatTable(records: List[LapRecord]): String =
+        let header = formatRow("Car", "Driver", "Lap", "Time", "KPH", "Class", "Team");
+        let separator = String.repeat(100, "-");
+        let rows = records |> List.map(r ->
+            formatRow(r#carNumber, r#driverName, r#lapNumber, r#lapTime, r#kph, r#class, r#team)
+        );
+        List.join("\n", header :: separator :: rows)
+
+    def formatRow(car: String, driver: String, lap: String, time: String, kph: String, cls: String, team: String): String =
+        let pad = s -> String.padRight(5, ' ', s);
+        "${pad(car)} ${String.padRight(20, ' ', driver)} ${pad(lap)} ${String.padRight(12, ' ', time)} ${pad(kph)} ${String.padRight(12, ' ', cls)} ${team}"
+
+}

--- a/flix/src/Csv.flix
+++ b/flix/src/Csv.flix
@@ -1,30 +1,11 @@
 mod Csv {
 
-    pub def parseLine(line: String): Option[Lap.LapRecord] =
-        let fields = String.split({regex = ";"}, line);
-        let len = List.length(fields);
-        if (len >= 25)
-            forM(
-                carNumber   <- List.nth(0, fields);
-                driverName  <- List.nth(19, fields);
-                lapNumber   <- List.nth(2, fields);
-                lapTime     <- List.nth(3, fields);
-                kph         <- List.nth(12, fields);
-                class       <- List.nth(21, fields);
-                team        <- List.nth(23, fields)
-            ) yield {
-                carNumber   = carNumber,
-                driverName  = driverName,
-                lapNumber   = lapNumber,
-                lapTime     = lapTime,
-                kph         = kph,
-                class       = class,
-                team        = team
-            }
-        else
-            None
+    pub type alias CsvRow = List[String]
 
-    pub def parseLines(lines: List[String]): List[Lap.LapRecord] =
-        lines |> List.filterMap(parseLine)
+    pub def parseRow(line: String): CsvRow =
+        String.split({regex = ";"}, line)
+
+    pub def parse(lines: List[String]): List[CsvRow] =
+        lines |> List.map(parseRow)
 
 }

--- a/flix/src/FileTask.flix
+++ b/flix/src/FileTask.flix
@@ -23,11 +23,9 @@ mod FileTask {
         let path = parsed#inputPath;
         let outputOverride = parsed#outputFile;
         forM(
-            exists <- Fs.FileStat.runWithIO(() -> Fs.FileStat.exists(path))
-                        |> Result.mapErr(e -> CliError.PathAccessError("${e}"));
+            exists <- Files.exists(path);
             _      <- if (exists) Ok(()) else Err(CliError.PathNotFound(path));
-            isDir  <- Fs.FileStat.runWithIO(() -> Fs.FileStat.isDirectory(path))
-                        |> Result.mapErr(e -> CliError.PathAccessError("${e}"));
+            isDir  <- Files.isDirectory(path);
             tasks  <- if (isDir) resolveDir(path, outputOverride)
                       else Ok(make(path, outputOverride) :: Nil)
         ) yield tasks
@@ -36,18 +34,16 @@ mod FileTask {
         match outputOverride {
             case Some(_) => Err(CliError.OutputWithDirectory)
             case None    =>
-                let listResult = Fs.DirList.runWithIO(() -> Fs.DirList.list(dirPath));
-                match listResult {
-                    case Err(e) => Err(CliError.ListDirError("${e}"))
-                    case Ok(entries) =>
-                        let csvFiles = entries
-                            |> List.filter(e -> String.endsWith({suffix = ".csv"}, e))
-                            |> List.map(e -> make("${dirPath}/${e}", None));
-                        if (List.isEmpty(csvFiles))
-                            Err(CliError.NoCsvFiles(dirPath))
-                        else
-                            Ok(csvFiles)
-                }
+                forM(
+                    entries <- Files.listDir(dirPath);
+                    csvFiles <- Ok(entries
+                                    |> List.filter(e -> String.endsWith({suffix = ".csv"}, e))
+                                    |> List.map(e -> make("${dirPath}/${e}", None)));
+                    result   <- if (List.isEmpty(csvFiles))
+                                    Err(CliError.NoCsvFiles(dirPath))
+                                else
+                                    Ok(csvFiles)
+                ) yield result
         }
 
     def defaultOutputPath(inputPath: String): String =

--- a/flix/src/FileTask.flix
+++ b/flix/src/FileTask.flix
@@ -1,0 +1,69 @@
+mod FileTask {
+
+    pub type alias FileTask = {
+        inputPath = String,
+        outputPath = String,
+        eventName = String
+    }
+
+    pub def make(inputPath: String, outputOverride: Option[String]): FileTask =
+        let outputPath = match outputOverride {
+            case Some(p) => p
+            case None    => defaultOutputPath(inputPath)
+        };
+        {
+            inputPath   = inputPath,
+            outputPath  = outputPath,
+            eventName   = eventName(inputPath)
+        }
+
+    pub def resolve(parsed: Args.ParsedArgs): Result[String, List[FileTask]] \ IO =
+        let path = parsed#inputPath;
+        let outputOverride = parsed#outputFile;
+        let existsResult = Fs.FileStat.runWithIO(() -> Fs.FileStat.exists(path));
+        match existsResult {
+            case Ok(false) => Err("Input path not found: ${path}")
+            case Err(e)    => Err("Cannot access path: ${e}")
+            case Ok(true)  =>
+                let isDirResult = Fs.FileStat.runWithIO(() -> Fs.FileStat.isDirectory(path));
+                match isDirResult {
+                    case Ok(true)  => resolveDir(path, outputOverride)
+                    case Ok(false) => Ok(make(path, outputOverride) :: Nil)
+                    case Err(e)    => Err("Cannot check path type: ${e}")
+                }
+        }
+
+    def resolveDir(dirPath: String, outputOverride: Option[String]): Result[String, List[FileTask]] \ IO =
+        match outputOverride {
+            case Some(_) => Err("--output cannot be used with a directory input")
+            case None    =>
+                let listResult = Fs.DirList.runWithIO(() -> Fs.DirList.list(dirPath));
+                match listResult {
+                    case Err(e) => Err("Cannot list directory: ${e}")
+                    case Ok(entries) =>
+                        let csvFiles = entries
+                            |> List.filter(e -> String.endsWith({suffix = ".csv"}, e))
+                            |> List.map(e -> make("${dirPath}/${e}", None));
+                        if (List.isEmpty(csvFiles))
+                            Err("No CSV files found in: ${dirPath}")
+                        else
+                            Ok(csvFiles)
+                }
+        }
+
+    def defaultOutputPath(inputPath: String): String =
+        if (String.endsWith({suffix = ".csv"}, inputPath))
+            String.dropRight(4, inputPath) + ".json"
+        else
+            inputPath + ".json"
+
+    def eventName(inputPath: String): String =
+        let parts = String.split({regex = "/"}, inputPath);
+        let fileName = parts |> List.last |> Option.getWithDefault(inputPath);
+        let segments = String.split({regex = "\\."}, fileName);
+        match segments {
+            case _ :: _ :: _ => segments |> List.reverse |> List.drop(1) |> List.reverse |> List.join(".")
+            case _           => fileName
+        }
+
+}

--- a/flix/src/FileTask.flix
+++ b/flix/src/FileTask.flix
@@ -1,5 +1,7 @@
 mod FileTask {
 
+    use Cli.CliError
+
     pub type alias FileTask = {
         inputPath = String,
         outputPath = String,
@@ -17,32 +19,32 @@ mod FileTask {
             eventName   = eventName(inputPath)
         }
 
-    pub def resolve(parsed: Args.ParsedArgs): Result[String, List[FileTask]] \ IO =
+    pub def resolve(parsed: Args.ParsedArgs): Result[CliError, List[FileTask]] \ IO =
         let path = parsed#inputPath;
         let outputOverride = parsed#outputFile;
         forM(
             exists <- Fs.FileStat.runWithIO(() -> Fs.FileStat.exists(path))
-                        |> Result.mapErr(e -> "Cannot access path: ${e}");
-            _      <- if (exists) Ok(()) else Err("Input path not found: ${path}");
+                        |> Result.mapErr(e -> CliError.PathAccessError("${e}"));
+            _      <- if (exists) Ok(()) else Err(CliError.PathNotFound(path));
             isDir  <- Fs.FileStat.runWithIO(() -> Fs.FileStat.isDirectory(path))
-                        |> Result.mapErr(e -> "Cannot check path type: ${e}");
+                        |> Result.mapErr(e -> CliError.PathAccessError("${e}"));
             tasks  <- if (isDir) resolveDir(path, outputOverride)
                       else Ok(make(path, outputOverride) :: Nil)
         ) yield tasks
 
-    def resolveDir(dirPath: String, outputOverride: Option[String]): Result[String, List[FileTask]] \ IO =
+    def resolveDir(dirPath: String, outputOverride: Option[String]): Result[CliError, List[FileTask]] \ IO =
         match outputOverride {
-            case Some(_) => Err("--output cannot be used with a directory input")
+            case Some(_) => Err(CliError.OutputWithDirectory)
             case None    =>
                 let listResult = Fs.DirList.runWithIO(() -> Fs.DirList.list(dirPath));
                 match listResult {
-                    case Err(e) => Err("Cannot list directory: ${e}")
+                    case Err(e) => Err(CliError.ListDirError("${e}"))
                     case Ok(entries) =>
                         let csvFiles = entries
                             |> List.filter(e -> String.endsWith({suffix = ".csv"}, e))
                             |> List.map(e -> make("${dirPath}/${e}", None));
                         if (List.isEmpty(csvFiles))
-                            Err("No CSV files found in: ${dirPath}")
+                            Err(CliError.NoCsvFiles(dirPath))
                         else
                             Ok(csvFiles)
                 }

--- a/flix/src/FileTask.flix
+++ b/flix/src/FileTask.flix
@@ -20,18 +20,15 @@ mod FileTask {
     pub def resolve(parsed: Args.ParsedArgs): Result[String, List[FileTask]] \ IO =
         let path = parsed#inputPath;
         let outputOverride = parsed#outputFile;
-        let existsResult = Fs.FileStat.runWithIO(() -> Fs.FileStat.exists(path));
-        match existsResult {
-            case Ok(false) => Err("Input path not found: ${path}")
-            case Err(e)    => Err("Cannot access path: ${e}")
-            case Ok(true)  =>
-                let isDirResult = Fs.FileStat.runWithIO(() -> Fs.FileStat.isDirectory(path));
-                match isDirResult {
-                    case Ok(true)  => resolveDir(path, outputOverride)
-                    case Ok(false) => Ok(make(path, outputOverride) :: Nil)
-                    case Err(e)    => Err("Cannot check path type: ${e}")
-                }
-        }
+        forM(
+            exists <- Fs.FileStat.runWithIO(() -> Fs.FileStat.exists(path))
+                        |> Result.mapErr(e -> "Cannot access path: ${e}");
+            _      <- if (exists) Ok(()) else Err("Input path not found: ${path}");
+            isDir  <- Fs.FileStat.runWithIO(() -> Fs.FileStat.isDirectory(path))
+                        |> Result.mapErr(e -> "Cannot check path type: ${e}");
+            tasks  <- if (isDir) resolveDir(path, outputOverride)
+                      else Ok(make(path, outputOverride) :: Nil)
+        ) yield tasks
 
     def resolveDir(dirPath: String, outputOverride: Option[String]): Result[String, List[FileTask]] \ IO =
         match outputOverride {

--- a/flix/src/FileTask.flix
+++ b/flix/src/FileTask.flix
@@ -35,10 +35,8 @@ mod FileTask {
             case Some(_) => Err(CliError.OutputWithDirectory)
             case None    =>
                 forM(
-                    entries <- Files.listDir(dirPath);
-                    csvFiles <- Ok(entries
-                                    |> List.filter(e -> String.endsWith({suffix = ".csv"}, e))
-                                    |> List.map(e -> make("${dirPath}/${e}", None)));
+                    csvPaths <- Files.walkCsvFiles(dirPath);
+                    csvFiles <- Ok(csvPaths |> List.map(p -> make(p, None)));
                     result   <- if (List.isEmpty(csvFiles))
                                     Err(CliError.NoCsvFiles(dirPath))
                                 else

--- a/flix/src/Files.flix
+++ b/flix/src/Files.flix
@@ -1,0 +1,31 @@
+mod Files {
+
+    use Cli.CliError
+
+    pub def readLines(path: String): Result[CliError, List[String]] \ IO =
+        Fs.FileRead.runWithIO(() ->
+            Fs.ReadLines.runWithFileRead(() ->
+                Fs.ReadLines.readLines(path)
+            )
+        ) |> Result.mapErr(e -> CliError.ReadFile(path, "${e}"))
+
+    pub def writeFile(path: String, content: String): Result[CliError, Unit] \ IO =
+        Fs.FileWrite.runWithIO(() ->
+            Fs.WriteFile.runWithFileWrite(() ->
+                Fs.WriteFile.write({str = content}, path)
+            )
+        ) |> Result.mapErr(e -> CliError.WriteFile(path, "${e}"))
+
+    pub def exists(path: String): Result[CliError, Bool] \ IO =
+        Fs.FileStat.runWithIO(() -> Fs.FileStat.exists(path))
+            |> Result.mapErr(e -> CliError.PathAccessError("${e}"))
+
+    pub def isDirectory(path: String): Result[CliError, Bool] \ IO =
+        Fs.FileStat.runWithIO(() -> Fs.FileStat.isDirectory(path))
+            |> Result.mapErr(e -> CliError.PathAccessError("${e}"))
+
+    pub def listDir(path: String): Result[CliError, List[String]] \ IO =
+        Fs.DirList.runWithIO(() -> Fs.DirList.list(path))
+            |> Result.mapErr(e -> CliError.ListDirError("${e}"))
+
+}

--- a/flix/src/Files.flix
+++ b/flix/src/Files.flix
@@ -28,4 +28,26 @@ mod Files {
         Fs.DirList.runWithIO(() -> Fs.DirList.list(path))
             |> Result.mapErr(e -> CliError.ListDirError("${e}"))
 
+    /// 指定ディレクトリ配下を再帰的に走査し、`.csv` で終わるファイルパスを
+    /// すべて返す。サブディレクトリには深さ制限なしで降りる。
+    pub def walkCsvFiles(dirPath: String): Result[CliError, List[String]] \ IO =
+        forM(
+            entries <- listDir(dirPath);
+            result  <- gatherCsvs(dirPath, entries)
+        ) yield result
+
+    def gatherCsvs(dirPath: String, entries: List[String]): Result[CliError, List[String]] \ IO =
+        match entries {
+            case Nil => Ok(Nil)
+            case e :: rest =>
+                let fullPath = "${dirPath}/${e}";
+                forM(
+                    isDir <- isDirectory(fullPath);
+                    head  <- if (isDir) walkCsvFiles(fullPath)
+                             else if (String.endsWith({suffix = ".csv"}, fullPath)) Ok(fullPath :: Nil)
+                             else Ok(Nil);
+                    tail  <- gatherCsvs(dirPath, rest)
+                ) yield List.append(head, tail)
+        }
+
 }

--- a/flix/src/Json.flix
+++ b/flix/src/Json.flix
@@ -1,0 +1,48 @@
+mod Json {
+
+    pub enum JsonValue with ToString {
+        case JsonNull
+        case JsonBool(Bool)
+        case JsonInt(Int32)
+        case JsonFloat(Float64)
+        case JsonString(String)
+        case JsonArray(List[JsonValue])
+        case JsonObject(List[(String, JsonValue)])
+    }
+
+    pub def render(value: JsonValue): String =
+        renderWithIndent(0, value)
+
+    def renderWithIndent(indent: Int32, value: JsonValue): String =
+        let spaces = String.repeat(indent, " ");
+        let inner = String.repeat(indent + 2, " ");
+        match value {
+            case JsonValue.JsonNull       => "null"
+            case JsonValue.JsonBool(b)    => if (b) "true" else "false"
+            case JsonValue.JsonInt(n)     => "${n}"
+            case JsonValue.JsonFloat(n)   => "${n}"
+            case JsonValue.JsonString(s)  => "\"${escapeString(s)}\""
+            case JsonValue.JsonArray(xs)  =>
+                if (List.isEmpty(xs))
+                    "[]"
+                else
+                    let items = xs |> List.map(x -> "${inner}${renderWithIndent(indent + 2, x)}");
+                    "[\n${List.join(",\n", items)}\n${spaces}]"
+            case JsonValue.JsonObject(kvs) =>
+                if (List.isEmpty(kvs))
+                    "{}"
+                else
+                    let entries = kvs |> List.map(match (k, v) ->
+                        "${inner}\"${escapeString(k)}\": ${renderWithIndent(indent + 2, v)}"
+                    );
+                    "{\n${List.join(",\n", entries)}\n${spaces}}"
+        }
+
+    def escapeString(s: String): String =
+        s |> String.replace({src = "\\"}, {dst = "\\\\"})
+          |> String.replace({src = "\""}, {dst = "\\\""})
+          |> String.replace({src = "\n"}, {dst = "\\n"})
+          |> String.replace({src = "\r"}, {dst = "\\r"})
+          |> String.replace({src = "\t"}, {dst = "\\t"})
+
+}

--- a/flix/src/Lap.flix
+++ b/flix/src/Lap.flix
@@ -1,0 +1,28 @@
+mod Lap {
+
+    pub type alias LapRecord = {
+        carNumber = String,
+        driverName = String,
+        lapNumber = String,
+        lapTime = String,
+        kph = String,
+        class = String,
+        team = String
+    }
+
+    pub def toJson(record: LapRecord): Json.JsonValue =
+        Json.JsonValue.JsonObject(
+            ("carNumber",  Json.JsonValue.JsonString(record#carNumber)) ::
+            ("driverName", Json.JsonValue.JsonString(record#driverName)) ::
+            ("lapNumber",  Json.JsonValue.JsonString(record#lapNumber)) ::
+            ("lapTime",    Json.JsonValue.JsonString(record#lapTime)) ::
+            ("kph",        Json.JsonValue.JsonString(record#kph)) ::
+            ("class",      Json.JsonValue.JsonString(record#class)) ::
+            ("team",       Json.JsonValue.JsonString(record#team)) ::
+            Nil
+        )
+
+    pub def toJsonArray(records: List[LapRecord]): Json.JsonValue =
+        Json.JsonValue.JsonArray(List.map(toJson, records))
+
+}

--- a/flix/src/Lap.flix
+++ b/flix/src/Lap.flix
@@ -12,6 +12,31 @@ mod Lap {
         team = String
     }
 
+    pub def fromCsvRow(row: Csv.CsvRow): Option[LapRecord] =
+        if (List.length(row) >= 25)
+            forM(
+                carNumber   <- List.nth(0, row);
+                driverName  <- List.nth(19, row);
+                lapNumber   <- List.nth(2, row);
+                lapTime     <- List.nth(3, row);
+                kph         <- List.nth(12, row);
+                class       <- List.nth(21, row);
+                team        <- List.nth(23, row)
+            ) yield {
+                carNumber   = carNumber,
+                driverName  = driverName,
+                lapNumber   = lapNumber,
+                lapTime     = lapTime,
+                kph         = kph,
+                class       = class,
+                team        = team
+            }
+        else
+            None
+
+    pub def fromCsvRows(rows: List[Csv.CsvRow]): List[LapRecord] =
+        rows |> List.filterMap(fromCsvRow)
+
     pub def toJson(record: LapRecord): Json.JsonValue =
         JsonObject(
             ("carNumber",  JsonString(record#carNumber)) ::

--- a/flix/src/Lap.flix
+++ b/flix/src/Lap.flix
@@ -1,5 +1,7 @@
 mod Lap {
 
+    use Json.JsonValue.{JsonObject, JsonString, JsonArray}
+
     pub type alias LapRecord = {
         carNumber = String,
         driverName = String,
@@ -11,18 +13,18 @@ mod Lap {
     }
 
     pub def toJson(record: LapRecord): Json.JsonValue =
-        Json.JsonValue.JsonObject(
-            ("carNumber",  Json.JsonValue.JsonString(record#carNumber)) ::
-            ("driverName", Json.JsonValue.JsonString(record#driverName)) ::
-            ("lapNumber",  Json.JsonValue.JsonString(record#lapNumber)) ::
-            ("lapTime",    Json.JsonValue.JsonString(record#lapTime)) ::
-            ("kph",        Json.JsonValue.JsonString(record#kph)) ::
-            ("class",      Json.JsonValue.JsonString(record#class)) ::
-            ("team",       Json.JsonValue.JsonString(record#team)) ::
+        JsonObject(
+            ("carNumber",  JsonString(record#carNumber)) ::
+            ("driverName", JsonString(record#driverName)) ::
+            ("lapNumber",  JsonString(record#lapNumber)) ::
+            ("lapTime",    JsonString(record#lapTime)) ::
+            ("kph",        JsonString(record#kph)) ::
+            ("class",      JsonString(record#class)) ::
+            ("team",       JsonString(record#team)) ::
             Nil
         )
 
     pub def toJsonArray(records: List[LapRecord]): Json.JsonValue =
-        Json.JsonValue.JsonArray(List.map(toJson, records))
+        JsonArray(List.map(toJson, records))
 
 }

--- a/flix/src/Log.flix
+++ b/flix/src/Log.flix
@@ -1,0 +1,11 @@
+mod Log {
+
+    import java.lang.System
+
+    pub def info(msg: String): Unit \ IO =
+        println(msg)
+
+    pub def error(msg: String): Unit \ IO =
+        System.err.println(msg)
+
+}

--- a/flix/src/Main.flix
+++ b/flix/src/Main.flix
@@ -1,0 +1,3 @@
+// The main entry point.
+def main(): Unit \ IO =
+    println("Hello World!")

--- a/flix/src/Main.flix
+++ b/flix/src/Main.flix
@@ -10,7 +10,8 @@ def main(): Unit \ IO =
             match lines {
                 case _header :: dataLines =>
                     let records = Csv.parseLines(dataLines);
-                    println(Csv.formatTable(records))
+                    let json = Lap.toJsonArray(records);
+                    println(Json.render(json))
                 case Nil =>
                     println("Empty file")
             }

--- a/flix/src/Main.flix
+++ b/flix/src/Main.flix
@@ -49,20 +49,13 @@ def processFile(task: FileTask.FileTask): Result[CliError, ProcessingReport] \ I
     let inputPath = task#inputPath;
     let outputPath = task#outputPath;
     forM(
-        lines     <- Fs.FileRead.runWithIO(() ->
-                        Fs.ReadLines.runWithFileRead(() ->
-                            Fs.ReadLines.readLines(inputPath)
-                     )) |> Result.mapErr(e -> CliError.ReadFile(inputPath, "${e}"));
+        lines     <- Files.readLines(inputPath);
         dataLines <- match lines {
                         case _ :: rest => Ok(rest)
                         case Nil       => Err(CliError.EmptyFile(inputPath))
                      };
         processed <- Ok(Pipeline.process(dataLines));
-        _         <- Fs.FileWrite.runWithIO(() ->
-                        Fs.WriteFile.runWithFileWrite(() ->
-                            Fs.WriteFile.write({str = processed#json}, outputPath)
-                        )
-                     ) |> Result.mapErr(e -> CliError.WriteFile(outputPath, "${e}"))
+        _         <- Files.writeFile(outputPath, processed#json)
     ) yield {
         lapCount   = processed#lapCount,
         outputPath = outputPath

--- a/flix/src/Main.flix
+++ b/flix/src/Main.flix
@@ -6,6 +6,11 @@ pub type alias ProcessingReport = {
     outputPath = String
 }
 
+pub type alias RunSummary = {
+    processed = Int32,
+    errors = Int32
+}
+
 def main(): Unit \ {Env, IO} =
     let args = Env.getArgs();
     match Args.parse(args) {
@@ -17,17 +22,24 @@ def main(): Unit \ {Env, IO} =
                 case Err(e) =>
                     println("Error: ${e}")
                 case Ok(tasks) =>
-                    List.forEach(convert, tasks)
+                    let summary = runTasks(tasks);
+                    println("Processing completed: ${summary#processed} processed, ${summary#errors} errors")
             }
     }
 
-def convert(task: FileTask.FileTask): Unit \ IO =
-    match processFile(task) {
-        case Ok(report) =>
-            println("${task#eventName}: Wrote ${report#lapCount} laps to ${report#outputPath}")
-        case Err(e) =>
-            println("${task#eventName}: ${e}")
-    }
+def runTasks(tasks: List[FileTask.FileTask]): RunSummary \ IO =
+    List.foldLeft(
+        (summary, task) -> match processFile(task) {
+            case Ok(report) =>
+                println("${task#eventName}: Wrote ${report#lapCount} laps to ${report#outputPath}");
+                { processed = summary#processed + 1, errors = summary#errors }
+            case Err(e) =>
+                println("${task#eventName}: ${e}");
+                { processed = summary#processed, errors = summary#errors + 1 }
+        },
+        { processed = 0, errors = 0 },
+        tasks
+    )
 
 def processFile(task: FileTask.FileTask): Result[CliError, ProcessingReport] \ IO =
     let inputPath = task#inputPath;

--- a/flix/src/Main.flix
+++ b/flix/src/Main.flix
@@ -1,6 +1,10 @@
 def main(): Unit \ IO =
     let path = "../cli/test_data.csv";
-    let result = FileRead.runWithIO(() -> checked_ecast(FileRead.readLines(path)));
+    let result = Fs.FileRead.runWithIO(() ->
+        Fs.ReadLines.runWithFileRead(() ->
+            Fs.ReadLines.readLines(path)
+        )
+    );
     match result {
         case Ok(lines) =>
             let count = List.length(lines);

--- a/flix/src/Main.flix
+++ b/flix/src/Main.flix
@@ -16,29 +16,23 @@ def main(): Unit \ {Env, IO} =
     }
 
 def convert(task: FileTask.FileTask): Unit \ IO =
-    let readResult = Fs.FileRead.runWithIO(() ->
-        Fs.ReadLines.runWithFileRead(() ->
-            Fs.ReadLines.readLines(task#inputPath)
-        )
-    );
-    match readResult {
-        case Ok(lines) =>
-            match lines {
-                case _header :: dataLines =>
-                    let records = Csv.parseLines(dataLines);
-                    let json = Json.render(Lap.toJsonArray(records));
-                    let writeResult = Fs.FileWrite.runWithIO(() ->
+    let result = forM(
+        lines     <- Fs.FileRead.runWithIO(() ->
+                        Fs.ReadLines.runWithFileRead(() ->
+                            Fs.ReadLines.readLines(task#inputPath)
+                     )) |> Result.mapErr(e -> "Read error: ${e}");
+        dataLines <- match lines {
+                        case _ :: rest => Ok(rest)
+                        case Nil       => Err("Empty file")
+                     };
+        _         <- Fs.FileWrite.runWithIO(() ->
+                        let json = Json.render(Lap.toJsonArray(Csv.parseLines(dataLines)));
                         Fs.WriteFile.runWithFileWrite(() ->
                             Fs.WriteFile.write({str = json}, task#outputPath)
                         )
-                    );
-                    match writeResult {
-                        case Ok(_)  => println("${task#eventName}: Written to ${task#outputPath}")
-                        case Err(e) => println("${task#eventName}: Write error: ${e}")
-                    }
-                case Nil =>
-                    println("${task#eventName}: Empty file")
-            }
-        case Err(e) =>
-            println("${task#eventName}: Read error: ${e}")
+                     ) |> Result.mapErr(e -> "Write error: ${e}")
+    ) yield ();
+    match result {
+        case Ok(_)  => println("${task#eventName}: Written to ${task#outputPath}")
+        case Err(e) => println("${task#eventName}: ${e}")
     }

--- a/flix/src/Main.flix
+++ b/flix/src/Main.flix
@@ -5,15 +5,20 @@ def main(): Unit \ {Env, IO} =
     match Args.parse(args) {
         case Err(e) =>
             println("Error: ${e}");
-            println("Usage: flix-run <input.csv> [--output <output.json>]")
+            println("Usage: flix-run <input.csv|dir> [--output <output.json>]")
         case Ok(parsed) =>
-            convert(parsed#inputPath, parsed#outputPath)
+            match FileTask.resolve(parsed) {
+                case Err(e) =>
+                    println("Error: ${e}")
+                case Ok(tasks) =>
+                    List.forEach(convert, tasks)
+            }
     }
 
-def convert(inputPath: String, outputPath: String): Unit \ IO =
+def convert(task: FileTask.FileTask): Unit \ IO =
     let readResult = Fs.FileRead.runWithIO(() ->
         Fs.ReadLines.runWithFileRead(() ->
-            Fs.ReadLines.readLines(inputPath)
+            Fs.ReadLines.readLines(task#inputPath)
         )
     );
     match readResult {
@@ -24,16 +29,16 @@ def convert(inputPath: String, outputPath: String): Unit \ IO =
                     let json = Json.render(Lap.toJsonArray(records));
                     let writeResult = Fs.FileWrite.runWithIO(() ->
                         Fs.WriteFile.runWithFileWrite(() ->
-                            Fs.WriteFile.write({str = json}, outputPath)
+                            Fs.WriteFile.write({str = json}, task#outputPath)
                         )
                     );
                     match writeResult {
-                        case Ok(_)  => println("Written to ${outputPath}")
-                        case Err(e) => println("Write error: ${e}")
+                        case Ok(_)  => println("${task#eventName}: Written to ${task#outputPath}")
+                        case Err(e) => println("${task#eventName}: Write error: ${e}")
                     }
                 case Nil =>
-                    println("Empty file")
+                    println("${task#eventName}: Empty file")
             }
         case Err(e) =>
-            println("Read error: ${e}")
+            println("${task#eventName}: Read error: ${e}")
     }

--- a/flix/src/Main.flix
+++ b/flix/src/Main.flix
@@ -25,8 +25,8 @@ def convert(task: FileTask.FileTask): Unit \ IO =
                         case _ :: rest => Ok(rest)
                         case Nil       => Err("Empty file")
                      };
+        json      <- Ok(Pipeline.process(dataLines));
         _         <- Fs.FileWrite.runWithIO(() ->
-                        let json = Json.render(Lap.toJsonArray(Csv.parseLines(dataLines)));
                         Fs.WriteFile.runWithFileWrite(() ->
                             Fs.WriteFile.write({str = json}, task#outputPath)
                         )

--- a/flix/src/Main.flix
+++ b/flix/src/Main.flix
@@ -1,20 +1,29 @@
 def main(): Unit \ IO =
-    let path = "../cli/test_data.csv";
-    let result = Fs.FileRead.runWithIO(() ->
+    let inputPath = "../cli/test_data.csv";
+    let outputPath = "../cli/test_data.json";
+    let readResult = Fs.FileRead.runWithIO(() ->
         Fs.ReadLines.runWithFileRead(() ->
-            Fs.ReadLines.readLines(path)
+            Fs.ReadLines.readLines(inputPath)
         )
     );
-    match result {
+    match readResult {
         case Ok(lines) =>
             match lines {
                 case _header :: dataLines =>
                     let records = Csv.parseLines(dataLines);
-                    let json = Lap.toJsonArray(records);
-                    println(Json.render(json))
+                    let json = Json.render(Lap.toJsonArray(records));
+                    let writeResult = Fs.FileWrite.runWithIO(() ->
+                        Fs.WriteFile.runWithFileWrite(() ->
+                            Fs.WriteFile.write({str = json}, outputPath)
+                        )
+                    );
+                    match writeResult {
+                        case Ok(_)  => println("Written to ${outputPath}")
+                        case Err(e) => println("Write error: ${e}")
+                    }
                 case Nil =>
                     println("Empty file")
             }
         case Err(e) =>
-            println("Error: ${e}")
+            println("Read error: ${e}")
     }

--- a/flix/src/Main.flix
+++ b/flix/src/Main.flix
@@ -1,3 +1,11 @@
-// The main entry point.
 def main(): Unit \ IO =
-    println("Hello World!")
+    let path = "../cli/test_data.csv";
+    let result = FileRead.runWithIO(() -> checked_ecast(FileRead.readLines(path)));
+    match result {
+        case Ok(lines) =>
+            let count = List.length(lines);
+            println("File: ${path}");
+            println("Lines: ${count}")
+        case Err(e) =>
+            println("Error: ${e}")
+    }

--- a/flix/src/Main.flix
+++ b/flix/src/Main.flix
@@ -1,5 +1,10 @@
 use Sys.Env
 
+pub type alias ProcessingReport = {
+    lapCount = Int32,
+    outputPath = String
+}
+
 def main(): Unit \ {Env, IO} =
     let args = Env.getArgs();
     match Args.parse(args) {
@@ -16,7 +21,15 @@ def main(): Unit \ {Env, IO} =
     }
 
 def convert(task: FileTask.FileTask): Unit \ IO =
-    let result = forM(
+    match processFile(task) {
+        case Ok(report) =>
+            println("${task#eventName}: Wrote ${report#lapCount} laps to ${report#outputPath}")
+        case Err(e) =>
+            println("${task#eventName}: ${e}")
+    }
+
+def processFile(task: FileTask.FileTask): Result[String, ProcessingReport] \ IO =
+    forM(
         lines     <- Fs.FileRead.runWithIO(() ->
                         Fs.ReadLines.runWithFileRead(() ->
                             Fs.ReadLines.readLines(task#inputPath)
@@ -25,14 +38,13 @@ def convert(task: FileTask.FileTask): Unit \ IO =
                         case _ :: rest => Ok(rest)
                         case Nil       => Err("Empty file")
                      };
-        json      <- Ok(Pipeline.process(dataLines));
+        processed <- Ok(Pipeline.process(dataLines));
         _         <- Fs.FileWrite.runWithIO(() ->
                         Fs.WriteFile.runWithFileWrite(() ->
-                            Fs.WriteFile.write({str = json}, task#outputPath)
+                            Fs.WriteFile.write({str = processed#json}, task#outputPath)
                         )
                      ) |> Result.mapErr(e -> "Write error: ${e}")
-    ) yield ();
-    match result {
-        case Ok(_)  => println("${task#eventName}: Written to ${task#outputPath}")
-        case Err(e) => println("${task#eventName}: ${e}")
+    ) yield {
+        lapCount   = processed#lapCount,
+        outputPath = task#outputPath
     }

--- a/flix/src/Main.flix
+++ b/flix/src/Main.flix
@@ -7,9 +7,13 @@ def main(): Unit \ IO =
     );
     match result {
         case Ok(lines) =>
-            let count = List.length(lines);
-            println("File: ${path}");
-            println("Lines: ${count}")
+            match lines {
+                case _header :: dataLines =>
+                    let records = Csv.parseLines(dataLines);
+                    println(Csv.formatTable(records))
+                case Nil =>
+                    println("Empty file")
+            }
         case Err(e) =>
             println("Error: ${e}")
     }

--- a/flix/src/Main.flix
+++ b/flix/src/Main.flix
@@ -1,4 +1,5 @@
 use Sys.Env
+use Cli.CliError
 
 pub type alias ProcessingReport = {
     lapCount = Int32,
@@ -28,23 +29,25 @@ def convert(task: FileTask.FileTask): Unit \ IO =
             println("${task#eventName}: ${e}")
     }
 
-def processFile(task: FileTask.FileTask): Result[String, ProcessingReport] \ IO =
+def processFile(task: FileTask.FileTask): Result[CliError, ProcessingReport] \ IO =
+    let inputPath = task#inputPath;
+    let outputPath = task#outputPath;
     forM(
         lines     <- Fs.FileRead.runWithIO(() ->
                         Fs.ReadLines.runWithFileRead(() ->
-                            Fs.ReadLines.readLines(task#inputPath)
-                     )) |> Result.mapErr(e -> "Read error: ${e}");
+                            Fs.ReadLines.readLines(inputPath)
+                     )) |> Result.mapErr(e -> CliError.ReadFile(inputPath, "${e}"));
         dataLines <- match lines {
                         case _ :: rest => Ok(rest)
-                        case Nil       => Err("Empty file")
+                        case Nil       => Err(CliError.EmptyFile(inputPath))
                      };
         processed <- Ok(Pipeline.process(dataLines));
         _         <- Fs.FileWrite.runWithIO(() ->
                         Fs.WriteFile.runWithFileWrite(() ->
-                            Fs.WriteFile.write({str = processed#json}, task#outputPath)
+                            Fs.WriteFile.write({str = processed#json}, outputPath)
                         )
-                     ) |> Result.mapErr(e -> "Write error: ${e}")
+                     ) |> Result.mapErr(e -> CliError.WriteFile(outputPath, "${e}"))
     ) yield {
         lapCount   = processed#lapCount,
-        outputPath = task#outputPath
+        outputPath = outputPath
     }

--- a/flix/src/Main.flix
+++ b/flix/src/Main.flix
@@ -1,6 +1,16 @@
-def main(): Unit \ IO =
-    let inputPath = "../cli/test_data.csv";
-    let outputPath = "../cli/test_data.json";
+use Sys.Env
+
+def main(): Unit \ {Env, IO} =
+    let args = Env.getArgs();
+    match Args.parse(args) {
+        case Err(e) =>
+            println("Error: ${e}");
+            println("Usage: flix-run <input.csv> [--output <output.json>]")
+        case Ok(parsed) =>
+            convert(parsed#inputPath, parsed#outputPath)
+    }
+
+def convert(inputPath: String, outputPath: String): Unit \ IO =
     let readResult = Fs.FileRead.runWithIO(() ->
         Fs.ReadLines.runWithFileRead(() ->
             Fs.ReadLines.readLines(inputPath)

--- a/flix/src/Main.flix
+++ b/flix/src/Main.flix
@@ -13,19 +13,23 @@ pub type alias RunSummary = {
 
 def main(): Unit \ {Env, IO} =
     let args = Env.getArgs();
-    match Args.parse(args) {
+    let code = match Args.parse(args) {
         case Err(e) =>
-            println("Error: ${e}");
-            println("Usage: flix-run <input.csv|dir> [--output <output.json>]")
+            Cli.eprintln("Error: ${e}");
+            Cli.eprintln("Usage: flix-run <input.csv|dir> [--output <output.json>]");
+            1
         case Ok(parsed) =>
             match FileTask.resolve(parsed) {
                 case Err(e) =>
-                    println("Error: ${e}")
+                    Cli.eprintln("Error: ${e}");
+                    1
                 case Ok(tasks) =>
                     let summary = runTasks(tasks);
-                    println("Processing completed: ${summary#processed} processed, ${summary#errors} errors")
+                    println("Processing completed: ${summary#processed} processed, ${summary#errors} errors");
+                    summaryExitCode(summary)
             }
-    }
+    };
+    Cli.exit(code)
 
 def runTasks(tasks: List[FileTask.FileTask]): RunSummary \ IO =
     List.foldLeft(
@@ -34,7 +38,7 @@ def runTasks(tasks: List[FileTask.FileTask]): RunSummary \ IO =
                 println("${task#eventName}: Wrote ${report#lapCount} laps to ${report#outputPath}");
                 { processed = summary#processed + 1, errors = summary#errors }
             case Err(e) =>
-                println("${task#eventName}: ${e}");
+                Cli.eprintln("${task#eventName}: ${e}");
                 { processed = summary#processed, errors = summary#errors + 1 }
         },
         { processed = 0, errors = 0 },
@@ -63,3 +67,6 @@ def processFile(task: FileTask.FileTask): Result[CliError, ProcessingReport] \ I
         lapCount   = processed#lapCount,
         outputPath = outputPath
     }
+
+def summaryExitCode(summary: RunSummary): Int32 =
+    if (summary#errors == 0) 0 else 1

--- a/flix/src/Main.flix
+++ b/flix/src/Main.flix
@@ -15,17 +15,17 @@ def main(): Unit \ {Env, IO} =
     let args = Env.getArgs();
     let code = match Args.parse(args) {
         case Err(e) =>
-            Cli.eprintln("Error: ${e}");
-            Cli.eprintln("Usage: flix-run <input.csv|dir> [--output <output.json>]");
+            Log.error("Error: ${e}");
+            Log.error("Usage: flix-run <input.csv|dir> [--output <output.json>]");
             1
         case Ok(parsed) =>
             match FileTask.resolve(parsed) {
                 case Err(e) =>
-                    Cli.eprintln("Error: ${e}");
+                    Log.error("Error: ${e}");
                     1
                 case Ok(tasks) =>
                     let summary = runTasks(tasks);
-                    println("Processing completed: ${summary#processed} processed, ${summary#errors} errors");
+                    Log.info("Processing completed: ${summary#processed} processed, ${summary#errors} errors");
                     summaryExitCode(summary)
             }
     };
@@ -35,10 +35,10 @@ def runTasks(tasks: List[FileTask.FileTask]): RunSummary \ IO =
     List.foldLeft(
         (summary, task) -> match processFile(task) {
             case Ok(report) =>
-                println("${task#eventName}: Wrote ${report#lapCount} laps to ${report#outputPath}");
+                Log.info("${task#eventName}: Wrote ${report#lapCount} laps to ${report#outputPath}");
                 { processed = summary#processed + 1, errors = summary#errors }
             case Err(e) =>
-                Cli.eprintln("${task#eventName}: ${e}");
+                Log.error("${task#eventName}: ${e}");
                 { processed = summary#processed, errors = summary#errors + 1 }
         },
         { processed = 0, errors = 0 },

--- a/flix/src/Pipeline.flix
+++ b/flix/src/Pipeline.flix
@@ -1,0 +1,9 @@
+mod Pipeline {
+
+    pub def process(dataLines: List[String]): String =
+        dataLines
+            |> Csv.parseLines
+            |> Lap.toJsonArray
+            |> Json.render
+
+}

--- a/flix/src/Pipeline.flix
+++ b/flix/src/Pipeline.flix
@@ -6,7 +6,7 @@ mod Pipeline {
     }
 
     pub def process(dataLines: List[String]): Result =
-        let records = Csv.parseLines(dataLines);
+        let records = dataLines |> Csv.parse |> Lap.fromCsvRows;
         let json = Json.render(Lap.toJsonArray(records));
         {
             lapCount = List.length(records),

--- a/flix/src/Pipeline.flix
+++ b/flix/src/Pipeline.flix
@@ -1,9 +1,16 @@
 mod Pipeline {
 
-    pub def process(dataLines: List[String]): String =
-        dataLines
-            |> Csv.parseLines
-            |> Lap.toJsonArray
-            |> Json.render
+    pub type alias Result = {
+        lapCount = Int32,
+        json = String
+    }
+
+    pub def process(dataLines: List[String]): Result =
+        let records = Csv.parseLines(dataLines);
+        let json = Json.render(Lap.toJsonArray(records));
+        {
+            lapCount = List.length(records),
+            json     = json
+        }
 
 }

--- a/flix/test/TestArgs.flix
+++ b/flix/test/TestArgs.flix
@@ -11,7 +11,7 @@ mod TestArgs {
         match result {
             case Ok(parsed) =>
                 Assert.assertTrue(parsed#inputPath == "input.csv");
-                Assert.assertTrue(parsed#outputPath == "input.json")
+                Assert.assertTrue(Option.isEmpty(parsed#outputFile))
             case Err(_) =>
                 Assert.assertTrue(false)
         }
@@ -22,7 +22,7 @@ mod TestArgs {
         match result {
             case Ok(parsed) =>
                 Assert.assertTrue(parsed#inputPath == "input.csv");
-                Assert.assertTrue(parsed#outputPath == "out.json")
+                Assert.assertTrue(parsed#outputFile == Some("out.json"))
             case Err(_) =>
                 Assert.assertTrue(false)
         }
@@ -33,7 +33,7 @@ mod TestArgs {
         match result {
             case Ok(parsed) =>
                 Assert.assertTrue(parsed#inputPath == "input.csv");
-                Assert.assertTrue(parsed#outputPath == "out.json")
+                Assert.assertTrue(parsed#outputFile == Some("out.json"))
             case Err(_) =>
                 Assert.assertTrue(false)
         }
@@ -52,21 +52,5 @@ mod TestArgs {
     def testParseDuplicateOutput(): Unit \ Assert =
         let result = Args.parse("--output" :: "a.json" :: "--output" :: "b.json" :: "input.csv" :: Nil);
         Assert.assertTrue(Result.isErr(result))
-
-    @Test
-    def testDefaultOutputPathCsv(): Unit \ Assert =
-        let result = Args.parse("data/race.csv" :: Nil);
-        match result {
-            case Ok(parsed) => Assert.assertTrue(parsed#outputPath == "data/race.json")
-            case Err(_)     => Assert.assertTrue(false)
-        }
-
-    @Test
-    def testDefaultOutputPathNonCsv(): Unit \ Assert =
-        let result = Args.parse("data/race.txt" :: Nil);
-        match result {
-            case Ok(parsed) => Assert.assertTrue(parsed#outputPath == "data/race.txt.json")
-            case Err(_)     => Assert.assertTrue(false)
-        }
 
 }

--- a/flix/test/TestArgs.flix
+++ b/flix/test/TestArgs.flix
@@ -1,0 +1,72 @@
+mod TestArgs {
+
+    @Test
+    def testParseNoArgs(): Unit \ Assert =
+        let result = Args.parse(Nil);
+        Assert.assertTrue(Result.isErr(result))
+
+    @Test
+    def testParseInputOnly(): Unit \ Assert =
+        let result = Args.parse("input.csv" :: Nil);
+        match result {
+            case Ok(parsed) =>
+                Assert.assertTrue(parsed#inputPath == "input.csv");
+                Assert.assertTrue(parsed#outputPath == "input.json")
+            case Err(_) =>
+                Assert.assertTrue(false)
+        }
+
+    @Test
+    def testParseWithOutput(): Unit \ Assert =
+        let result = Args.parse("input.csv" :: "--output" :: "out.json" :: Nil);
+        match result {
+            case Ok(parsed) =>
+                Assert.assertTrue(parsed#inputPath == "input.csv");
+                Assert.assertTrue(parsed#outputPath == "out.json")
+            case Err(_) =>
+                Assert.assertTrue(false)
+        }
+
+    @Test
+    def testParseOutputBeforeInput(): Unit \ Assert =
+        let result = Args.parse("--output" :: "out.json" :: "input.csv" :: Nil);
+        match result {
+            case Ok(parsed) =>
+                Assert.assertTrue(parsed#inputPath == "input.csv");
+                Assert.assertTrue(parsed#outputPath == "out.json")
+            case Err(_) =>
+                Assert.assertTrue(false)
+        }
+
+    @Test
+    def testParseUnexpectedArgument(): Unit \ Assert =
+        let result = Args.parse("input.csv" :: "extra" :: Nil);
+        Assert.assertTrue(Result.isErr(result))
+
+    @Test
+    def testParseOutputWithoutValue(): Unit \ Assert =
+        let result = Args.parse("input.csv" :: "--output" :: Nil);
+        Assert.assertTrue(Result.isErr(result))
+
+    @Test
+    def testParseDuplicateOutput(): Unit \ Assert =
+        let result = Args.parse("--output" :: "a.json" :: "--output" :: "b.json" :: "input.csv" :: Nil);
+        Assert.assertTrue(Result.isErr(result))
+
+    @Test
+    def testDefaultOutputPathCsv(): Unit \ Assert =
+        let result = Args.parse("data/race.csv" :: Nil);
+        match result {
+            case Ok(parsed) => Assert.assertTrue(parsed#outputPath == "data/race.json")
+            case Err(_)     => Assert.assertTrue(false)
+        }
+
+    @Test
+    def testDefaultOutputPathNonCsv(): Unit \ Assert =
+        let result = Args.parse("data/race.txt" :: Nil);
+        match result {
+            case Ok(parsed) => Assert.assertTrue(parsed#outputPath == "data/race.txt.json")
+            case Err(_)     => Assert.assertTrue(false)
+        }
+
+}

--- a/flix/test/TestCsv.flix
+++ b/flix/test/TestCsv.flix
@@ -1,9 +1,26 @@
 mod TestCsv {
 
     @Test
-    def testParseValidLine(): Unit \ Assert =
-        let line = "12;1;3;2:41.963;0;;41.805;0;1:03.483;0;56.675;0;101.4;6:10.938;11:06:38.429;0:41.805;1:03.483;0:56.675;88.5;Will STEVENS;;HYPERCAR;H;Hertz Team JOTA;Porsche;SF;41.805;63.483;56.675;";
-        match Csv.parseLine(line) {
+    def testParseRowSplitsBySemicolon(): Unit \ Assert =
+        let row = Csv.parseRow("a;b;c");
+        Assert.assertTrue(List.length(row) == 3);
+        Assert.assertTrue(List.nth(0, row) == Some("a"));
+        Assert.assertTrue(List.nth(2, row) == Some("c"))
+
+    @Test
+    def testParseRowEmpty(): Unit \ Assert =
+        let row = Csv.parseRow("");
+        Assert.assertTrue(List.length(row) == 1)
+
+    @Test
+    def testParseMultipleLines(): Unit \ Assert =
+        let rows = Csv.parse("a;b" :: "c;d;e" :: Nil);
+        Assert.assertTrue(List.length(rows) == 2)
+
+    @Test
+    def testFromCsvRowValid(): Unit \ Assert =
+        let row = Csv.parseRow("12;1;3;2:41.963;0;;41.805;0;1:03.483;0;56.675;0;101.4;6:10.938;11:06:38.429;0:41.805;1:03.483;0:56.675;88.5;Will STEVENS;;HYPERCAR;H;Hertz Team JOTA;Porsche;SF;41.805;63.483;56.675;");
+        match Lap.fromCsvRow(row) {
             case Some(r) =>
                 Assert.assertTrue(r#carNumber == "12");
                 Assert.assertTrue(r#driverName == "Will STEVENS");
@@ -17,23 +34,23 @@ mod TestCsv {
         }
 
     @Test
-    def testParseShortLine(): Unit \ Assert =
-        let line = "12;1;3";
-        Assert.assertTrue(Option.isEmpty(Csv.parseLine(line)))
+    def testFromCsvRowShort(): Unit \ Assert =
+        let row = Csv.parseRow("12;1;3");
+        Assert.assertTrue(Option.isEmpty(Lap.fromCsvRow(row)))
 
     @Test
-    def testParseEmptyLine(): Unit \ Assert =
-        let line = "";
-        Assert.assertTrue(Option.isEmpty(Csv.parseLine(line)))
+    def testFromCsvRowEmpty(): Unit \ Assert =
+        let row = Csv.parseRow("");
+        Assert.assertTrue(Option.isEmpty(Lap.fromCsvRow(row)))
 
     @Test
-    def testParseLinesSkipsInvalid(): Unit \ Assert =
+    def testFromCsvRowsSkipsInvalid(): Unit \ Assert =
         let lines =
             "12;1;1;1:35.365;0;;23.155;0;29.928;0;42.282;0;160.7;1:35.365;11:02:02.856;0:23.155;0:29.928;0:42.282;;Will STEVENS;;HYPERCAR;H;Hertz Team JOTA;Porsche;GF;23.155;29.928;42.282;" ::
             "short line" ::
             "7;1;1;1:35.421;0;;23.277;0;29.848;0;42.296;0;160.5;1:35.421;11:02:02.912;0:23.277;0:29.848;0:42.296;;Kamui KOBAYASHI;;HYPERCAR;H;Toyota Gazoo Racing;Toyota;GF;23.277;29.848;42.296;" ::
             Nil;
-        let records = Csv.parseLines(lines);
+        let records = lines |> Csv.parse |> Lap.fromCsvRows;
         Assert.assertTrue(List.length(records) == 2)
 
 }

--- a/flix/test/TestCsv.flix
+++ b/flix/test/TestCsv.flix
@@ -1,0 +1,39 @@
+mod TestCsv {
+
+    @Test
+    def testParseValidLine(): Unit \ Assert =
+        let line = "12;1;3;2:41.963;0;;41.805;0;1:03.483;0;56.675;0;101.4;6:10.938;11:06:38.429;0:41.805;1:03.483;0:56.675;88.5;Will STEVENS;;HYPERCAR;H;Hertz Team JOTA;Porsche;SF;41.805;63.483;56.675;";
+        match Csv.parseLine(line) {
+            case Some(r) =>
+                Assert.assertTrue(r#carNumber == "12");
+                Assert.assertTrue(r#driverName == "Will STEVENS");
+                Assert.assertTrue(r#lapNumber == "3");
+                Assert.assertTrue(r#lapTime == "2:41.963");
+                Assert.assertTrue(r#kph == "101.4");
+                Assert.assertTrue(r#class == "HYPERCAR");
+                Assert.assertTrue(r#team == "Hertz Team JOTA")
+            case None =>
+                Assert.assertTrue(false)
+        }
+
+    @Test
+    def testParseShortLine(): Unit \ Assert =
+        let line = "12;1;3";
+        Assert.assertTrue(Option.isEmpty(Csv.parseLine(line)))
+
+    @Test
+    def testParseEmptyLine(): Unit \ Assert =
+        let line = "";
+        Assert.assertTrue(Option.isEmpty(Csv.parseLine(line)))
+
+    @Test
+    def testParseLinesSkipsInvalid(): Unit \ Assert =
+        let lines =
+            "12;1;1;1:35.365;0;;23.155;0;29.928;0;42.282;0;160.7;1:35.365;11:02:02.856;0:23.155;0:29.928;0:42.282;;Will STEVENS;;HYPERCAR;H;Hertz Team JOTA;Porsche;GF;23.155;29.928;42.282;" ::
+            "short line" ::
+            "7;1;1;1:35.421;0;;23.277;0;29.848;0;42.296;0;160.5;1:35.421;11:02:02.912;0:23.277;0:29.848;0:42.296;;Kamui KOBAYASHI;;HYPERCAR;H;Toyota Gazoo Racing;Toyota;GF;23.277;29.848;42.296;" ::
+            Nil;
+        let records = Csv.parseLines(lines);
+        Assert.assertTrue(List.length(records) == 2)
+
+}

--- a/flix/test/TestFileTask.flix
+++ b/flix/test/TestFileTask.flix
@@ -1,0 +1,42 @@
+mod TestFileTask {
+
+    @Test
+    def testMakeWithOutputOverride(): Unit \ Assert =
+        let task = FileTask.make("input.csv", Some("custom.json"));
+        Assert.assertTrue(task#inputPath == "input.csv");
+        Assert.assertTrue(task#outputPath == "custom.json");
+        Assert.assertTrue(task#eventName == "input")
+
+    @Test
+    def testMakeWithoutOutputOverride(): Unit \ Assert =
+        let task = FileTask.make("input.csv", None);
+        Assert.assertTrue(task#inputPath == "input.csv");
+        Assert.assertTrue(task#outputPath == "input.json");
+        Assert.assertTrue(task#eventName == "input")
+
+    @Test
+    def testMakeDefaultOutputPathCsv(): Unit \ Assert =
+        let task = FileTask.make("data/race.csv", None);
+        Assert.assertTrue(task#outputPath == "data/race.json")
+
+    @Test
+    def testMakeDefaultOutputPathNonCsv(): Unit \ Assert =
+        let task = FileTask.make("data/race.txt", None);
+        Assert.assertTrue(task#outputPath == "data/race.txt.json")
+
+    @Test
+    def testEventNameSimple(): Unit \ Assert =
+        let task = FileTask.make("race.csv", None);
+        Assert.assertTrue(task#eventName == "race")
+
+    @Test
+    def testEventNameWithPath(): Unit \ Assert =
+        let task = FileTask.make("data/wec/2025/race.csv", None);
+        Assert.assertTrue(task#eventName == "race")
+
+    @Test
+    def testEventNameNoExtension(): Unit \ Assert =
+        let task = FileTask.make("data/race", None);
+        Assert.assertTrue(task#eventName == "race")
+
+}

--- a/flix/test/TestJson.flix
+++ b/flix/test/TestJson.flix
@@ -1,0 +1,52 @@
+mod TestJson {
+
+    use Json.JsonValue.{JsonNull, JsonBool, JsonInt, JsonFloat, JsonString, JsonArray, JsonObject}
+
+    @Test
+    def testRenderNull(): Unit \ Assert =
+        Assert.assertTrue(Json.render(JsonNull) == "null")
+
+    @Test
+    def testRenderBoolTrue(): Unit \ Assert =
+        Assert.assertTrue(Json.render(JsonBool(true)) == "true")
+
+    @Test
+    def testRenderBoolFalse(): Unit \ Assert =
+        Assert.assertTrue(Json.render(JsonBool(false)) == "false")
+
+    @Test
+    def testRenderInt(): Unit \ Assert =
+        Assert.assertTrue(Json.render(JsonInt(42)) == "42")
+
+    @Test
+    def testRenderString(): Unit \ Assert =
+        Assert.assertTrue(Json.render(JsonString("hello")) == "\"hello\"")
+
+    @Test
+    def testRenderStringWithQuotes(): Unit \ Assert =
+        let result = Json.render(JsonString("say \"hi\""));
+        Assert.assertTrue(String.contains({substr = "\\\""}, result))
+
+    @Test
+    def testRenderEmptyArray(): Unit \ Assert =
+        Assert.assertTrue(Json.render(JsonArray(Nil)) == "[]")
+
+    @Test
+    def testRenderEmptyObject(): Unit \ Assert =
+        Assert.assertTrue(Json.render(JsonObject(Nil)) == "{}")
+
+    @Test
+    def testRenderObject(): Unit \ Assert =
+        let obj = JsonObject(("name", JsonString("test")) :: ("value", JsonInt(1)) :: Nil);
+        let result = Json.render(obj);
+        Assert.assertTrue(String.contains({substr = "\"name\": \"test\""}, result));
+        Assert.assertTrue(String.contains({substr = "\"value\": 1"}, result))
+
+    @Test
+    def testRenderArray(): Unit \ Assert =
+        let arr = JsonArray(JsonInt(1) :: JsonInt(2) :: Nil);
+        let result = Json.render(arr);
+        Assert.assertTrue(String.contains({substr = "1"}, result));
+        Assert.assertTrue(String.contains({substr = "2"}, result))
+
+}

--- a/flix/test/TestMain.flix
+++ b/flix/test/TestMain.flix
@@ -1,0 +1,2 @@
+@Test
+def test01(): Bool = 1 + 1 == 2

--- a/flix/test/TestMain.flix
+++ b/flix/test/TestMain.flix
@@ -1,2 +1,3 @@
 @Test
-def test01(): Bool = 1 + 1 == 2
+def test01(): Unit \ Assert =
+    Assert.assertTrue(1 + 1 == 2)


### PR DESCRIPTION
## Summary
Adds a Flix implementation of the CSV-to-JSON race-data CLI under `/flix`, mirroring the architecture of the Rust CLI in `/cli`. The two ports now share the same domain modeling shape — typed errors, a pipeline split into lexical/semantic/IO stages, an opaque `FileTask`, and a `RunSummary` that drives the OS exit code — so design improvements can flow between them.

## Why
- Hands-on Flix learning ground for evaluating effect-tracked functional programming on a real, non-trivial CLI we already understand in Rust.
- Concrete cross-language reference: the Rust CLI's recent functional-domain-modeling refactors (`#80`, `#81`) gave us a target shape; this branch incrementally rebuilds the Flix side toward that shape so we can compare ergonomics directly.

## What's included
- **Toolchain**: `nix` apps for `flix-build`, `flix-run`, `flix-test`; Flix pinned to 0.71.0.
- **Per-file pipeline**: pure `Pipeline.process` composing `Csv.parse → Lap.fromCsvRows → Lap.toJsonArray → Json.render`, with I/O kept at the orchestrator (`Main.processFile`).
- **CSV split into lexical and semantic stages**: `Csv.parseRow / parse` produce a raw `CsvRow`; `Lap.fromCsvRow` projects to the domain `LapRecord`. Mirrors Rust's `csv_input` + `structure` boundary.
- **Typed errors**: `Cli.CliError` covers `PathNotFound`, `PathAccessError`, `ListDirError`, `NoCsvFiles`, `OutputWithDirectory`, `ReadFile`, `EmptyFile`, `WriteFile`. `Args.ArgsError` stays distinct so the usage hint can be scoped to argument failures.
- **FileTask resolution**: argument parsing (`Args.parse`, `try_fold`-style state machine) is separate from filesystem validation (`FileTask.resolve`). Single-file and directory inputs are both supported.
- **Recursive directory walk**: `Files.walkCsvFiles` traverses subdirectories with no depth limit, matching the Rust `walkdir` behavior.
- **Filesystem I/O module**: `Files.flix` centralizes the `Fs.*` effect-handler nesting and `CliError` mapping for `readLines / writeFile / exists / isDirectory / listDir / walkCsvFiles`.
- **RunSummary + exit code**: batch processing accumulates `{processed, errors}`; non-zero `errors` triggers `System.exit(1)`. Successful runs exit 0.
- **Logging**: `Log.info` (stdout) / `Log.error` (stderr) replace bare `println` calls and encapsulate the `java.lang.System` interop. Leaves a single place to add level prefixes or timestamps later.
- **Tests**: 32 Flix unit tests covering `Args`, `Csv`, `Lap.fromCsvRow`, `FileTask`, and `Json` rendering.

## Notable design notes for reviewers
- **`def main(): Int32` does NOT set the OS exit code in Flix** — the value gets printed to stdout instead. We use `System.exit(code)` via Java interop (`Cli.exit`); a comment in `Cli.flix` records this gotcha.
- **Java interop is encapsulated**: `Cli.exit` wraps `System.exit`; `Log.error` wraps `System.err.println`. No business-logic module imports `java.lang.System` directly.
- **Imports inside `mod` blocks**: `import java.lang.System` placed at the top of a file is not visible inside `mod` declarations. The pattern used here is `mod Foo { import java.lang.System ... }`.
- **Out of scope (intentional)**: the Rust CLI's `transform` stage (lap stats, best times, mini-sectors, starting grid) and its dual `metadata.json` + `_laps.json` outputs are not ported. This PR establishes structural parity, not feature parity. Domain expansion is queued for a follow-up.