### PR TITLE
Refactor CLI argument parsing to use GetOpt library

### DIFF
--- a/flix/src/Cli/Args.flix
+++ b/flix/src/Cli/Args.flix
@@ -2,9 +2,9 @@ mod Cli.Args {
 
     pub enum ArgsError with ToString {
         case MissingInputPath
-        case MissingOutputValue
+        case UnexpectedArguments(List[String])
         case DuplicateOutput
-        case UnexpectedArgument(String)
+        case ParseErrors(List[String])
     }
 
     pub type alias ParsedArgs = {
@@ -12,41 +12,42 @@ mod Cli.Args {
         outputFile = Option[String]
     }
 
-    enum ParseState {
-        case Ready(Option[String], Option[String])
-        case ExpectingOutputValue(Option[String])
+    enum CliOption {
+        case Output(String)
     }
 
+    def optionDescrs(): List[GetOpt.OptionDescr[CliOption]] =
+        {
+            optionIds     = Nil,
+            optionNames   = "output" :: Nil,
+            argDescriptor = GetOpt.ArgDescr.ReqArg(s -> Some(CliOption.Output(s)), "<file>"),
+            explanation   = "write metadata JSON to <file>"
+        } :: Nil
+
     pub def parse(args: List[String]): Result[ArgsError, ParsedArgs] =
-        let finalState = List.foldLeft((acc, arg) ->
-            Result.flatMap(st -> step(st, arg), acc),
-            Ok(ParseState.Ready(None, None)),
-            args
-        );
-        finalState |> Result.flatMap(resolve)
-
-    def step(state: ParseState, arg: String): Result[ArgsError, ParseState] =
-        match state {
-            case ParseState.ExpectingOutputValue(input) =>
-                Ok(ParseState.Ready(input, Some(arg)))
-            case ParseState.Ready(input, None) if arg == "--output" =>
-                Ok(ParseState.ExpectingOutputValue(input))
-            case ParseState.Ready(_, Some(_)) if arg == "--output" =>
-                Err(ArgsError.DuplicateOutput)
-            case ParseState.Ready(None, output) =>
-                Ok(ParseState.Ready(Some(arg), output))
-            case ParseState.Ready(Some(_), _) =>
-                Err(ArgsError.UnexpectedArgument(arg))
+        match GetOpt.getOpt(GetOpt.ArgOrder.Permute, optionDescrs(), args) {
+            case Validation.Failure(errors) =>
+                Err(ArgsError.ParseErrors(Nec.toList(errors)))
+            case Validation.Success(result) =>
+                let outputs = List.filterMap(opt -> match opt {
+                    case CliOption.Output(p) => Some(p)
+                }, result#options);
+                let outputFile = match outputs {
+                    case Nil      => Ok(None)
+                    case p :: Nil => Ok(Some(p))
+                    case _        => Err(ArgsError.DuplicateOutput)
+                };
+                Result.flatMap(out ->
+                    match result#nonOptions {
+                        case input :: Nil => Ok({ inputPath = input, outputFile = out })
+                        case Nil          => Err(ArgsError.MissingInputPath)
+                        case extras       => Err(ArgsError.UnexpectedArguments(extras))
+                    },
+                    outputFile
+                )
         }
 
-    def resolve(state: ParseState): Result[ArgsError, ParsedArgs] =
-        match state {
-            case ParseState.Ready(Some(input), output) =>
-                Ok({ inputPath = input, outputFile = output })
-            case ParseState.Ready(None, _) =>
-                Err(ArgsError.MissingInputPath)
-            case ParseState.ExpectingOutputValue(_) =>
-                Err(ArgsError.MissingOutputValue)
-        }
+    pub def usageInfo(): String =
+        GetOpt.usageInfo("Usage: flix-run <input.csv|dir>", optionDescrs())
 
 }

--- a/flix/src/Cli/Args.flix
+++ b/flix/src/Cli/Args.flix
@@ -25,26 +25,30 @@ mod Cli.Args {
         } :: Nil
 
     pub def parse(args: List[String]): Result[ArgsError, ParsedArgs] =
+        forM(
+            result <- getOptResult(args);
+            out    <- extractOutput(result#options);
+            input  <- extractInput(result#nonOptions)
+        ) yield { inputPath = input, outputFile = out }
+
+    def getOptResult(args: List[String]): Result[ArgsError, {options = List[CliOption], nonOptions = List[String]}] =
         match GetOpt.getOpt(GetOpt.ArgOrder.Permute, optionDescrs(), args) {
-            case Validation.Failure(errors) =>
-                Err(ArgsError.ParseErrors(Nec.toList(errors)))
-            case Validation.Success(result) =>
-                let outputs = List.filterMap(opt -> match opt {
-                    case CliOption.Output(p) => Some(p)
-                }, result#options);
-                let outputFile = match outputs {
-                    case Nil      => Ok(None)
-                    case p :: Nil => Ok(Some(p))
-                    case _        => Err(ArgsError.DuplicateOutput)
-                };
-                Result.flatMap(out ->
-                    match result#nonOptions {
-                        case input :: Nil => Ok({ inputPath = input, outputFile = out })
-                        case Nil          => Err(ArgsError.MissingInputPath)
-                        case extras       => Err(ArgsError.UnexpectedArguments(extras))
-                    },
-                    outputFile
-                )
+            case Validation.Failure(errors) => Err(ArgsError.ParseErrors(Nec.toList(errors)))
+            case Validation.Success(result) => Ok(result)
+        }
+
+    def extractOutput(opts: List[CliOption]): Result[ArgsError, Option[String]] =
+        match opts {
+            case Nil                        => Ok(None)
+            case CliOption.Output(p) :: Nil => Ok(Some(p))
+            case _                          => Err(ArgsError.DuplicateOutput)
+        }
+
+    def extractInput(nonOptions: List[String]): Result[ArgsError, String] =
+        match nonOptions {
+            case input :: Nil => Ok(input)
+            case Nil          => Err(ArgsError.MissingInputPath)
+            case extras       => Err(ArgsError.UnexpectedArguments(extras))
         }
 
     pub def usageInfo(): String =

--- a/flix/src/Main.flix
+++ b/flix/src/Main.flix
@@ -9,7 +9,7 @@ def main(): Unit \ {Env, IO, Exit, Console} =
     let code = match Args.parse(Env.getArgs()) {
         case Err(e) =>
             Console.eprintln("Error: ${e}");
-            Console.eprintln("Usage: flix-run <input.csv|dir> [--output <output.json>]");
+            Console.eprintln(Args.usageInfo());
             1
         case Ok(parsed) =>
             match FileTask.resolve(parsed) {

--- a/flix/src/Util/Files.flix
+++ b/flix/src/Util/Files.flix
@@ -4,7 +4,7 @@ mod Util.Files {
         case ReadError(String, String)   // path, underlying message
         case WriteError(String, String)
         case AccessError(String)         // failure to obtain path stat / existence
-        case ListDirError(String)
+        case GlobError(String)
     }
 
     pub def readLines(path: String): Result[FileError, List[String]] \ IO =
@@ -29,30 +29,9 @@ mod Util.Files {
         Fs.FileStat.runWithIO(() -> Fs.FileStat.isDirectory(path))
             |> Result.mapErr(e -> FileError.AccessError("${e}"))
 
-    def listDir(path: String): Result[FileError, List[String]] \ IO =
-        Fs.DirList.runWithIO(() -> Fs.DirList.list(path))
-            |> Result.mapErr(e -> FileError.ListDirError("${e}"))
-
-    /// Recursively walks the given directory and returns every path ending in `.csv`.
-    /// Descends into subdirectories without a depth limit.
+    /// Recursively finds every `.csv` file under `dirPath`.
     pub def walkCsvFiles(dirPath: String): Result[FileError, List[String]] \ IO =
-        forM(
-            entries <- listDir(dirPath);
-            result  <- gatherCsvs(dirPath, entries)
-        ) yield result
-
-    def gatherCsvs(dirPath: String, entries: List[String]): Result[FileError, List[String]] \ IO =
-        match entries {
-            case Nil => Ok(Nil)
-            case e :: rest =>
-                let fullPath = "${dirPath}/${e}";
-                forM(
-                    isDir <- isDirectory(fullPath);
-                    head  <- if (isDir) walkCsvFiles(fullPath)
-                             else if (String.endsWith({suffix = ".csv"}, fullPath)) Ok(fullPath :: Nil)
-                             else Ok(Nil);
-                    tail  <- gatherCsvs(dirPath, rest)
-                ) yield List.append(head, tail)
-        }
+        Fs.Glob.runWithIO(() -> Fs.Glob.glob(dirPath, "**/*.csv"))
+            |> Result.mapErr(e -> FileError.GlobError("${e}"))
 
 }

--- a/flix/src/Util/Files.flix
+++ b/flix/src/Util/Files.flix
@@ -4,7 +4,7 @@ mod Util.Files {
         case ReadError(String, String)   // path, underlying message
         case WriteError(String, String)
         case AccessError(String)         // failure to obtain path stat / existence
-        case GlobError(String)
+        case ListDirError(String)
     }
 
     pub def readLines(path: String): Result[FileError, List[String]] \ IO =
@@ -29,9 +29,29 @@ mod Util.Files {
         Fs.FileStat.runWithIO(() -> Fs.FileStat.isDirectory(path))
             |> Result.mapErr(e -> FileError.AccessError("${e}"))
 
-    /// Recursively finds every `.csv` file under `dirPath`.
+    def listDir(path: String): Result[FileError, List[String]] \ IO =
+        Fs.DirList.runWithIO(() -> Fs.DirList.list(path))
+            |> Result.mapErr(e -> FileError.ListDirError("${e}"))
+
+    /// Recursively walks the given directory and returns every path ending in `.csv`.
     pub def walkCsvFiles(dirPath: String): Result[FileError, List[String]] \ IO =
-        Fs.Glob.runWithIO(() -> Fs.Glob.glob(dirPath, "**/*.csv"))
-            |> Result.mapErr(e -> FileError.GlobError("${e}"))
+        forM(
+            entries <- listDir(dirPath);
+            result  <- gatherCsvs(dirPath, entries)
+        ) yield result
+
+    def gatherCsvs(dirPath: String, entries: List[String]): Result[FileError, List[String]] \ IO =
+        match entries {
+            case Nil => Ok(Nil)
+            case e :: rest =>
+                let fullPath = "${dirPath}/${e}";
+                forM(
+                    isDir <- isDirectory(fullPath);
+                    head  <- if (isDir) walkCsvFiles(fullPath)
+                             else if (String.endsWith({suffix = ".csv"}, fullPath)) Ok(fullPath :: Nil)
+                             else Ok(Nil);
+                    tail  <- gatherCsvs(dirPath, rest)
+                ) yield List.append(head, tail)
+        }
 
 }

--- a/flix/src/Util/Files.flix
+++ b/flix/src/Util/Files.flix
@@ -4,7 +4,7 @@ mod Util.Files {
         case ReadError(String, String)   // path, underlying message
         case WriteError(String, String)
         case AccessError(String)         // failure to obtain path stat / existence
-        case ListDirError(String)
+        case GlobError(String)
     }
 
     pub def readLines(path: String): Result[FileError, List[String]] \ IO =
@@ -29,29 +29,10 @@ mod Util.Files {
         Fs.FileStat.runWithIO(() -> Fs.FileStat.isDirectory(path))
             |> Result.mapErr(e -> FileError.AccessError("${e}"))
 
-    def listDir(path: String): Result[FileError, List[String]] \ IO =
-        Fs.DirList.runWithIO(() -> Fs.DirList.list(path))
-            |> Result.mapErr(e -> FileError.ListDirError("${e}"))
-
-    /// Recursively walks the given directory and returns every path ending in `.csv`.
+    /// Recursively finds every `.csv` file under `dirPath`.
+    /// Uses `{*.csv,**/*.csv}` to match both direct children and nested files.
     pub def walkCsvFiles(dirPath: String): Result[FileError, List[String]] \ IO =
-        forM(
-            entries <- listDir(dirPath);
-            result  <- gatherCsvs(dirPath, entries)
-        ) yield result
-
-    def gatherCsvs(dirPath: String, entries: List[String]): Result[FileError, List[String]] \ IO =
-        match entries {
-            case Nil => Ok(Nil)
-            case e :: rest =>
-                let fullPath = "${dirPath}/${e}";
-                forM(
-                    isDir <- isDirectory(fullPath);
-                    head  <- if (isDir) walkCsvFiles(fullPath)
-                             else if (String.endsWith({suffix = ".csv"}, fullPath)) Ok(fullPath :: Nil)
-                             else Ok(Nil);
-                    tail  <- gatherCsvs(dirPath, rest)
-                ) yield List.append(head, tail)
-        }
+        Fs.Glob.runWithIO(() -> Fs.Glob.glob(dirPath, "{*.csv,**/*.csv}"))
+            |> Result.mapErr(e -> FileError.GlobError("${e}"))
 
 }

--- a/flix/src/Util/Json.flix
+++ b/flix/src/Util/Json.flix
@@ -10,32 +10,63 @@ mod Util.Json {
         case JsonObject(List[(String, JsonValue)])
     }
 
-    pub def render(value: JsonValue): String =
-        renderWithIndent(0, value)
+    pub def render(value: JsonValue): String = region rc {
+        let sb = StringBuilder.empty(rc);
+        appendValue!(sb, 0, value);
+        StringBuilder.toString(sb)
+    }
 
-    def renderWithIndent(indent: Int32, value: JsonValue): String =
-        let spaces = String.repeat(indent, " ");
-        let inner = String.repeat(indent + 2, " ");
+    def appendValue!(sb: StringBuilder[r], indent: Int32, value: JsonValue): Unit \ r =
         match value {
-            case JsonValue.JsonNull       => "null"
-            case JsonValue.JsonBool(b)    => if (b) "true" else "false"
-            case JsonValue.JsonInt(n)     => "${n}"
-            case JsonValue.JsonFloat(n)   => "${n}"
-            case JsonValue.JsonString(s)  => "\"${escapeString(s)}\""
+            case JsonValue.JsonNull       => StringBuilder.appendString!("null", sb)
+            case JsonValue.JsonBool(b)    => StringBuilder.appendString!(if (b) "true" else "false", sb)
+            case JsonValue.JsonInt(n)     => StringBuilder.appendString!("${n}", sb)
+            case JsonValue.JsonFloat(n)   => StringBuilder.appendString!("${n}", sb)
+            case JsonValue.JsonString(s)  =>
+                StringBuilder.appendString!("\"", sb);
+                StringBuilder.appendString!(escapeString(s), sb);
+                StringBuilder.appendString!("\"", sb)
             case JsonValue.JsonArray(xs)  =>
                 if (List.isEmpty(xs))
-                    "[]"
+                    StringBuilder.appendString!("[]", sb)
                 else
-                    let items = xs |> List.map(x -> "${inner}${renderWithIndent(indent + 2, x)}");
-                    "[\n${List.join(",\n", items)}\n${spaces}]"
+                    let spaces = String.repeat(indent, " ");
+                    let inner = String.repeat(indent + 2, " ");
+                    StringBuilder.appendString!("[\n", sb);
+                    appendSeparated!(sb, ",\n", xs, x -> {
+                        StringBuilder.appendString!(inner, sb);
+                        appendValue!(sb, indent + 2, x)
+                    });
+                    StringBuilder.appendString!("\n", sb);
+                    StringBuilder.appendString!(spaces, sb);
+                    StringBuilder.appendString!("]", sb)
             case JsonValue.JsonObject(kvs) =>
                 if (List.isEmpty(kvs))
-                    "{}"
+                    StringBuilder.appendString!("{}", sb)
                 else
-                    let entries = kvs |> List.map(match (k, v) ->
-                        "${inner}\"${escapeString(k)}\": ${renderWithIndent(indent + 2, v)}"
-                    );
-                    "{\n${List.join(",\n", entries)}\n${spaces}}"
+                    let spaces = String.repeat(indent, " ");
+                    let inner = String.repeat(indent + 2, " ");
+                    StringBuilder.appendString!("{\n", sb);
+                    appendSeparated!(sb, ",\n", kvs, match (k, v) -> {
+                        StringBuilder.appendString!(inner, sb);
+                        StringBuilder.appendString!("\"", sb);
+                        StringBuilder.appendString!(escapeString(k), sb);
+                        StringBuilder.appendString!("\": ", sb);
+                        appendValue!(sb, indent + 2, v)
+                    });
+                    StringBuilder.appendString!("\n", sb);
+                    StringBuilder.appendString!(spaces, sb);
+                    StringBuilder.appendString!("}", sb)
+        }
+
+    def appendSeparated!(sb: StringBuilder[r], sep: String, xs: List[a], f: a -> Unit \ r): Unit \ r =
+        match xs {
+            case Nil       => ()
+            case x :: Nil  => f(x)
+            case x :: rest =>
+                f(x);
+                StringBuilder.appendString!(sep, sb);
+                appendSeparated!(sb, sep, rest, f)
         }
 
     def escapeString(s: String): String =

--- a/flix/src/Util/Json.flix
+++ b/flix/src/Util/Json.flix
@@ -10,63 +10,32 @@ mod Util.Json {
         case JsonObject(List[(String, JsonValue)])
     }
 
-    pub def render(value: JsonValue): String = region rc {
-        let sb = StringBuilder.empty(rc);
-        appendValue!(sb, 0, value);
-        StringBuilder.toString(sb)
-    }
+    pub def render(value: JsonValue): String =
+        renderWithIndent(0, value)
 
-    def appendValue!(sb: StringBuilder[r], indent: Int32, value: JsonValue): Unit \ r =
+    def renderWithIndent(indent: Int32, value: JsonValue): String =
+        let spaces = String.repeat(indent, " ");
+        let inner = String.repeat(indent + 2, " ");
         match value {
-            case JsonValue.JsonNull       => StringBuilder.appendString!("null", sb)
-            case JsonValue.JsonBool(b)    => StringBuilder.appendString!(if (b) "true" else "false", sb)
-            case JsonValue.JsonInt(n)     => StringBuilder.appendString!("${n}", sb)
-            case JsonValue.JsonFloat(n)   => StringBuilder.appendString!("${n}", sb)
-            case JsonValue.JsonString(s)  =>
-                StringBuilder.appendString!("\"", sb);
-                StringBuilder.appendString!(escapeString(s), sb);
-                StringBuilder.appendString!("\"", sb)
+            case JsonValue.JsonNull       => "null"
+            case JsonValue.JsonBool(b)    => if (b) "true" else "false"
+            case JsonValue.JsonInt(n)     => "${n}"
+            case JsonValue.JsonFloat(n)   => "${n}"
+            case JsonValue.JsonString(s)  => "\"${escapeString(s)}\""
             case JsonValue.JsonArray(xs)  =>
                 if (List.isEmpty(xs))
-                    StringBuilder.appendString!("[]", sb)
+                    "[]"
                 else
-                    let spaces = String.repeat(indent, " ");
-                    let inner = String.repeat(indent + 2, " ");
-                    StringBuilder.appendString!("[\n", sb);
-                    appendSeparated!(sb, ",\n", xs, x -> {
-                        StringBuilder.appendString!(inner, sb);
-                        appendValue!(sb, indent + 2, x)
-                    });
-                    StringBuilder.appendString!("\n", sb);
-                    StringBuilder.appendString!(spaces, sb);
-                    StringBuilder.appendString!("]", sb)
+                    let items = xs |> List.map(x -> "${inner}${renderWithIndent(indent + 2, x)}");
+                    "[\n${List.join(",\n", items)}\n${spaces}]"
             case JsonValue.JsonObject(kvs) =>
                 if (List.isEmpty(kvs))
-                    StringBuilder.appendString!("{}", sb)
+                    "{}"
                 else
-                    let spaces = String.repeat(indent, " ");
-                    let inner = String.repeat(indent + 2, " ");
-                    StringBuilder.appendString!("{\n", sb);
-                    appendSeparated!(sb, ",\n", kvs, match (k, v) -> {
-                        StringBuilder.appendString!(inner, sb);
-                        StringBuilder.appendString!("\"", sb);
-                        StringBuilder.appendString!(escapeString(k), sb);
-                        StringBuilder.appendString!("\": ", sb);
-                        appendValue!(sb, indent + 2, v)
-                    });
-                    StringBuilder.appendString!("\n", sb);
-                    StringBuilder.appendString!(spaces, sb);
-                    StringBuilder.appendString!("}", sb)
-        }
-
-    def appendSeparated!(sb: StringBuilder[r], sep: String, xs: List[a], f: a -> Unit \ r): Unit \ r =
-        match xs {
-            case Nil       => ()
-            case x :: Nil  => f(x)
-            case x :: rest =>
-                f(x);
-                StringBuilder.appendString!(sep, sb);
-                appendSeparated!(sb, sep, rest, f)
+                    let entries = kvs |> List.map(match (k, v) ->
+                        "${inner}\"${escapeString(k)}\": ${renderWithIndent(indent + 2, v)}"
+                    );
+                    "{\n${List.join(",\n", entries)}\n${spaces}}"
         }
 
     def escapeString(s: String): String =


### PR DESCRIPTION
## Summary
Refactored the command-line argument parsing logic to use the `GetOpt` library instead of a custom state machine implementation. This improves code maintainability and provides better error handling for argument parsing.

## Key Changes

- **CLI argument parsing**: Replaced custom `ParseState` state machine with `GetOpt.getOpt()` for standard argument parsing
  - Introduced `CliOption` enum to represent parsed options
  - Added `optionDescrs()` to define available CLI options with proper metadata
  - Simplified `parse()` to use monadic composition with the GetOpt result

- **Error handling improvements**:
  - Changed `MissingOutputValue` to `UnexpectedArguments(List[String])` to better represent multiple unexpected arguments
  - Changed `UnexpectedArgument(String)` to `ParseErrors(List[String])` to handle multiple parsing errors from GetOpt
  - Maintained existing error cases: `MissingInputPath` and `DuplicateOutput`

- **File operations**: Simplified CSV file discovery
  - Replaced recursive `listDir()` and `gatherCsvs()` implementation with `Fs.Glob.glob()` using pattern `{*.csv,**/*.csv}`
  - Changed `ListDirError` to `GlobError` in `FileError` enum to reflect the new implementation

- **User-facing improvements**:
  - Added `usageInfo()` function to generate standardized usage information
  - Updated `Main.flix` to use `Args.usageInfo()` instead of hardcoded usage string

## Implementation Details

The new argument parsing uses GetOpt's `ArgOrder.Permute` to allow flexible argument ordering. The `--output` option is defined as requiring an argument with the descriptor `<file>`. Input path is extracted from non-option arguments, allowing for cleaner separation of concerns between option and positional argument handling.