### PR TITLE
refactor: fix JSON fixture decoder and update benchmark event generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "start": "pnpm --filter app start",
     "build": "pnpm --filter app build",
     "test": "pnpm --filter package test",
-    "benchmark": "pnpm --filter cli benchmark"
+    "benchmark": "pnpm --filter package benchmark"
   },
   "pnpm": {
     "ignoredBuiltDependencies": [

--- a/package/benchmark/UpdateCarsBenchmark.elm
+++ b/package/benchmark/UpdateCarsBenchmark.elm
@@ -4,7 +4,7 @@ import Benchmark exposing (Benchmark, describe)
 import Benchmark.Runner exposing (BenchmarkProgram, program)
 import Fixture.Json as Fixture
 import List.Extra
-import Motorsport.Car exposing (Car, Status(..))
+import Motorsport.Car exposing (Car)
 import Motorsport.Duration exposing (Duration)
 import Motorsport.Lap as Lap
 import Motorsport.RaceControl as RaceControl
@@ -26,24 +26,7 @@ suite =
             calcTimeLimit cars
     in
     describe "RaceControl.updateCars" <|
-        [ Benchmark.scale "old"
-            ([ 25 -- 5,338
-             , 50 -- 5,282
-             , 75 -- 5,186
-             ]
-                |> List.map
-                    (\size ->
-                        ( String.fromInt size ++ "%"
-                        , \_ ->
-                            let
-                                clock =
-                                    { elapsed = floor (toFloat timeLimit * toFloat size / 100) }
-                            in
-                            updateCars timeLimit clock cars
-                        )
-                    )
-            )
-        , Benchmark.scale "new"
+        [ Benchmark.scale "new"
             ([ 25 -- 10,812
              , 50 -- 10,994
              , 75 -- 12,744
@@ -68,75 +51,6 @@ suite =
                     )
             )
         ]
-
-
-
--- OLD
-
-
-updateCars : Duration -> { elapsed : Duration } -> List Car -> List Car
-updateCars timeLimit raceClock cars =
-    cars
-        |> List.map (updateWithClock { elapsed = raceClock.elapsed, timeLimit = timeLimit })
-        |> List.sortWith
-            (\a b ->
-                Maybe.map2 (Lap.compareAt raceClock) a.currentLap b.currentLap
-                    |> Maybe.withDefault EQ
-            )
-
-
-updateWithClock : { elapsed : Duration, timeLimit : Duration } -> Car -> Car
-updateWithClock raceClock car =
-    { car
-        | currentLap = Lap.findCurrentLap { elapsed = raceClock.elapsed } car.laps
-        , lastLap = Lap.findLastLapAt { elapsed = raceClock.elapsed } car.laps
-    }
-        |> (\updatedCar ->
-                { updatedCar
-                    | status =
-                        case ( updatedCar.status, hasCompletedAllLaps raceClock updatedCar, isOnFinalLap raceClock updatedCar ) of
-                            ( PreRace, _, _ ) ->
-                                Racing
-
-                            ( Racing, True, True ) ->
-                                Checkered
-
-                            ( Racing, True, False ) ->
-                                Retired
-
-                            ( Racing, False, _ ) ->
-                                Racing
-
-                            ( Checkered, _, _ ) ->
-                                Checkered
-
-                            ( Retired, _, _ ) ->
-                                Retired
-
-                            ( InPit, _, _ ) ->
-                                InPit
-                }
-           )
-
-
-isOnFinalLap : { elapsed : Duration, timeLimit : Duration } -> Car -> Bool
-isOnFinalLap raceClock car =
-    let
-        finishedAfterTimeLimit =
-            raceClock.timeLimit <= raceClock.elapsed
-
-        hasReachedFinalLap =
-            Maybe.map2 (==) car.currentLap (List.Extra.last car.laps)
-                |> Maybe.withDefault False
-    in
-    hasReachedFinalLap && finishedAfterTimeLimit
-
-
-hasCompletedAllLaps : { a | elapsed : Duration } -> Car -> Bool
-hasCompletedAllLaps raceClock car =
-    List.Extra.last car.laps
-        |> Maybe.map (\finalLap -> finalLap.elapsed <= raceClock.elapsed)
-        |> Maybe.withDefault False
 
 
 

--- a/package/benchmark/UpdateCarsBenchmark.elm
+++ b/package/benchmark/UpdateCarsBenchmark.elm
@@ -4,7 +4,7 @@ import Benchmark exposing (Benchmark, describe)
 import Benchmark.Runner exposing (BenchmarkProgram, program)
 import Fixture.Json as Fixture
 import List.Extra
-import Motorsport.Car exposing (Car)
+import Motorsport.Car exposing (Car, Status(..))
 import Motorsport.Duration exposing (Duration)
 import Motorsport.Lap as Lap
 import Motorsport.RaceControl as RaceControl
@@ -26,7 +26,24 @@ suite =
             calcTimeLimit cars
     in
     describe "RaceControl.updateCars" <|
-        [ Benchmark.scale "new"
+        [ Benchmark.scale "old"
+            ([ 25 -- 5,338
+             , 50 -- 5,282
+             , 75 -- 5,186
+             ]
+                |> List.map
+                    (\size ->
+                        ( String.fromInt size ++ "%"
+                        , \_ ->
+                            let
+                                clock =
+                                    { elapsed = floor (toFloat timeLimit * toFloat size / 100) }
+                            in
+                            updateCars timeLimit clock cars
+                        )
+                    )
+            )
+        , Benchmark.scale "new"
             ([ 25 -- 10,812
              , 50 -- 10,994
              , 75 -- 12,744
@@ -51,6 +68,75 @@ suite =
                     )
             )
         ]
+
+
+
+-- OLD
+
+
+updateCars : Duration -> { elapsed : Duration } -> List Car -> List Car
+updateCars timeLimit raceClock cars =
+    cars
+        |> List.map (updateWithClock { elapsed = raceClock.elapsed, timeLimit = timeLimit })
+        |> List.sortWith
+            (\a b ->
+                Maybe.map2 (Lap.compareAt raceClock) a.currentLap b.currentLap
+                    |> Maybe.withDefault EQ
+            )
+
+
+updateWithClock : { elapsed : Duration, timeLimit : Duration } -> Car -> Car
+updateWithClock raceClock car =
+    { car
+        | currentLap = Lap.findCurrentLap { elapsed = raceClock.elapsed } car.laps
+        , lastLap = Lap.findLastLapAt { elapsed = raceClock.elapsed } car.laps
+    }
+        |> (\updatedCar ->
+                { updatedCar
+                    | status =
+                        case ( updatedCar.status, hasCompletedAllLaps raceClock updatedCar, isOnFinalLap raceClock updatedCar ) of
+                            ( PreRace, _, _ ) ->
+                                Racing
+
+                            ( Racing, True, True ) ->
+                                Checkered
+
+                            ( Racing, True, False ) ->
+                                Retired
+
+                            ( Racing, False, _ ) ->
+                                Racing
+
+                            ( Checkered, _, _ ) ->
+                                Checkered
+
+                            ( Retired, _, _ ) ->
+                                Retired
+
+                            ( InPit, _, _ ) ->
+                                InPit
+                }
+           )
+
+
+isOnFinalLap : { elapsed : Duration, timeLimit : Duration } -> Car -> Bool
+isOnFinalLap raceClock car =
+    let
+        finishedAfterTimeLimit =
+            raceClock.timeLimit <= raceClock.elapsed
+
+        hasReachedFinalLap =
+            Maybe.map2 (==) car.currentLap (List.Extra.last car.laps)
+                |> Maybe.withDefault False
+    in
+    hasReachedFinalLap && finishedAfterTimeLimit
+
+
+hasCompletedAllLaps : { a | elapsed : Duration } -> Car -> Bool
+hasCompletedAllLaps raceClock car =
+    List.Extra.last car.laps
+        |> Maybe.map (\finalLap -> finalLap.elapsed <= raceClock.elapsed)
+        |> Maybe.withDefault False
 
 
 

--- a/package/benchmark/UpdateCarsBenchmark.elm
+++ b/package/benchmark/UpdateCarsBenchmark.elm
@@ -8,6 +8,7 @@ import Motorsport.Car exposing (Car, Status(..))
 import Motorsport.Duration exposing (Duration)
 import Motorsport.Lap as Lap
 import Motorsport.RaceControl as RaceControl
+import Motorsport.TimelineEvent as TimelineEvent
 
 
 main : BenchmarkProgram
@@ -47,7 +48,7 @@ suite =
              , 50 -- 10,994
              , 75 -- 12,744
              ]
-                |> List.map (\size -> ( size, RaceControl.calcEvents timeLimit cars ))
+                |> List.map (\size -> ( size, TimelineEvent.fromCars cars ))
                 |> List.map
                     (\( size, events ) ->
                         ( String.fromInt size ++ "%"

--- a/package/benchmark/UpdateCarsBenchmark.elm
+++ b/package/benchmark/UpdateCarsBenchmark.elm
@@ -112,6 +112,9 @@ updateWithClock raceClock car =
 
                             ( Retired, _, _ ) ->
                                 Retired
+
+                            ( InPit, _, _ ) ->
+                                InPit
                 }
            )
 


### PR DESCRIPTION
## Summary
This PR refactors the JSON fixture decoder to extract car information directly from lap data and updates the benchmark suite to use the new timeline event generation API.

## Key Changes

- **Fixture JSON Decoder Refactoring**
  - Replaced dependency on `Data.Wec.eventDecoder` with a custom `fixtureDecoder` that extracts car data from lap information
  - Implemented `LapCarInfo` type to capture car metadata from lap records (car number, driver, class, group, team, manufacturer)
  - Added `extractCars` function that aggregates lap data by car number and collects unique drivers per car
  - Created `toPlaceholderCar` helper to convert aggregated car data into `Car` objects using `Car.fromStartingGrid`
  - Updated imports to include necessary decoders and types (`Laps`, `Class`, `Driver`, `Manufacturer`)

- **Benchmark Updates**
  - Changed event generation from `RaceControl.calcEvents` to `TimelineEvent.fromCars` for consistency with updated API
  - Added missing `InPit` status case in the `updateWithClock` function to handle pit stop scenarios

- **Build Configuration**
  - Fixed benchmark script to run from the `package` filter instead of `cli` filter in package.json

## Implementation Details

The new fixture decoder uses a two-step approach:
1. Decodes lap data and car information from the JSON fixture
2. Aggregates car information by car number, deduplicating drivers while preserving other car attributes
3. Converts the aggregated data into `Car` objects with placeholder starting grid positions

This approach allows the fixture to be more flexible and maintainable by deriving car data from lap records rather than maintaining separate car definitions.

https://claude.ai/code/session_01XpiVv8saN77SjYJ8RsJHyG