### PR TITLE
feat: refactor lap data processing with comprehensive Duration normalization

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -110,7 +110,7 @@
           cli-run              = { type = "app"; program = "${mkCargoApp "cli-run"   "cargo run -p cli -- ../app/static/wec/2025"}/bin/cli-run";                     meta.description = "Run Rust CLI (CSV -> JSON)"; };
           flix-build           = { type = "app"; program = "${mkFlixApp "flix-build" "flix build"}/bin/flix-build";                                                   meta.description = "Build Flix project"; };
           flix-test            = { type = "app"; program = "${mkFlixApp "flix-test"  "flix test"}/bin/flix-test";                                                     meta.description = "Run Flix tests"; };
-          flix-run             = { type = "app"; program = "${mkFlixApp "flix-run"   "flix run -- ../cli/test_data.csv"}/bin/flix-run";                               meta.description = "Run Flix project (CSV -> JSON)"; };
+          flix-run             = { type = "app"; program = "${mkFlixApp "flix-run"   "flix run -- ../app/static/wec/2025/cota_6h.csv --output ../app/static/wec/2025/cota_6h_laps.json"}/bin/flix-run"; meta.description = "Run Flix project (CSV -> JSON)"; };
         };
       });
 }

--- a/flix/src/Duration.flix
+++ b/flix/src/Duration.flix
@@ -2,7 +2,7 @@ mod Duration {
 
     /// `H:MM:SS.sss` / `MM:SS.sss` / `SS.sss` 形式の文字列を ms 単位の Int32 にパースする。
     /// 不正フォーマットは `None` を返す。
-    pub def parse(s: String): Option[Int32] =
+    def parse(s: String): Option[Int32] =
         match String.split({regex = "\\."}, s) {
             case wholePart :: msPart :: Nil =>
                 forM(
@@ -16,7 +16,7 @@ mod Duration {
 
     /// ms 単位の Int32 を `H:MM:SS.sss` / `M:SS.sss` / `S.sss` 形式に整形する。
     /// 桁ぞろえ規則は Rust 版 `motorsport::duration::to_string` と同じ。
-    pub def format(ms: Int32): String =
+    def format(ms: Int32): String =
         let totalSec = ms / 1000;
         let msPart   = ms - totalSec * 1000;
         let h        = totalSec / 3600;

--- a/flix/src/Duration.flix
+++ b/flix/src/Duration.flix
@@ -1,0 +1,73 @@
+mod Duration {
+
+    /// `H:MM:SS.sss` / `MM:SS.sss` / `SS.sss` 形式の文字列を ms 単位の Int32 にパースする。
+    /// 不正フォーマットは `None` を返す。
+    pub def parse(s: String): Option[Int32] =
+        match String.split({regex = "\\."}, s) {
+            case wholePart :: msPart :: Nil =>
+                forM(
+                    seconds <- parseHmsToSeconds(wholePart);
+                    millis  <- Int32.fromString(padMilliseconds(msPart))
+                ) yield seconds * 1000 + millis
+            case wholeOnly :: Nil =>
+                Option.map(secs -> secs * 1000, parseHmsToSeconds(wholeOnly))
+            case _ => None
+        }
+
+    /// ms 単位の Int32 を `H:MM:SS.sss` / `M:SS.sss` / `S.sss` 形式に整形する。
+    /// 桁ぞろえ規則は Rust 版 `motorsport::duration::to_string` と同じ。
+    pub def format(ms: Int32): String =
+        let totalSec = ms / 1000;
+        let msPart   = ms - totalSec * 1000;
+        let h        = totalSec / 3600;
+        let m        = (totalSec - h * 3600) / 60;
+        let s        = totalSec - h * 3600 - m * 60;
+        if (h > 0)
+            "${h}:${zeroPad2(m)}:${zeroPad2(s)}.${zeroPad3(msPart)}"
+        else if (m > 0)
+            "${m}:${zeroPad2(s)}.${zeroPad3(msPart)}"
+        else
+            "${s}.${zeroPad3(msPart)}"
+
+    /// 入力文字列を Duration として読み直し、正規形式で再フォーマットする。
+    /// 空文字列はそのまま、パース不能はそのまま返す (フェイルセーフ)。
+    pub def normalize(s: String): String =
+        if (String.isEmpty(s)) s
+        else
+            match parse(s) {
+                case Some(ms) => format(ms)
+                case None     => s
+            }
+
+    def parseHmsToSeconds(s: String): Option[Int32] =
+        match String.split({regex = ":"}, s) {
+            case h :: m :: sec :: Nil =>
+                forM(
+                    hi <- Int32.fromString(h);
+                    mi <- Int32.fromString(m);
+                    si <- Int32.fromString(sec)
+                ) yield hi * 3600 + mi * 60 + si
+            case m :: sec :: Nil =>
+                forM(
+                    mi <- Int32.fromString(m);
+                    si <- Int32.fromString(sec)
+                ) yield mi * 60 + si
+            case sec :: Nil =>
+                Int32.fromString(sec)
+            case _ => None
+        }
+
+    def padMilliseconds(s: String): String =
+        let len = String.length(s);
+        if (len >= 3) String.take(3, s)
+        else s + String.repeat(3 - len, "0")
+
+    def zeroPad2(n: Int32): String =
+        if (n < 10) "0${n}" else "${n}"
+
+    def zeroPad3(n: Int32): String =
+        if (n < 10) "00${n}"
+        else if (n < 100) "0${n}"
+        else "${n}"
+
+}

--- a/flix/src/Duration.flix
+++ b/flix/src/Duration.flix
@@ -13,7 +13,7 @@ mod Duration {
             case wholePart :: msPart :: Nil =>
                 forM(
                     seconds <- parseHmsToSeconds(wholePart);
-                    millis  <- Int32.fromString(padMilliseconds(msPart))
+                    millis  <- Int32.fromString(padFractionalToMs(msPart))
                 ) yield seconds * 1000 + millis
             case wholeOnly :: Nil =>
                 Option.map(secs -> secs * 1000, parseHmsToSeconds(wholeOnly))
@@ -63,7 +63,7 @@ mod Duration {
             case _ => None
         }
 
-    def padMilliseconds(s: String): String =
+    def padFractionalToMs(s: String): String =
         let len = String.length(s);
         if (len >= 3) String.take(3, s)
         else s + String.repeat(3 - len, "0")

--- a/flix/src/Duration.flix
+++ b/flix/src/Duration.flix
@@ -1,3 +1,9 @@
+/// `H:MM:SS.sss` / `MM:SS.sss` / `SS.sss` 形式の時間文字列を ms 単位の
+/// `Int32` と相互変換する。Rust 版 `motorsport::duration` と同じ規則:
+/// 1時間以上は `H:MM:SS.sss`、1分以上は `M:SS.sss`、それ未満は `S.sss`。
+///
+/// 公開 API は `normalize` のみ (入力を一度パースして正規形に整形し直す)。
+/// `parse` / `format` は `normalize` 内部の実装詳細として private に保つ。
 mod Duration {
 
     /// `H:MM:SS.sss` / `MM:SS.sss` / `SS.sss` 形式の文字列を ms 単位の Int32 にパースする。

--- a/flix/src/Lap.flix
+++ b/flix/src/Lap.flix
@@ -1,3 +1,16 @@
+/// CSV 行を `xxx_laps.json` 出力用の `LapRecord` に整形するモジュール。
+/// 出力 JSON 形状は Rust 版 CLI の
+/// `motorsport::cli::stages::output::RawLap` (`#[serde(rename_all =
+/// "camelCase")]`) と一致する 22 フィールドの camelCase キー:
+///   carNumber, driverNumber, lapNumber, lapTime, lapImprovement,
+///   crossingFinishLineInPit, s1, s1Improvement, s2, s2Improvement,
+///   s3, s3Improvement, kph, elapsed, hour, topSpeed, driverName,
+///   pitTime, class, group, team, manufacturer
+///
+/// `lapTime` / `s1` / `s2` / `s3` / `elapsed` / `pitTime` は `Duration`
+/// で正規形 (`"0:01:41.031"` -> `"1:41.031"` 等) に整形される。一方
+/// `hour` は CSV 上の時刻表記 (`"HH:MM:SS.sss"`) — duration ではないので
+/// 正規化を通さず文字列そのままを保持する。
 mod Lap {
 
     use Json.JsonValue.{JsonObject, JsonString, JsonInt, JsonFloat, JsonArray}

--- a/flix/src/Lap.flix
+++ b/flix/src/Lap.flix
@@ -128,7 +128,7 @@ mod Lap {
         match Int32.parse(10, trimmed) {
             case Ok(n)  => JsonInt(n)
             case Err(_) =>
-                match Float64.fromString(s) {
+                match Float64.fromString(trimmed) {
                     case Some(f) => JsonFloat(f)
                     case None    => JsonString(s)
                 }

--- a/flix/src/Lap.flix
+++ b/flix/src/Lap.flix
@@ -1,35 +1,80 @@
 mod Lap {
 
-    use Json.JsonValue.{JsonObject, JsonString, JsonArray}
+    use Json.JsonValue.{JsonObject, JsonString, JsonInt, JsonFloat, JsonArray}
 
     pub type alias LapRecord = {
         carNumber = String,
-        driverName = String,
-        lapNumber = String,
+        driverNumber = Int32,
+        lapNumber = Int32,
         lapTime = String,
+        lapImprovement = Int32,
+        crossingFinishLineInPit = String,
+        s1 = String,
+        s1Improvement = Int32,
+        s2 = String,
+        s2Improvement = Int32,
+        s3 = String,
+        s3Improvement = Int32,
         kph = String,
+        elapsed = String,
+        hour = String,
+        topSpeed = String,
+        driverName = String,
+        pitTime = String,
         class = String,
-        team = String
+        group = String,
+        team = String,
+        manufacturer = String
     }
 
     pub def fromCsvRow(row: Csv.CsvRow): Option[LapRecord] =
         if (List.length(row) >= 25)
             forM(
-                carNumber   <- List.nth(0, row);
-                driverName  <- List.nth(19, row);
-                lapNumber   <- List.nth(2, row);
-                lapTime     <- List.nth(3, row);
-                kph         <- List.nth(12, row);
-                class       <- List.nth(21, row);
-                team        <- List.nth(23, row)
+                carNumber               <- List.nth(0, row);
+                driverNumberStr         <- List.nth(1, row);
+                lapNumberStr            <- List.nth(2, row);
+                lapTime                 <- List.nth(3, row);
+                lapImprovementStr       <- List.nth(4, row);
+                crossingFinishLineInPit <- List.nth(5, row);
+                s1                      <- List.nth(6, row);
+                s1ImprovementStr        <- List.nth(7, row);
+                s2                      <- List.nth(8, row);
+                s2ImprovementStr        <- List.nth(9, row);
+                s3                      <- List.nth(10, row);
+                s3ImprovementStr        <- List.nth(11, row);
+                kph                     <- List.nth(12, row);
+                elapsed                 <- List.nth(13, row);
+                hour                    <- List.nth(14, row);
+                topSpeed                <- List.nth(18, row);
+                driverName              <- List.nth(19, row);
+                pitTime                 <- List.nth(20, row);
+                class                   <- List.nth(21, row);
+                group                   <- List.nth(22, row);
+                team                    <- List.nth(23, row);
+                manufacturer            <- List.nth(24, row)
             ) yield {
-                carNumber   = carNumber,
-                driverName  = driverName,
-                lapNumber   = lapNumber,
-                lapTime     = lapTime,
-                kph         = kph,
-                class       = class,
-                team        = team
+                carNumber               = carNumber,
+                driverNumber            = parseInt(driverNumberStr),
+                lapNumber               = parseInt(lapNumberStr),
+                lapTime                 = Duration.normalize(lapTime),
+                lapImprovement          = parseInt(lapImprovementStr),
+                crossingFinishLineInPit = crossingFinishLineInPit,
+                s1                      = Duration.normalize(s1),
+                s1Improvement           = parseInt(s1ImprovementStr),
+                s2                      = Duration.normalize(s2),
+                s2Improvement           = parseInt(s2ImprovementStr),
+                s3                      = Duration.normalize(s3),
+                s3Improvement           = parseInt(s3ImprovementStr),
+                kph                     = kph,
+                elapsed                 = Duration.normalize(elapsed),
+                hour                    = hour,
+                topSpeed                = stripTrailingDotZero(topSpeed),
+                driverName              = driverName,
+                pitTime                 = Duration.normalize(pitTime),
+                class                   = class,
+                group                   = group,
+                team                    = team,
+                manufacturer            = manufacturer
             }
         else
             None
@@ -39,17 +84,60 @@ mod Lap {
 
     pub def toJson(record: LapRecord): Json.JsonValue =
         JsonObject(
-            ("carNumber",  JsonString(record#carNumber)) ::
-            ("driverName", JsonString(record#driverName)) ::
-            ("lapNumber",  JsonString(record#lapNumber)) ::
-            ("lapTime",    JsonString(record#lapTime)) ::
-            ("kph",        JsonString(record#kph)) ::
-            ("class",      JsonString(record#class)) ::
-            ("team",       JsonString(record#team)) ::
+            ("carNumber",               JsonString(record#carNumber)) ::
+            ("driverNumber",            JsonInt(record#driverNumber)) ::
+            ("lapNumber",               JsonInt(record#lapNumber)) ::
+            ("lapTime",                 JsonString(record#lapTime)) ::
+            ("lapImprovement",          JsonInt(record#lapImprovement)) ::
+            ("crossingFinishLineInPit", JsonString(record#crossingFinishLineInPit)) ::
+            ("s1",                      JsonString(record#s1)) ::
+            ("s1Improvement",           JsonInt(record#s1Improvement)) ::
+            ("s2",                      JsonString(record#s2)) ::
+            ("s2Improvement",           JsonInt(record#s2Improvement)) ::
+            ("s3",                      JsonString(record#s3)) ::
+            ("s3Improvement",           JsonInt(record#s3Improvement)) ::
+            ("kph",                     kphValue(record#kph)) ::
+            ("elapsed",                 JsonString(record#elapsed)) ::
+            ("hour",                    JsonString(record#hour)) ::
+            ("topSpeed",                JsonString(record#topSpeed)) ::
+            ("driverName",              JsonString(record#driverName)) ::
+            ("pitTime",                 JsonString(record#pitTime)) ::
+            ("class",                   JsonString(record#class)) ::
+            ("group",                   JsonString(record#group)) ::
+            ("team",                    JsonString(record#team)) ::
+            ("manufacturer",            JsonString(record#manufacturer)) ::
             Nil
         )
 
     pub def toJsonArray(records: List[LapRecord]): Json.JsonValue =
         JsonArray(List.map(toJson, records))
+
+    /// 文字列が `.0` で終わっていればその2文字を落とす。それ以外はそのまま。
+    /// 例: `"86.0"` -> `"86"`、`"116.3"` -> `"116.3"`、`""` -> `""`。
+    pub def stripTrailingDotZero(s: String): String =
+        if (String.endsWith({suffix = ".0"}, s))
+            String.dropRight(2, s)
+        else
+            s
+
+    /// CSV の KPH 文字列を JSON 数値に変換する。
+    /// 末尾が `.0` の値や整数表記は `JsonInt` に、それ以外で Float としてパースできれば `JsonFloat` に、
+    /// パース不能の場合は文字列のまま `JsonString` で返す (フェイルセーフ)。
+    pub def kphValue(s: String): Json.JsonValue =
+        let trimmed = stripTrailingDotZero(s);
+        match Int32.parse(10, trimmed) {
+            case Ok(n)  => JsonInt(n)
+            case Err(_) =>
+                match Float64.fromString(s) {
+                    case Some(f) => JsonFloat(f)
+                    case None    => JsonString(s)
+                }
+        }
+
+    def parseInt(s: String): Int32 =
+        match Int32.parse(10, s) {
+            case Ok(n)  => n
+            case Err(_) => 0
+        }
 
 }

--- a/flix/src/Lap.flix
+++ b/flix/src/Lap.flix
@@ -28,56 +28,53 @@ mod Lap {
     }
 
     pub def fromCsvRow(row: Csv.CsvRow): Option[LapRecord] =
-        if (List.length(row) >= 25)
-            forM(
-                carNumber               <- List.nth(0, row);
-                driverNumberStr         <- List.nth(1, row);
-                lapNumberStr            <- List.nth(2, row);
-                lapTime                 <- List.nth(3, row);
-                lapImprovementStr       <- List.nth(4, row);
-                crossingFinishLineInPit <- List.nth(5, row);
-                s1                      <- List.nth(6, row);
-                s1ImprovementStr        <- List.nth(7, row);
-                s2                      <- List.nth(8, row);
-                s2ImprovementStr        <- List.nth(9, row);
-                s3                      <- List.nth(10, row);
-                s3ImprovementStr        <- List.nth(11, row);
-                kph                     <- List.nth(12, row);
-                elapsed                 <- List.nth(13, row);
-                hour                    <- List.nth(14, row);
-                topSpeed                <- List.nth(18, row);
-                driverName              <- List.nth(19, row);
-                pitTime                 <- List.nth(20, row);
-                class                   <- List.nth(21, row);
-                group                   <- List.nth(22, row);
-                team                    <- List.nth(23, row);
-                manufacturer            <- List.nth(24, row)
-            ) yield {
-                carNumber               = carNumber,
-                driverNumber            = parseInt(driverNumberStr),
-                lapNumber               = parseInt(lapNumberStr),
-                lapTime                 = Duration.normalize(lapTime),
-                lapImprovement          = parseInt(lapImprovementStr),
-                crossingFinishLineInPit = crossingFinishLineInPit,
-                s1                      = Duration.normalize(s1),
-                s1Improvement           = parseInt(s1ImprovementStr),
-                s2                      = Duration.normalize(s2),
-                s2Improvement           = parseInt(s2ImprovementStr),
-                s3                      = Duration.normalize(s3),
-                s3Improvement           = parseInt(s3ImprovementStr),
-                kph                     = kph,
-                elapsed                 = Duration.normalize(elapsed),
-                hour                    = hour,
-                topSpeed                = stripTrailingDotZero(topSpeed),
-                driverName              = driverName,
-                pitTime                 = Duration.normalize(pitTime),
-                class                   = class,
-                group                   = group,
-                team                    = team,
-                manufacturer            = manufacturer
-            }
-        else
-            None
+        forM(
+            carNumber               <- List.nth(0, row);
+            driverNumberStr         <- List.nth(1, row);
+            lapNumberStr            <- List.nth(2, row);
+            lapTime                 <- List.nth(3, row);
+            lapImprovementStr       <- List.nth(4, row);
+            crossingFinishLineInPit <- List.nth(5, row);
+            s1                      <- List.nth(6, row);
+            s1ImprovementStr        <- List.nth(7, row);
+            s2                      <- List.nth(8, row);
+            s2ImprovementStr        <- List.nth(9, row);
+            s3                      <- List.nth(10, row);
+            s3ImprovementStr        <- List.nth(11, row);
+            kph                     <- List.nth(12, row);
+            elapsed                 <- List.nth(13, row);
+            hour                    <- List.nth(14, row);
+            topSpeed                <- List.nth(18, row);
+            driverName              <- List.nth(19, row);
+            pitTime                 <- List.nth(20, row);
+            class                   <- List.nth(21, row);
+            group                   <- List.nth(22, row);
+            team                    <- List.nth(23, row);
+            manufacturer            <- List.nth(24, row)
+        ) yield {
+            carNumber               = carNumber,
+            driverNumber            = parseInt(driverNumberStr),
+            lapNumber               = parseInt(lapNumberStr),
+            lapTime                 = Duration.normalize(lapTime),
+            lapImprovement          = parseInt(lapImprovementStr),
+            crossingFinishLineInPit = crossingFinishLineInPit,
+            s1                      = Duration.normalize(s1),
+            s1Improvement           = parseInt(s1ImprovementStr),
+            s2                      = Duration.normalize(s2),
+            s2Improvement           = parseInt(s2ImprovementStr),
+            s3                      = Duration.normalize(s3),
+            s3Improvement           = parseInt(s3ImprovementStr),
+            kph                     = kph,
+            elapsed                 = Duration.normalize(elapsed),
+            hour                    = hour,
+            topSpeed                = stripTrailingDotZero(topSpeed),
+            driverName              = driverName,
+            pitTime                 = Duration.normalize(pitTime),
+            class                   = class,
+            group                   = group,
+            team                    = team,
+            manufacturer            = manufacturer
+        }
 
     pub def fromCsvRows(rows: List[Csv.CsvRow]): List[LapRecord] =
         rows |> List.filterMap(fromCsvRow)
@@ -114,7 +111,7 @@ mod Lap {
 
     /// 文字列が `.0` で終わっていればその2文字を落とす。それ以外はそのまま。
     /// 例: `"86.0"` -> `"86"`、`"116.3"` -> `"116.3"`、`""` -> `""`。
-    pub def stripTrailingDotZero(s: String): String =
+    def stripTrailingDotZero(s: String): String =
         if (String.endsWith({suffix = ".0"}, s))
             String.dropRight(2, s)
         else
@@ -123,7 +120,7 @@ mod Lap {
     /// CSV の KPH 文字列を JSON 数値に変換する。
     /// 末尾が `.0` の値や整数表記は `JsonInt` に、それ以外で Float としてパースできれば `JsonFloat` に、
     /// パース不能の場合は文字列のまま `JsonString` で返す (フェイルセーフ)。
-    pub def kphValue(s: String): Json.JsonValue =
+    def kphValue(s: String): Json.JsonValue =
         let trimmed = stripTrailingDotZero(s);
         match Int32.parse(10, trimmed) {
             case Ok(n)  => JsonInt(n)

--- a/flix/src/Main.flix
+++ b/flix/src/Main.flix
@@ -54,7 +54,7 @@ def processFile(task: FileTask.FileTask): Result[CliError, ProcessingReport] \ I
                         case _ :: rest => Ok(rest)
                         case Nil       => Err(CliError.EmptyFile(inputPath))
                      };
-        processed <- Ok(Pipeline.process(dataLines));
+        processed <- Ok(Stages.process(dataLines));
         _         <- Files.writeFile(outputPath, processed#json)
     ) yield {
         lapCount   = processed#lapCount,

--- a/flix/src/Pipeline.flix
+++ b/flix/src/Pipeline.flix
@@ -1,15 +1,15 @@
 mod Pipeline {
 
-    pub type alias Result = {
+    pub type alias Output = {
         lapCount = Int32,
         json = String
     }
 
-    pub def process(dataLines: List[String]): Result =
-        let records = dataLines |> Csv.parse |> Lap.fromCsvRows;
-        let json = Json.render(Lap.toJsonArray(records));
+    pub def process(dataLines: List[String]): Output =
+        let rawLaps = dataLines |> Csv.parse |> RawLap.fromCsvRows;
+        let json = Json.render(RawLap.toJsonArray(rawLaps));
         {
-            lapCount = List.length(records),
+            lapCount = List.length(rawLaps),
             json     = json
         }
 

--- a/flix/src/RawLap.flix
+++ b/flix/src/RawLap.flix
@@ -1,4 +1,4 @@
-/// CSV 行を `xxx_laps.json` 出力用の `LapRecord` に整形するモジュール。
+/// CSV 行を `xxx_laps.json` 出力用の `RawLap` に整形するモジュール。
 /// 出力 JSON 形状は Rust 版 CLI の
 /// `motorsport::cli::stages::output::RawLap` (`#[serde(rename_all =
 /// "camelCase")]`) と一致する 22 フィールドの camelCase キー:
@@ -11,11 +11,11 @@
 /// で正規形 (`"0:01:41.031"` -> `"1:41.031"` 等) に整形される。一方
 /// `hour` は CSV 上の時刻表記 (`"HH:MM:SS.sss"`) — duration ではないので
 /// 正規化を通さず文字列そのままを保持する。
-mod Lap {
+mod RawLap {
 
     use Json.JsonValue.{JsonObject, JsonString, JsonInt, JsonFloat, JsonArray}
 
-    pub type alias LapRecord = {
+    pub type alias RawLap = {
         carNumber = String,
         driverNumber = Int32,
         lapNumber = Int32,
@@ -40,7 +40,7 @@ mod Lap {
         manufacturer = String
     }
 
-    pub def fromCsvRow(row: Csv.CsvRow): Option[LapRecord] =
+    pub def fromCsvRow(row: Csv.CsvRow): Option[RawLap] =
         forM(
             carNumber               <- List.nth(0, row);
             driverNumberStr         <- List.nth(1, row);
@@ -66,17 +66,17 @@ mod Lap {
             manufacturer            <- List.nth(24, row)
         ) yield {
             carNumber               = carNumber,
-            driverNumber            = parseInt(driverNumberStr),
-            lapNumber               = parseInt(lapNumberStr),
+            driverNumber            = parseIntOrZero(driverNumberStr),
+            lapNumber               = parseIntOrZero(lapNumberStr),
             lapTime                 = Duration.normalize(lapTime),
-            lapImprovement          = parseInt(lapImprovementStr),
+            lapImprovement          = parseIntOrZero(lapImprovementStr),
             crossingFinishLineInPit = crossingFinishLineInPit,
             s1                      = Duration.normalize(s1),
-            s1Improvement           = parseInt(s1ImprovementStr),
+            s1Improvement           = parseIntOrZero(s1ImprovementStr),
             s2                      = Duration.normalize(s2),
-            s2Improvement           = parseInt(s2ImprovementStr),
+            s2Improvement           = parseIntOrZero(s2ImprovementStr),
             s3                      = Duration.normalize(s3),
-            s3Improvement           = parseInt(s3ImprovementStr),
+            s3Improvement           = parseIntOrZero(s3ImprovementStr),
             kph                     = kph,
             elapsed                 = Duration.normalize(elapsed),
             hour                    = hour,
@@ -89,38 +89,38 @@ mod Lap {
             manufacturer            = manufacturer
         }
 
-    pub def fromCsvRows(rows: List[Csv.CsvRow]): List[LapRecord] =
+    pub def fromCsvRows(rows: List[Csv.CsvRow]): List[RawLap] =
         rows |> List.filterMap(fromCsvRow)
 
-    pub def toJson(record: LapRecord): Json.JsonValue =
+    pub def toJson(rawLap: RawLap): Json.JsonValue =
         JsonObject(
-            ("carNumber",               JsonString(record#carNumber)) ::
-            ("driverNumber",            JsonInt(record#driverNumber)) ::
-            ("lapNumber",               JsonInt(record#lapNumber)) ::
-            ("lapTime",                 JsonString(record#lapTime)) ::
-            ("lapImprovement",          JsonInt(record#lapImprovement)) ::
-            ("crossingFinishLineInPit", JsonString(record#crossingFinishLineInPit)) ::
-            ("s1",                      JsonString(record#s1)) ::
-            ("s1Improvement",           JsonInt(record#s1Improvement)) ::
-            ("s2",                      JsonString(record#s2)) ::
-            ("s2Improvement",           JsonInt(record#s2Improvement)) ::
-            ("s3",                      JsonString(record#s3)) ::
-            ("s3Improvement",           JsonInt(record#s3Improvement)) ::
-            ("kph",                     kphValue(record#kph)) ::
-            ("elapsed",                 JsonString(record#elapsed)) ::
-            ("hour",                    JsonString(record#hour)) ::
-            ("topSpeed",                JsonString(record#topSpeed)) ::
-            ("driverName",              JsonString(record#driverName)) ::
-            ("pitTime",                 JsonString(record#pitTime)) ::
-            ("class",                   JsonString(record#class)) ::
-            ("group",                   JsonString(record#group)) ::
-            ("team",                    JsonString(record#team)) ::
-            ("manufacturer",            JsonString(record#manufacturer)) ::
+            ("carNumber",               JsonString(rawLap#carNumber)) ::
+            ("driverNumber",            JsonInt(rawLap#driverNumber)) ::
+            ("lapNumber",               JsonInt(rawLap#lapNumber)) ::
+            ("lapTime",                 JsonString(rawLap#lapTime)) ::
+            ("lapImprovement",          JsonInt(rawLap#lapImprovement)) ::
+            ("crossingFinishLineInPit", JsonString(rawLap#crossingFinishLineInPit)) ::
+            ("s1",                      JsonString(rawLap#s1)) ::
+            ("s1Improvement",           JsonInt(rawLap#s1Improvement)) ::
+            ("s2",                      JsonString(rawLap#s2)) ::
+            ("s2Improvement",           JsonInt(rawLap#s2Improvement)) ::
+            ("s3",                      JsonString(rawLap#s3)) ::
+            ("s3Improvement",           JsonInt(rawLap#s3Improvement)) ::
+            ("kph",                     kphValue(rawLap#kph)) ::
+            ("elapsed",                 JsonString(rawLap#elapsed)) ::
+            ("hour",                    JsonString(rawLap#hour)) ::
+            ("topSpeed",                JsonString(rawLap#topSpeed)) ::
+            ("driverName",              JsonString(rawLap#driverName)) ::
+            ("pitTime",                 JsonString(rawLap#pitTime)) ::
+            ("class",                   JsonString(rawLap#class)) ::
+            ("group",                   JsonString(rawLap#group)) ::
+            ("team",                    JsonString(rawLap#team)) ::
+            ("manufacturer",            JsonString(rawLap#manufacturer)) ::
             Nil
         )
 
-    pub def toJsonArray(records: List[LapRecord]): Json.JsonValue =
-        JsonArray(List.map(toJson, records))
+    pub def toJsonArray(rawLaps: List[RawLap]): Json.JsonValue =
+        JsonArray(List.map(toJson, rawLaps))
 
     /// 文字列が `.0` で終わっていればその2文字を落とす。それ以外はそのまま。
     /// 例: `"86.0"` -> `"86"`、`"116.3"` -> `"116.3"`、`""` -> `""`。
@@ -144,7 +144,9 @@ mod Lap {
                 }
         }
 
-    def parseInt(s: String): Int32 =
+    /// 10進整数としてパースし、失敗時は 0 を返す。`driverNumber` や
+    /// `lapImprovement` のような「空セル/不正値はゼロ扱い」の CSV 列で使う。
+    def parseIntOrZero(s: String): Int32 =
         match Int32.parse(10, s) {
             case Ok(n)  => n
             case Err(_) => 0

--- a/flix/src/Stages.flix
+++ b/flix/src/Stages.flix
@@ -1,4 +1,4 @@
-mod Pipeline {
+mod Stages {
 
     pub type alias Output = {
         lapCount = Int32,

--- a/flix/test/TestCsv.flix
+++ b/flix/test/TestCsv.flix
@@ -23,12 +23,35 @@ mod TestCsv {
         match Lap.fromCsvRow(row) {
             case Some(r) =>
                 Assert.assertTrue(r#carNumber == "12");
-                Assert.assertTrue(r#driverName == "Will STEVENS");
-                Assert.assertTrue(r#lapNumber == "3");
+                Assert.assertTrue(r#driverNumber == 1);
+                Assert.assertTrue(r#lapNumber == 3);
                 Assert.assertTrue(r#lapTime == "2:41.963");
+                Assert.assertTrue(r#lapImprovement == 0);
+                Assert.assertTrue(r#crossingFinishLineInPit == "");
+                Assert.assertTrue(r#s1 == "41.805");
+                Assert.assertTrue(r#s1Improvement == 0);
+                Assert.assertTrue(r#s2 == "1:03.483");
+                Assert.assertTrue(r#s3 == "56.675");
                 Assert.assertTrue(r#kph == "101.4");
+                Assert.assertTrue(r#elapsed == "6:10.938");
+                Assert.assertTrue(r#hour == "11:06:38.429");
+                Assert.assertTrue(r#topSpeed == "88.5");
+                Assert.assertTrue(r#driverName == "Will STEVENS");
+                Assert.assertTrue(r#pitTime == "");
                 Assert.assertTrue(r#class == "HYPERCAR");
-                Assert.assertTrue(r#team == "Hertz Team JOTA")
+                Assert.assertTrue(r#group == "H");
+                Assert.assertTrue(r#team == "Hertz Team JOTA");
+                Assert.assertTrue(r#manufacturer == "Porsche")
+            case None =>
+                Assert.assertTrue(false)
+        }
+
+    @Test
+    def testFromCsvRowStripsTopSpeedTrailingDotZero(): Unit \ Assert =
+        let row = Csv.parseRow("12;1;3;2:41.963;0;;41.805;0;1:03.483;0;56.675;0;101.4;6:10.938;11:06:38.429;0:41.805;1:03.483;0:56.675;150.0;Will STEVENS;;HYPERCAR;H;Hertz Team JOTA;Porsche;SF;41.805;63.483;56.675;");
+        match Lap.fromCsvRow(row) {
+            case Some(r) =>
+                Assert.assertTrue(r#topSpeed == "150")
             case None =>
                 Assert.assertTrue(false)
         }
@@ -42,6 +65,23 @@ mod TestCsv {
     def testFromCsvRowEmpty(): Unit \ Assert =
         let row = Csv.parseRow("");
         Assert.assertTrue(Option.isEmpty(Lap.fromCsvRow(row)))
+
+    @Test
+    def testStripTrailingDotZero(): Unit \ Assert =
+        Assert.assertTrue(Lap.stripTrailingDotZero("150.0") == "150");
+        Assert.assertTrue(Lap.stripTrailingDotZero("116.3") == "116.3");
+        Assert.assertTrue(Lap.stripTrailingDotZero("") == "")
+
+    @Test
+    def testKphValueWhole(): Unit \ Assert =
+        let v = Lap.kphValue("86.0");
+        Assert.assertTrue(String.contains({substr = "86"}, Json.render(v)));
+        Assert.assertTrue(not String.contains({substr = "."}, Json.render(v)))
+
+    @Test
+    def testKphValueDecimal(): Unit \ Assert =
+        let rendered = Json.render(Lap.kphValue("107.1"));
+        Assert.assertTrue(String.contains({substr = "107.1"}, rendered))
 
     @Test
     def testFromCsvRowsSkipsInvalid(): Unit \ Assert =

--- a/flix/test/TestCsv.flix
+++ b/flix/test/TestCsv.flix
@@ -20,7 +20,7 @@ mod TestCsv {
     @Test
     def testFromCsvRowValid(): Unit \ Assert =
         let row = Csv.parseRow("12;1;3;2:41.963;0;;41.805;0;1:03.483;0;56.675;0;101.4;6:10.938;11:06:38.429;0:41.805;1:03.483;0:56.675;88.5;Will STEVENS;;HYPERCAR;H;Hertz Team JOTA;Porsche;SF;41.805;63.483;56.675;");
-        match Lap.fromCsvRow(row) {
+        match RawLap.fromCsvRow(row) {
             case Some(r) =>
                 Assert.assertTrue(r#carNumber == "12");
                 Assert.assertTrue(r#driverNumber == 1);
@@ -49,7 +49,7 @@ mod TestCsv {
     @Test
     def testFromCsvRowStripsTopSpeedTrailingDotZero(): Unit \ Assert =
         let row = Csv.parseRow("12;1;3;2:41.963;0;;41.805;0;1:03.483;0;56.675;0;101.4;6:10.938;11:06:38.429;0:41.805;1:03.483;0:56.675;150.0;Will STEVENS;;HYPERCAR;H;Hertz Team JOTA;Porsche;SF;41.805;63.483;56.675;");
-        match Lap.fromCsvRow(row) {
+        match RawLap.fromCsvRow(row) {
             case Some(r) =>
                 Assert.assertTrue(r#topSpeed == "150")
             case None =>
@@ -59,20 +59,20 @@ mod TestCsv {
     @Test
     def testFromCsvRowShort(): Unit \ Assert =
         let row = Csv.parseRow("12;1;3");
-        Assert.assertTrue(Option.isEmpty(Lap.fromCsvRow(row)))
+        Assert.assertTrue(Option.isEmpty(RawLap.fromCsvRow(row)))
 
     @Test
     def testFromCsvRowEmpty(): Unit \ Assert =
         let row = Csv.parseRow("");
-        Assert.assertTrue(Option.isEmpty(Lap.fromCsvRow(row)))
+        Assert.assertTrue(Option.isEmpty(RawLap.fromCsvRow(row)))
 
     @Test
     def testToJsonRendersWholeKphAsInt(): Unit \ Assert =
         // kph (列12) "86.0" は JsonInt として "86" に整形される。
         let row = Csv.parseRow("12;1;3;2:41.963;0;;41.805;0;1:03.483;0;56.675;0;86.0;6:10.938;11:06:38.429;0:41.805;1:03.483;0:56.675;88.5;Will STEVENS;;HYPERCAR;H;Hertz Team JOTA;Porsche;SF;41.805;63.483;56.675;");
-        match Lap.fromCsvRow(row) {
+        match RawLap.fromCsvRow(row) {
             case Some(r) =>
-                let json = Json.render(Lap.toJson(r));
+                let json = Json.render(RawLap.toJson(r));
                 Assert.assertTrue(String.contains({substr = "\"kph\": 86,"}, json));
                 Assert.assertTrue(not String.contains({substr = "\"kph\": 86.0"}, json))
             case None =>
@@ -83,9 +83,9 @@ mod TestCsv {
     def testToJsonRendersDecimalKphAsFloat(): Unit \ Assert =
         // kph (列12) "107.1" は JsonFloat として "107.1" に整形される。
         let row = Csv.parseRow("12;1;3;2:41.963;0;;41.805;0;1:03.483;0;56.675;0;107.1;6:10.938;11:06:38.429;0:41.805;1:03.483;0:56.675;88.5;Will STEVENS;;HYPERCAR;H;Hertz Team JOTA;Porsche;SF;41.805;63.483;56.675;");
-        match Lap.fromCsvRow(row) {
+        match RawLap.fromCsvRow(row) {
             case Some(r) =>
-                let json = Json.render(Lap.toJson(r));
+                let json = Json.render(RawLap.toJson(r));
                 Assert.assertTrue(String.contains({substr = "\"kph\": 107.1"}, json))
             case None =>
                 Assert.assertTrue(false)
@@ -96,7 +96,7 @@ mod TestCsv {
         // pitTime (列20) に正規形でない "0:01:41.031" を仕込み、Duration.normalize が
         // fromCsvRow 経由で適用されて "1:41.031" になることを確認する。
         let row = Csv.parseRow("12;1;3;2:41.963;0;;41.805;0;1:03.483;0;56.675;0;101.4;6:10.938;11:06:38.429;0:41.805;1:03.483;0:56.675;88.5;Will STEVENS;0:01:41.031;HYPERCAR;H;Hertz Team JOTA;Porsche;SF;41.805;63.483;56.675;");
-        match Lap.fromCsvRow(row) {
+        match RawLap.fromCsvRow(row) {
             case Some(r) =>
                 Assert.assertTrue(r#pitTime == "1:41.031")
             case None =>
@@ -110,7 +110,7 @@ mod TestCsv {
             "short line" ::
             "7;1;1;1:35.421;0;;23.277;0;29.848;0;42.296;0;160.5;1:35.421;11:02:02.912;0:23.277;0:29.848;0:42.296;;Kamui KOBAYASHI;;HYPERCAR;H;Toyota Gazoo Racing;Toyota;GF;23.277;29.848;42.296;" ::
             Nil;
-        let records = lines |> Csv.parse |> Lap.fromCsvRows;
+        let records = lines |> Csv.parse |> RawLap.fromCsvRows;
         Assert.assertTrue(List.length(records) == 2);
         // 無効行スキップ後も最初のレコードは新フィールド (group/manufacturer) まで埋まっている。
         match List.head(records) {
@@ -128,7 +128,7 @@ mod TestCsv {
         // CSV 列18 (TOP_SPEED) が空の行 — 非ピットラップで頻出。`stripTrailingDotZero("")` が
         // 空文字列をそのまま返し、JSON 上も `"topSpeed": ""` になることを確認する。
         let row = Csv.parseRow("12;1;3;2:41.963;0;;41.805;0;1:03.483;0;56.675;0;101.4;6:10.938;11:06:38.429;0:41.805;1:03.483;0:56.675;;Will STEVENS;;HYPERCAR;H;Hertz Team JOTA;Porsche;SF;41.805;63.483;56.675;");
-        match Lap.fromCsvRow(row) {
+        match RawLap.fromCsvRow(row) {
             case Some(r) =>
                 Assert.assertTrue(r#topSpeed == "")
             case None =>
@@ -140,9 +140,9 @@ mod TestCsv {
         // kph が Int32/Float64 のいずれにもパースできない場合のフェイルセーフ経路。
         // kphValue は JsonString に落ち、`"kph": "not-a-number"` として出力される。
         let row = Csv.parseRow("12;1;3;2:41.963;0;;41.805;0;1:03.483;0;56.675;0;not-a-number;6:10.938;11:06:38.429;0:41.805;1:03.483;0:56.675;88.5;Will STEVENS;;HYPERCAR;H;Hertz Team JOTA;Porsche;SF;41.805;63.483;56.675;");
-        match Lap.fromCsvRow(row) {
+        match RawLap.fromCsvRow(row) {
             case Some(r) =>
-                let json = Json.render(Lap.toJson(r));
+                let json = Json.render(RawLap.toJson(r));
                 Assert.assertTrue(String.contains({substr = "\"kph\": \"not-a-number\""}, json))
             case None =>
                 Assert.assertTrue(false)

--- a/flix/test/TestCsv.flix
+++ b/flix/test/TestCsv.flix
@@ -67,18 +67,29 @@ mod TestCsv {
         Assert.assertTrue(Option.isEmpty(Lap.fromCsvRow(row)))
 
     @Test
-    def testStripTrailingDotZero(): Unit \ Assert =
-        Assert.assertTrue(Lap.stripTrailingDotZero("150.0") == "150");
-        Assert.assertTrue(Lap.stripTrailingDotZero("116.3") == "116.3");
-        Assert.assertTrue(Lap.stripTrailingDotZero("") == "")
+    def testToJsonRendersWholeKphAsInt(): Unit \ Assert =
+        // kph (列12) "86.0" は JsonInt として "86" に整形される。
+        let row = Csv.parseRow("12;1;3;2:41.963;0;;41.805;0;1:03.483;0;56.675;0;86.0;6:10.938;11:06:38.429;0:41.805;1:03.483;0:56.675;88.5;Will STEVENS;;HYPERCAR;H;Hertz Team JOTA;Porsche;SF;41.805;63.483;56.675;");
+        match Lap.fromCsvRow(row) {
+            case Some(r) =>
+                let json = Json.render(Lap.toJson(r));
+                Assert.assertTrue(String.contains({substr = "\"kph\": 86,"}, json));
+                Assert.assertTrue(not String.contains({substr = "\"kph\": 86.0"}, json))
+            case None =>
+                Assert.assertTrue(false)
+        }
 
     @Test
-    def testKphValueWhole(): Unit \ Assert =
-        Assert.assertTrue(Json.render(Lap.kphValue("86.0")) == "86")
-
-    @Test
-    def testKphValueDecimal(): Unit \ Assert =
-        Assert.assertTrue(Json.render(Lap.kphValue("107.1")) == "107.1")
+    def testToJsonRendersDecimalKphAsFloat(): Unit \ Assert =
+        // kph (列12) "107.1" は JsonFloat として "107.1" に整形される。
+        let row = Csv.parseRow("12;1;3;2:41.963;0;;41.805;0;1:03.483;0;56.675;0;107.1;6:10.938;11:06:38.429;0:41.805;1:03.483;0:56.675;88.5;Will STEVENS;;HYPERCAR;H;Hertz Team JOTA;Porsche;SF;41.805;63.483;56.675;");
+        match Lap.fromCsvRow(row) {
+            case Some(r) =>
+                let json = Json.render(Lap.toJson(r));
+                Assert.assertTrue(String.contains({substr = "\"kph\": 107.1"}, json))
+            case None =>
+                Assert.assertTrue(false)
+        }
 
     @Test
     def testFromCsvRowNormalizesPitTime(): Unit \ Assert =

--- a/flix/test/TestCsv.flix
+++ b/flix/test/TestCsv.flix
@@ -111,6 +111,41 @@ mod TestCsv {
             "7;1;1;1:35.421;0;;23.277;0;29.848;0;42.296;0;160.5;1:35.421;11:02:02.912;0:23.277;0:29.848;0:42.296;;Kamui KOBAYASHI;;HYPERCAR;H;Toyota Gazoo Racing;Toyota;GF;23.277;29.848;42.296;" ::
             Nil;
         let records = lines |> Csv.parse |> Lap.fromCsvRows;
-        Assert.assertTrue(List.length(records) == 2)
+        Assert.assertTrue(List.length(records) == 2);
+        // 無効行スキップ後も最初のレコードは新フィールド (group/manufacturer) まで埋まっている。
+        match List.head(records) {
+            case Some(r) =>
+                Assert.assertTrue(r#carNumber == "12");
+                Assert.assertTrue(r#driverNumber == 1);
+                Assert.assertTrue(r#group == "H");
+                Assert.assertTrue(r#manufacturer == "Porsche")
+            case None =>
+                Assert.assertTrue(false)
+        }
+
+    @Test
+    def testFromCsvRowEmptyTopSpeed(): Unit \ Assert =
+        // CSV 列18 (TOP_SPEED) が空の行 — 非ピットラップで頻出。`stripTrailingDotZero("")` が
+        // 空文字列をそのまま返し、JSON 上も `"topSpeed": ""` になることを確認する。
+        let row = Csv.parseRow("12;1;3;2:41.963;0;;41.805;0;1:03.483;0;56.675;0;101.4;6:10.938;11:06:38.429;0:41.805;1:03.483;0:56.675;;Will STEVENS;;HYPERCAR;H;Hertz Team JOTA;Porsche;SF;41.805;63.483;56.675;");
+        match Lap.fromCsvRow(row) {
+            case Some(r) =>
+                Assert.assertTrue(r#topSpeed == "")
+            case None =>
+                Assert.assertTrue(false)
+        }
+
+    @Test
+    def testToJsonHandlesUnparseableKphAsString(): Unit \ Assert =
+        // kph が Int32/Float64 のいずれにもパースできない場合のフェイルセーフ経路。
+        // kphValue は JsonString に落ち、`"kph": "not-a-number"` として出力される。
+        let row = Csv.parseRow("12;1;3;2:41.963;0;;41.805;0;1:03.483;0;56.675;0;not-a-number;6:10.938;11:06:38.429;0:41.805;1:03.483;0:56.675;88.5;Will STEVENS;;HYPERCAR;H;Hertz Team JOTA;Porsche;SF;41.805;63.483;56.675;");
+        match Lap.fromCsvRow(row) {
+            case Some(r) =>
+                let json = Json.render(Lap.toJson(r));
+                Assert.assertTrue(String.contains({substr = "\"kph\": \"not-a-number\""}, json))
+            case None =>
+                Assert.assertTrue(false)
+        }
 
 }

--- a/flix/test/TestCsv.flix
+++ b/flix/test/TestCsv.flix
@@ -74,14 +74,23 @@ mod TestCsv {
 
     @Test
     def testKphValueWhole(): Unit \ Assert =
-        let v = Lap.kphValue("86.0");
-        Assert.assertTrue(String.contains({substr = "86"}, Json.render(v)));
-        Assert.assertTrue(not String.contains({substr = "."}, Json.render(v)))
+        Assert.assertTrue(Json.render(Lap.kphValue("86.0")) == "86")
 
     @Test
     def testKphValueDecimal(): Unit \ Assert =
-        let rendered = Json.render(Lap.kphValue("107.1"));
-        Assert.assertTrue(String.contains({substr = "107.1"}, rendered))
+        Assert.assertTrue(Json.render(Lap.kphValue("107.1")) == "107.1")
+
+    @Test
+    def testFromCsvRowNormalizesPitTime(): Unit \ Assert =
+        // pitTime (列20) に正規形でない "0:01:41.031" を仕込み、Duration.normalize が
+        // fromCsvRow 経由で適用されて "1:41.031" になることを確認する。
+        let row = Csv.parseRow("12;1;3;2:41.963;0;;41.805;0;1:03.483;0;56.675;0;101.4;6:10.938;11:06:38.429;0:41.805;1:03.483;0:56.675;88.5;Will STEVENS;0:01:41.031;HYPERCAR;H;Hertz Team JOTA;Porsche;SF;41.805;63.483;56.675;");
+        match Lap.fromCsvRow(row) {
+            case Some(r) =>
+                Assert.assertTrue(r#pitTime == "1:41.031")
+            case None =>
+                Assert.assertTrue(false)
+        }
 
     @Test
     def testFromCsvRowsSkipsInvalid(): Unit \ Assert =

--- a/flix/test/TestDuration.flix
+++ b/flix/test/TestDuration.flix
@@ -1,0 +1,45 @@
+mod TestDuration {
+
+    @Test
+    def testParseSecondsOnly(): Unit \ Assert =
+        Assert.assertTrue(Duration.parse("23.155") == Some(23155))
+
+    @Test
+    def testParseMinutesSeconds(): Unit \ Assert =
+        Assert.assertTrue(Duration.parse("1:35.365") == Some(95365))
+
+    @Test
+    def testParseHoursMinutesSeconds(): Unit \ Assert =
+        Assert.assertTrue(Duration.parse("0:01:41.031") == Some(101031))
+
+    @Test
+    def testParseInvalid(): Unit \ Assert =
+        Assert.assertTrue(Duration.parse("not-a-duration") == None)
+
+    @Test
+    def testFormatSecondsOnly(): Unit \ Assert =
+        Assert.assertTrue(Duration.format(23155) == "23.155")
+
+    @Test
+    def testFormatMinutesSeconds(): Unit \ Assert =
+        Assert.assertTrue(Duration.format(95365) == "1:35.365")
+
+    @Test
+    def testFormatHoursMinutesSeconds(): Unit \ Assert =
+        Assert.assertTrue(Duration.format(3725001) == "1:02:05.001")
+
+    @Test
+    def testNormalizeStripsLeadingZeroSegments(): Unit \ Assert =
+        Assert.assertTrue(Duration.normalize("0:01:41.031") == "1:41.031");
+        Assert.assertTrue(Duration.normalize("0:00:48.666") == "48.666")
+
+    @Test
+    def testNormalizeKeepsCanonical(): Unit \ Assert =
+        Assert.assertTrue(Duration.normalize("3:38.404") == "3:38.404");
+        Assert.assertTrue(Duration.normalize("23.155") == "23.155")
+
+    @Test
+    def testNormalizeEmpty(): Unit \ Assert =
+        Assert.assertTrue(Duration.normalize("") == "")
+
+}

--- a/flix/test/TestDuration.flix
+++ b/flix/test/TestDuration.flix
@@ -1,45 +1,31 @@
 mod TestDuration {
 
     @Test
-    def testParseSecondsOnly(): Unit \ Assert =
-        Assert.assertTrue(Duration.parse("23.155") == Some(23155))
-
-    @Test
-    def testParseMinutesSeconds(): Unit \ Assert =
-        Assert.assertTrue(Duration.parse("1:35.365") == Some(95365))
-
-    @Test
-    def testParseHoursMinutesSeconds(): Unit \ Assert =
-        Assert.assertTrue(Duration.parse("0:01:41.031") == Some(101031))
-
-    @Test
-    def testParseInvalid(): Unit \ Assert =
-        Assert.assertTrue(Duration.parse("not-a-duration") == None)
-
-    @Test
-    def testFormatSecondsOnly(): Unit \ Assert =
-        Assert.assertTrue(Duration.format(23155) == "23.155")
-
-    @Test
-    def testFormatMinutesSeconds(): Unit \ Assert =
-        Assert.assertTrue(Duration.format(95365) == "1:35.365")
-
-    @Test
-    def testFormatHoursMinutesSeconds(): Unit \ Assert =
-        Assert.assertTrue(Duration.format(3725001) == "1:02:05.001")
-
-    @Test
-    def testNormalizeStripsLeadingZeroSegments(): Unit \ Assert =
-        Assert.assertTrue(Duration.normalize("0:01:41.031") == "1:41.031");
-        Assert.assertTrue(Duration.normalize("0:00:48.666") == "48.666")
-
-    @Test
-    def testNormalizeKeepsCanonical(): Unit \ Assert =
-        Assert.assertTrue(Duration.normalize("3:38.404") == "3:38.404");
+    def testNormalizeKeepsSecondsOnly(): Unit \ Assert =
         Assert.assertTrue(Duration.normalize("23.155") == "23.155")
+
+    @Test
+    def testNormalizeKeepsMinutesSeconds(): Unit \ Assert =
+        Assert.assertTrue(Duration.normalize("3:38.404") == "3:38.404")
+
+    @Test
+    def testNormalizeKeepsHoursMinutesSeconds(): Unit \ Assert =
+        Assert.assertTrue(Duration.normalize("1:02:05.001") == "1:02:05.001")
+
+    @Test
+    def testNormalizeStripsLeadingZeroHour(): Unit \ Assert =
+        Assert.assertTrue(Duration.normalize("0:01:41.031") == "1:41.031")
+
+    @Test
+    def testNormalizeStripsLeadingZeroHourAndMinute(): Unit \ Assert =
+        Assert.assertTrue(Duration.normalize("0:00:48.666") == "48.666")
 
     @Test
     def testNormalizeEmpty(): Unit \ Assert =
         Assert.assertTrue(Duration.normalize("") == "")
+
+    @Test
+    def testNormalizeInvalidPassthrough(): Unit \ Assert =
+        Assert.assertTrue(Duration.normalize("not-a-duration") == "not-a-duration")
 
 }


### PR DESCRIPTION
## Summary
This PR significantly expands the lap data processing pipeline by introducing a new `RawLap` module that captures all 22 fields from the CSV format (matching the Rust CLI's output structure), replacing the minimal `Lap` module. It also adds a `Duration` module for normalizing time duration strings to canonical form, and refactors the pipeline orchestration.

## Key Changes

- **New `RawLap` module** (`flix/src/RawLap.flix`):
  - Defines a 22-field record type matching the Rust CLI's `RawLap` structure with camelCase keys
  - Implements `fromCsvRow()` to parse CSV rows with proper type conversions (Int32 for numeric fields, Duration normalization for time fields)
  - Implements `toJson()` to serialize to JSON with intelligent type handling (e.g., KPH as Int/Float/String depending on value)
  - Includes helper functions: `stripTrailingDotZero()` for numeric formatting and `kphValue()` for smart KPH type conversion

- **New `Duration` module** (`flix/src/Duration.flix`):
  - Parses time strings in `H:MM:SS.sss`, `MM:SS.sss`, or `SS.sss` formats to milliseconds
  - Formats milliseconds back to canonical form (strips leading zero hours/minutes)
  - Public API: `normalize()` function that parses and re-formats for canonical representation
  - Handles edge cases: empty strings and unparseable input pass through unchanged (fail-safe)

- **Replaced `Lap` module** with `RawLap`:
  - Old `Lap` extracted only 7 fields; new `RawLap` captures all 25 CSV columns
  - Proper type conversions: `driverNumber` and `lapNumber` are now Int32 instead of String
  - Duration fields (`lapTime`, `s1`, `s2`, `s3`, `elapsed`, `pitTime`) are normalized
  - Added new fields: `lapImprovement`, `crossingFinishLineInPit`, `s1Improvement`, `s2Improvement`, `s3Improvement`, `topSpeed`, `group`, `manufacturer`

- **Renamed `Pipeline` to `Stages`** (`flix/src/Stages.flix`):
  - Updated to use `RawLap.fromCsvRows()` instead of `Lap.fromCsvRows()`
  - Output type renamed from `Result` to `Output` for clarity

- **Comprehensive test coverage** (`flix/test/TestCsv.flix` and `flix/test/TestDuration.flix`):
  - Tests for Duration normalization (leading zero stripping, various formats)
  - Tests for RawLap field extraction and type conversion
  - Tests for KPH smart type handling (Int for whole numbers, Float for decimals, String for unparseable)
  - Tests for edge cases (empty fields, invalid input, trailing `.0` stripping)

## Notable Implementation Details

- **Fail-safe design**: Duration parsing and KPH conversion gracefully handle invalid input by passing through original strings
- **Smart numeric formatting**: KPH values ending in `.0` are converted to integers in JSON; decimal values remain floats
- **CSV column mapping**: Carefully maps 25 CSV columns to 22 output fields, skipping columns 15-17 (duplicate sector times)
- **Canonical duration format**: Follows Rust CLI rules—1+ hours use `H:MM:SS.sss`, 1+ minutes use `M:SS.sss`, otherwise `S.sss`