### PR TITLE
Add Le Mans mini-sector validation rules

### DIFF
--- a/flix/src/Cli/Validation.flix
+++ b/flix/src/Cli/Validation.flix
@@ -12,19 +12,13 @@
 ///   3. HourElapsedOffset          — across the CSV, `(hour - elapsed) mod 24h` is
 ///                                   constant
 ///   4. MiniSectorSum              — when mini-sectors present, `sum(time) == lapTime`
-///                                   (per row, blank `time` counted as zero).
-///                                   **Skipped on pit laps** (see below).
+///                                   (blank `time` counted as zero).
+///                                   Skipped on pit laps and Ford-chicane track-limits
+///                                   signatures (see below).
 ///   5. MiniSectorElapsedMonotonic — when mini-sectors present, `elapsed` values are
-///                                   strictly increasing in track order (reports each
-///                                   adjacent pair where the second value is less than
-///                                   or equal to the first). Always run even on pit
-///                                   laps — monotonicity is not affected by missing
-///                                   markers because blank `elapsed` entries are
-///                                   skipped without breaking the chain. Equality is
-///                                   treated as a violation: two timing loops cannot
-///                                   physically fire at the same millisecond, and the
-///                                   real Le Mans 2025 dataset never produces an
-///                                   equal-adjacent pair.
+///                                   strictly increasing in track order. Equality is
+///                                   reported (two timing loops cannot fire at the
+///                                   same millisecond). Always run, even on pit laps.
 ///
 /// Design notes:
 ///   - HourElapsedOffset's baseline is the **first valid row in the whole
@@ -36,23 +30,14 @@
 ///     per-car uses first-seen-index to sort the car groups).
 ///   - Mini-sector rules silently skip laps where `miniSectors == None`
 ///     (non-Le Mans rounds, or laps where all 30 source columns were blank).
-///   - **MiniSectorSum is skipped on pit laps** — when a car enters the pits
-///     it bypasses main-line markers (typically FORDOUT and FL_time) so the
-///     sum can never reach lapTime. A pit lap is identified by either
-///     `crossingFinishLineInPit == "B"` (crossed FL inside the pit lane) or
-///     `pitTime != None` (pit-stop duration recorded for this lap).
-///   - **MiniSectorSum is also skipped for known Ford-chicane track-limits
-///     signatures** — when a driver runs off track at a Ford chicane
-///     (track-limits violation), the timing loops inside the bypassed
-///     section go untriggered (SCL1 + FORDOUT for the second chicane,
-///     PITREF + SCL1 for the first). Empirically (Le Mans 2025) these two
-///     adjacent-pair blank patterns are the dominant cause of the remaining
-///     non-pit MiniSectorSum noise (310 of 311 warnings after the pit
-///     skip), concentrated on the front-running hypercars.
-///   - Combined skips (pit lap + track-limits violation) reduce Le Mans
-///     2025 noise from 2240 → 1 MiniSectorSum warning while preserving
-///     genuine timing-loop anomalies (e.g. a wide moment causing FORDOUT +
-///     FL_time to drop while the car was not in the pits).
+///   - **MiniSectorSum pit-lap skip** — pit-entry laps bypass main-line
+///     markers (typically FORDOUT and FL_time) so the sum can never reach
+///     lapTime. Identified by `crossingFinishLineInPit == "B"` or
+///     `pitTime != None`.
+///   - **MiniSectorSum track-limits skip** — running off the Ford chicanes
+///     leaves a known blank pattern (SCL1+FORDOUT for the second chicane,
+///     PITREF+SCL1 for the first). These are the dominant non-pit cause of
+///     residual sum mismatches in Le Mans 2025.
 mod Cli.Validation {
 
     use Util.Duration.Duration
@@ -76,18 +61,14 @@ mod Cli.Validation {
         /// Args: lap / baseline offset (ms, signed) / actual offset (ms, signed).
         case HourElapsedOffset(RawLap, Int32, Int32)
 
-        /// `sum(miniSector.time) != lapTime` for laps with mini-sector data.
+        /// `sum(miniSector.time) != lapTime`.
         /// Args: lap / lapTime / sum / IDs of sub-sectors with blank time
-        /// (in track order). Carry the `MiniSectorId` rather than its
-        /// JSON key so downstream consumers (e.g. `isTrackLimitsPattern`)
-        /// stay type-safe; `formatViolation` calls `MiniSector.jsonKey`
-        /// at the rendering boundary.
+        /// (in track order).
         case MiniSectorSum(RawLap, Duration, Duration, List[MiniSectorId])
 
-        /// Mini-sector `elapsed[i] <= elapsed[i-1]` for some adjacent
-        /// pair in track order (only entries where both sides are
-        /// present are compared). Equality is reported because two
-        /// timing loops cannot physically fire at the same millisecond.
+        /// Mini-sector `elapsed[i] <= elapsed[i-1]` for some adjacent pair
+        /// in track order. Only entries where both sides are present are
+        /// compared.
         /// Args: lap / prev id / prev elapsed / curr id / curr elapsed.
         case MiniSectorElapsedMonotonic(RawLap, MiniSectorId, Duration, MiniSectorId, Duration)
     }
@@ -212,12 +193,6 @@ mod Cli.Validation {
                 formatLabelledDurationPair(eventName, lap, kind, "prev", prevElapsed, "curr", currElapsed)
         }
 
-    /// Per-lap mini-sector checks. Skipped entirely for laps without
-    /// mini-sector data (`miniSectors == None`). Otherwise emits at most
-    /// one `MiniSectorSum` plus zero or more `MiniSectorElapsedMonotonic`
-    /// violations. The `MiniSectorSum` rule is skipped on pit laps since
-    /// the car bypasses some main-line markers (see the module-level
-    /// docstring).
     def checkMiniSectors(lap: RawLap): List[Violation] =
         match lap#miniSectors {
             case None       => Nil
@@ -229,10 +204,6 @@ mod Cli.Validation {
                 List.append(sumViol, monoViol)
         }
 
-    /// True when the car was either flagged as crossing the finish line
-    /// inside the pit lane or had a pit-stop duration recorded for this
-    /// lap. Either condition implies the car missed at least one main-line
-    /// timing loop, so MiniSectorSum can never balance.
     def isPitLap(lap: RawLap): Bool =
         lap#crossingFinishLineInPit or lap#pitTime != None
 
@@ -255,25 +226,15 @@ mod Cli.Validation {
                 else                                  Violation.MiniSectorSum(lap, lap#lapTime, sum, blanks) :: Nil
         }
 
-    /// True when the blank `time`-column set matches a known Ford-chicane
-    /// track-limits-violation signature for Le Mans 2025. Track-ordered
-    /// list, so SCL1 always precedes FORDOUT and PITREF always precedes
-    /// SCL1. Compares `MiniSectorId` directly so a rename of a
-    /// `MiniSector.jsonKey` mapping cannot silently drift this rule out
-    /// of sync.
+    /// Matches the two known Ford-chicane track-limits blank patterns at
+    /// Le Mans 2025. The blanks list is in track order, so SCL1 always
+    /// precedes FORDOUT and PITREF always precedes SCL1.
     def isTrackLimitsPattern(blanks: List[MiniSectorId]): Bool =
         blanks == MiniSectorId.SCL1 :: MiniSectorId.FORDOUT :: Nil
             or blanks == MiniSectorId.PITREF :: MiniSectorId.SCL1 :: Nil
 
-    /// Walks the track-ordered list and reports each adjacent pair
-    /// where the second elapsed is less than *or equal to* the first.
-    /// Equality is rejected because two timing loops cannot physically
-    /// fire at the same millisecond — the real Le Mans 2025 dataset
-    /// never produces an equal-adjacent pair, so the strict check
-    /// catches stuck-clock anomalies without adding noise. Entries
-    /// with blank elapsed are skipped without breaking the chain (so
-    /// we still catch a backwards step that straddles a single missing
-    /// marker).
+    /// Reports each adjacent pair where the second elapsed is `<=` the first.
+    /// Blank-elapsed entries are skipped without breaking the chain.
     def checkMiniSectorMonotonic(lap: RawLap, list: List[(MiniSectorId, RawMiniSector)]): List[Violation] =
         let folded = list |> List.foldLeft(
             (state, pair) -> match (state, pair) {
@@ -304,9 +265,6 @@ mod Cli.Validation {
         formatLabelledDurationPair(eventName, lap, kind, "expected", expected, "actual", actual)
 
     /// Same shape as `formatDurationPair` but with caller-supplied labels.
-    /// Used by `MiniSectorElapsedMonotonic` to emit `prev=/curr=` instead of
-    /// `expected=/actual=`, since the comparison is "previous marker vs.
-    /// current marker" rather than "what we expected vs. what we observed".
     def formatLabelledDurationPair(
         eventName: String,
         lap: RawLap,

--- a/flix/src/Cli/Validation.flix
+++ b/flix/src/Cli/Validation.flix
@@ -12,10 +12,14 @@
 ///   3. HourElapsedOffset          — across the CSV, `(hour - elapsed) mod 24h` is
 ///                                   constant
 ///   4. MiniSectorSum              — when mini-sectors present, `sum(time) == lapTime`
-///                                   (per row, blank `time` counted as zero)
+///                                   (per row, blank `time` counted as zero).
+///                                   **Skipped on pit laps** (see below).
 ///   5. MiniSectorElapsedMonotonic — when mini-sectors present, `elapsed` values are
 ///                                   non-decreasing in track order (reports each
-///                                   adjacent pair that goes backwards)
+///                                   adjacent pair that goes backwards). Always run
+///                                   even on pit laps — monotonicity is not affected
+///                                   by missing markers because blank `elapsed`
+///                                   entries are skipped without breaking the chain.
 ///
 /// Design notes:
 ///   - HourElapsedOffset's baseline is the **first valid row in the whole
@@ -27,6 +31,15 @@
 ///     per-car uses first-seen-index to sort the car groups).
 ///   - Mini-sector rules silently skip laps where `miniSectors == None`
 ///     (non-Le Mans rounds, or laps where all 30 source columns were blank).
+///   - **MiniSectorSum is skipped on pit laps** — when a car enters the pits
+///     it bypasses main-line markers (typically FORDOUT and FL_time) so the
+///     sum can never reach lapTime. Empirically (Le Mans 2025, 20182 laps)
+///     this skip removes ~86% of MiniSectorSum noise (1929 of 2240) while
+///     preserving real timing-loop anomalies (the remaining ~311 cases are
+///     adjacent SCL1+FORDOUT loop failures on non-pit laps, concentrated on
+///     specific cars). A pit lap is identified by either
+///     `crossingFinishLineInPit == "B"` (crossed FL inside the pit lane) or
+///     `pitTime != None` (pit-stop duration recorded for this lap).
 mod Cli.Validation {
 
     use Util.Duration.Duration
@@ -184,15 +197,26 @@ mod Cli.Validation {
     /// Per-lap mini-sector checks. Skipped entirely for laps without
     /// mini-sector data (`miniSectors == None`). Otherwise emits at most
     /// one `MiniSectorSum` plus zero or more `MiniSectorElapsedMonotonic`
-    /// violations.
+    /// violations. The `MiniSectorSum` rule is skipped on pit laps since
+    /// the car bypasses some main-line markers (see the module-level
+    /// docstring).
     def checkMiniSectors(lap: RawLap): List[Violation] =
         match lap#miniSectors {
             case None       => Nil
             case Some(list) =>
-                let sumViol  = checkMiniSectorSum(lap, list);
+                let sumViol  =
+                    if (isPitLap(lap)) Nil
+                    else checkMiniSectorSum(lap, list);
                 let monoViol = checkMiniSectorMonotonic(lap, list);
                 List.append(sumViol, monoViol)
         }
+
+    /// True when the car was either flagged as crossing the finish line
+    /// inside the pit lane or had a pit-stop duration recorded for this
+    /// lap. Either condition implies the car missed at least one main-line
+    /// timing loop, so MiniSectorSum can never balance.
+    def isPitLap(lap: RawLap): Bool =
+        lap#crossingFinishLineInPit or lap#pitTime != None
 
     def checkMiniSectorSum(lap: RawLap, list: List[(MiniSectorId, RawMiniSector)]): List[Violation] =
         let parts = list |> List.map(match (id, sector) ->

--- a/flix/src/Cli/Validation.flix
+++ b/flix/src/Cli/Validation.flix
@@ -230,26 +230,22 @@ mod Cli.Validation {
     /// Blank-elapsed entries are skipped without breaking the chain.
     def checkMiniSectorMonotonic(lap: RawLap, list: List[(MiniSectorId, RawMiniSector)]): List[Violation] =
         let folded = list |> List.foldLeft(
-            (state, pair) -> match (state, pair) {
-                case ((prev, acc), (id, sector)) =>
-                    match sector#elapsed {
-                        case None => (prev, acc)
-                        case Some(curr) => match prev {
-                            case None => (Some((id, curr)), acc)
-                            case Some((prevId, prevElapsed)) =>
-                                if (curr > prevElapsed)
-                                    (Some((id, curr)), acc)
-                                else
-                                    (Some((id, curr)),
-                                     Violation.MiniSectorElapsedMonotonic(lap, prevId, prevElapsed, id, curr) :: acc)
-                        }
-                    }
-            },
+            (state, pair) ->
+                let (prev, acc) = state;
+                let (id, sector) = pair;
+                match (sector#elapsed, prev) {
+                    case (None, _)          => (prev, acc)
+                    case (Some(curr), None) => (Some((id, curr)), acc)
+                    case (Some(curr), Some((prevId, prevElapsed))) =>
+                        let newAcc =
+                            if (curr > prevElapsed) acc
+                            else Violation.MiniSectorElapsedMonotonic(lap, prevId, prevElapsed, id, curr) :: acc;
+                        (Some((id, curr)), newAcc)
+                },
             (None, Nil)
         );
-        match folded {
-            case (_, acc) => List.reverse(acc)
-        }
+        let (_, acc) = folded;
+        List.reverse(acc)
 
     /// Emits `{eventName}: [car X #N] kind: expected=<fmt> (<ms>ms) actual=<fmt> (<ms>ms)`.
     /// The raw ms is included alongside the formatted Duration to keep the

--- a/flix/src/Cli/Validation.flix
+++ b/flix/src/Cli/Validation.flix
@@ -149,7 +149,7 @@ mod Cli.Validation {
         let sum = Util.Duration.add(Util.Duration.add(s1, s2), s3);
         if (sum == lapTime) Ok(())
         else
-            let blanks = (s1Blank :: s2Blank :: s3Blank :: Nil) |> List.filterMap(x -> x);
+            let blanks = List#{s1Blank, s2Blank, s3Blank} |> List.filterMap(x -> x);
             Err(Violation.SectorSum(lap, lapTime, sum, blanks))
 
     def sectorOrZero(sector: Option[Duration], name: String): (Duration, Option[String]) =

--- a/flix/src/Cli/Validation.flix
+++ b/flix/src/Cli/Validation.flix
@@ -15,11 +15,16 @@
 ///                                   (per row, blank `time` counted as zero).
 ///                                   **Skipped on pit laps** (see below).
 ///   5. MiniSectorElapsedMonotonic — when mini-sectors present, `elapsed` values are
-///                                   non-decreasing in track order (reports each
-///                                   adjacent pair that goes backwards). Always run
-///                                   even on pit laps — monotonicity is not affected
-///                                   by missing markers because blank `elapsed`
-///                                   entries are skipped without breaking the chain.
+///                                   strictly increasing in track order (reports each
+///                                   adjacent pair where the second value is less than
+///                                   or equal to the first). Always run even on pit
+///                                   laps — monotonicity is not affected by missing
+///                                   markers because blank `elapsed` entries are
+///                                   skipped without breaking the chain. Equality is
+///                                   treated as a violation: two timing loops cannot
+///                                   physically fire at the same millisecond, and the
+///                                   real Le Mans 2025 dataset never produces an
+///                                   equal-adjacent pair.
 ///
 /// Design notes:
 ///   - HourElapsedOffset's baseline is the **first valid row in the whole
@@ -75,9 +80,10 @@ mod Cli.Validation {
         /// Args: lap / lapTime / sum / json keys of sub-sectors with blank time.
         case MiniSectorSum(RawLap, Duration, Duration, List[String])
 
-        /// Mini-sector `elapsed[i] < elapsed[i-1]` for some adjacent pair
-        /// in track order (only entries where both sides are present are
-        /// compared).
+        /// Mini-sector `elapsed[i] <= elapsed[i-1]` for some adjacent
+        /// pair in track order (only entries where both sides are
+        /// present are compared). Equality is reported because two
+        /// timing loops cannot physically fire at the same millisecond.
         /// Args: lap / prev id / prev elapsed / curr id / curr elapsed.
         case MiniSectorElapsedMonotonic(RawLap, MiniSectorId, Duration, MiniSectorId, Duration)
     }
@@ -253,10 +259,15 @@ mod Cli.Validation {
         blanks == "scl1" :: "fordout" :: Nil
             or blanks == "pitref" :: "scl1" :: Nil
 
-    /// Walks the track-ordered list and reports each adjacent pair where
-    /// the second elapsed is strictly less than the first. Entries with
-    /// blank elapsed are skipped without breaking the chain (so we still
-    /// catch a backwards step that straddles a single missing marker).
+    /// Walks the track-ordered list and reports each adjacent pair
+    /// where the second elapsed is less than *or equal to* the first.
+    /// Equality is rejected because two timing loops cannot physically
+    /// fire at the same millisecond — the real Le Mans 2025 dataset
+    /// never produces an equal-adjacent pair, so the strict check
+    /// catches stuck-clock anomalies without adding noise. Entries
+    /// with blank elapsed are skipped without breaking the chain (so
+    /// we still catch a backwards step that straddles a single missing
+    /// marker).
     def checkMiniSectorMonotonic(lap: RawLap, list: List[(MiniSectorId, RawMiniSector)]): List[Violation] =
         let folded = list |> List.foldLeft(
             (state, pair) -> match (state, pair) {
@@ -266,7 +277,7 @@ mod Cli.Validation {
                         case Some(curr) => match prev {
                             case None => (Some((id, curr)), acc)
                             case Some((prevId, prevElapsed)) =>
-                                if (curr >= prevElapsed)
+                                if (curr > prevElapsed)
                                     (Some((id, curr)), acc)
                                 else
                                     (Some((id, curr)),

--- a/flix/src/Cli/Validation.flix
+++ b/flix/src/Cli/Validation.flix
@@ -221,17 +221,10 @@ mod Cli.Validation {
         match folded {
             case (sum, blanksRev) =>
                 let blanks = List.reverse(blanksRev);
-                if (sum == lap#lapTime)               Nil
-                else if (isTrackLimitsPattern(blanks)) Nil
-                else                                  Violation.MiniSectorSum(lap, lap#lapTime, sum, blanks) :: Nil
+                if (sum == lap#lapTime)                             Nil
+                else if (MiniSector.isTrackLimitsSignature(blanks)) Nil
+                else                                                Violation.MiniSectorSum(lap, lap#lapTime, sum, blanks) :: Nil
         }
-
-    /// Matches the two known Ford-chicane track-limits blank patterns at
-    /// Le Mans 2025. The blanks list is in track order, so SCL1 always
-    /// precedes FORDOUT and PITREF always precedes SCL1.
-    def isTrackLimitsPattern(blanks: List[MiniSectorId]): Bool =
-        blanks == MiniSectorId.SCL1 :: MiniSectorId.FORDOUT :: Nil
-            or blanks == MiniSectorId.PITREF :: MiniSectorId.SCL1 :: Nil
 
     /// Reports each adjacent pair where the second elapsed is `<=` the first.
     /// Blank-elapsed entries are skipped without breaking the chain.

--- a/flix/src/Cli/Validation.flix
+++ b/flix/src/Cli/Validation.flix
@@ -77,8 +77,12 @@ mod Cli.Validation {
         case HourElapsedOffset(RawLap, Int32, Int32)
 
         /// `sum(miniSector.time) != lapTime` for laps with mini-sector data.
-        /// Args: lap / lapTime / sum / json keys of sub-sectors with blank time.
-        case MiniSectorSum(RawLap, Duration, Duration, List[String])
+        /// Args: lap / lapTime / sum / IDs of sub-sectors with blank time
+        /// (in track order). Carry the `MiniSectorId` rather than its
+        /// JSON key so downstream consumers (e.g. `isTrackLimitsPattern`)
+        /// stay type-safe; `formatViolation` calls `MiniSector.jsonKey`
+        /// at the rendering boundary.
+        case MiniSectorSum(RawLap, Duration, Duration, List[MiniSectorId])
 
         /// Mini-sector `elapsed[i] <= elapsed[i-1]` for some adjacent
         /// pair in track order (only entries where both sides are
@@ -201,7 +205,7 @@ mod Cli.Validation {
             case Violation.MiniSectorSum(lap, lapTime, sum, blanks) =>
                 let suffix =
                     if (List.isEmpty(blanks)) ""
-                    else " (blank: ${List.join(",", blanks)})";
+                    else " (blank: ${List.join(",", List.map(MiniSector.jsonKey, blanks))})";
                 formatDurationPair(eventName, lap, "mini-sector-sum", lapTime, sum) + suffix
             case Violation.MiniSectorElapsedMonotonic(lap, prevId, prevElapsed, currId, currElapsed) =>
                 let kind = "mini-sector-elapsed[${MiniSector.jsonKey(prevId)}->${MiniSector.jsonKey(currId)}]";
@@ -238,7 +242,7 @@ mod Cli.Validation {
                 case ((accSum, accBlanks), (id, sector)) =>
                     match sector#time {
                         case Some(d) => (Util.Duration.add(accSum, d), accBlanks)
-                        case None    => (accSum, MiniSector.jsonKey(id) :: accBlanks)
+                        case None    => (accSum, id :: accBlanks)
                     }
             },
             (Util.Duration.zero(), Nil)
@@ -254,10 +258,12 @@ mod Cli.Validation {
     /// True when the blank `time`-column set matches a known Ford-chicane
     /// track-limits-violation signature for Le Mans 2025. Track-ordered
     /// list, so SCL1 always precedes FORDOUT and PITREF always precedes
-    /// SCL1.
-    def isTrackLimitsPattern(blanks: List[String]): Bool =
-        blanks == "scl1" :: "fordout" :: Nil
-            or blanks == "pitref" :: "scl1" :: Nil
+    /// SCL1. Compares `MiniSectorId` directly so a rename of a
+    /// `MiniSector.jsonKey` mapping cannot silently drift this rule out
+    /// of sync.
+    def isTrackLimitsPattern(blanks: List[MiniSectorId]): Bool =
+        blanks == MiniSectorId.SCL1 :: MiniSectorId.FORDOUT :: Nil
+            or blanks == MiniSectorId.PITREF :: MiniSectorId.SCL1 :: Nil
 
     /// Walks the track-ordered list and reports each adjacent pair
     /// where the second elapsed is less than *or equal to* the first.

--- a/flix/src/Cli/Validation.flix
+++ b/flix/src/Cli/Validation.flix
@@ -33,13 +33,20 @@
 ///     (non-Le Mans rounds, or laps where all 30 source columns were blank).
 ///   - **MiniSectorSum is skipped on pit laps** — when a car enters the pits
 ///     it bypasses main-line markers (typically FORDOUT and FL_time) so the
-///     sum can never reach lapTime. Empirically (Le Mans 2025, 20182 laps)
-///     this skip removes ~86% of MiniSectorSum noise (1929 of 2240) while
-///     preserving real timing-loop anomalies (the remaining ~311 cases are
-///     adjacent SCL1+FORDOUT loop failures on non-pit laps, concentrated on
-///     specific cars). A pit lap is identified by either
+///     sum can never reach lapTime. A pit lap is identified by either
 ///     `crossingFinishLineInPit == "B"` (crossed FL inside the pit lane) or
 ///     `pitTime != None` (pit-stop duration recorded for this lap).
+///   - **MiniSectorSum is also skipped for known Ford-chicane-cut
+///     signatures** — when a driver cuts a Ford chicane, the timing loops
+///     inside the cut (SCL1 + FORDOUT for the second chicane, PITREF + SCL1
+///     for the first) go untriggered. Empirically (Le Mans 2025) these two
+///     adjacent-pair blank patterns are the dominant cause of the remaining
+///     non-pit MiniSectorSum noise (310 of 311 warnings after the pit
+///     skip), concentrated on the front-running hypercars.
+///   - Combined skips (pit lap + chicane cut) reduce Le Mans 2025 noise
+///     from 2240 → 1 MiniSectorSum warning while preserving genuine
+///     timing-loop anomalies (e.g. a wide moment causing FORDOUT + FL_time
+///     to drop while the car was not in the pits).
 mod Cli.Validation {
 
     use Util.Duration.Duration
@@ -232,8 +239,16 @@ mod Cli.Validation {
             Util.Duration.zero()
         );
         let blanks = parts |> List.filterMap(match (_, b) -> b);
-        if (sum == lap#lapTime) Nil
-        else Violation.MiniSectorSum(lap, lap#lapTime, sum, blanks) :: Nil
+        if (sum == lap#lapTime)             Nil
+        else if (isChicaneCutPattern(blanks)) Nil
+        else                                Violation.MiniSectorSum(lap, lap#lapTime, sum, blanks) :: Nil
+
+    /// True when the blank `time`-column set matches a known Ford-chicane
+    /// cut signature for Le Mans 2025. Track-ordered list, so SCL1 always
+    /// precedes FORDOUT and PITREF always precedes SCL1.
+    def isChicaneCutPattern(blanks: List[String]): Bool =
+        blanks == "scl1" :: "fordout" :: Nil
+            or blanks == "pitref" :: "scl1" :: Nil
 
     /// Walks the track-ordered list and reports each adjacent pair where
     /// the second elapsed is strictly less than the first. Entries with

--- a/flix/src/Cli/Validation.flix
+++ b/flix/src/Cli/Validation.flix
@@ -236,13 +236,13 @@ mod Cli.Validation {
     def isPitLap(lap: RawLap): Bool =
         lap#crossingFinishLineInPit or lap#pitTime != None
 
-    def checkMiniSectorSum(lap: RawLap, list: List[(MiniSectorId, RawMiniSector)]): List[Violation] =
+    def checkMiniSectorSum(lap: RawLap, list: List[(MiniSectorId, Option[RawMiniSector])]): List[Violation] =
         let folded = list |> List.foldLeft(
             (state, pair) -> match (state, pair) {
-                case ((accSum, accBlanks), (id, sector)) =>
-                    match sector#time {
-                        case Some(d) => (Util.Duration.add(accSum, d), accBlanks)
-                        case None    => (accSum, id :: accBlanks)
+                case ((accSum, accBlanks), (id, opt)) =>
+                    match opt {
+                        case Some(sector) => (Util.Duration.add(accSum, sector#time), accBlanks)
+                        case None         => (accSum, id :: accBlanks)
                     }
             },
             (Util.Duration.zero(), Nil)
@@ -274,21 +274,23 @@ mod Cli.Validation {
     /// with blank elapsed are skipped without breaking the chain (so
     /// we still catch a backwards step that straddles a single missing
     /// marker).
-    def checkMiniSectorMonotonic(lap: RawLap, list: List[(MiniSectorId, RawMiniSector)]): List[Violation] =
+    def checkMiniSectorMonotonic(lap: RawLap, list: List[(MiniSectorId, Option[RawMiniSector])]): List[Violation] =
         let folded = list |> List.foldLeft(
             (state, pair) -> match (state, pair) {
-                case ((prev, acc), (id, sector)) =>
-                    match sector#elapsed {
+                case ((prev, acc), (id, opt)) =>
+                    match opt {
                         case None => (prev, acc)
-                        case Some(curr) => match prev {
-                            case None => (Some((id, curr)), acc)
-                            case Some((prevId, prevElapsed)) =>
-                                if (curr > prevElapsed)
-                                    (Some((id, curr)), acc)
-                                else
-                                    (Some((id, curr)),
-                                     Violation.MiniSectorElapsedMonotonic(lap, prevId, prevElapsed, id, curr) :: acc)
-                        }
+                        case Some(sector) =>
+                            let curr = sector#elapsed;
+                            match prev {
+                                case None => (Some((id, curr)), acc)
+                                case Some((prevId, prevElapsed)) =>
+                                    if (curr > prevElapsed)
+                                        (Some((id, curr)), acc)
+                                    else
+                                        (Some((id, curr)),
+                                         Violation.MiniSectorElapsedMonotonic(lap, prevId, prevElapsed, id, curr) :: acc)
+                            }
                     }
             },
             (None, Nil)

--- a/flix/src/Cli/Validation.flix
+++ b/flix/src/Cli/Validation.flix
@@ -36,17 +36,18 @@
 ///     sum can never reach lapTime. A pit lap is identified by either
 ///     `crossingFinishLineInPit == "B"` (crossed FL inside the pit lane) or
 ///     `pitTime != None` (pit-stop duration recorded for this lap).
-///   - **MiniSectorSum is also skipped for known Ford-chicane-cut
-///     signatures** — when a driver cuts a Ford chicane, the timing loops
-///     inside the cut (SCL1 + FORDOUT for the second chicane, PITREF + SCL1
-///     for the first) go untriggered. Empirically (Le Mans 2025) these two
+///   - **MiniSectorSum is also skipped for known Ford-chicane track-limits
+///     signatures** — when a driver runs off track at a Ford chicane
+///     (track-limits violation), the timing loops inside the bypassed
+///     section go untriggered (SCL1 + FORDOUT for the second chicane,
+///     PITREF + SCL1 for the first). Empirically (Le Mans 2025) these two
 ///     adjacent-pair blank patterns are the dominant cause of the remaining
 ///     non-pit MiniSectorSum noise (310 of 311 warnings after the pit
 ///     skip), concentrated on the front-running hypercars.
-///   - Combined skips (pit lap + chicane cut) reduce Le Mans 2025 noise
-///     from 2240 → 1 MiniSectorSum warning while preserving genuine
-///     timing-loop anomalies (e.g. a wide moment causing FORDOUT + FL_time
-///     to drop while the car was not in the pits).
+///   - Combined skips (pit lap + track-limits violation) reduce Le Mans
+///     2025 noise from 2240 → 1 MiniSectorSum warning while preserving
+///     genuine timing-loop anomalies (e.g. a wide moment causing FORDOUT +
+///     FL_time to drop while the car was not in the pits).
 mod Cli.Validation {
 
     use Util.Duration.Duration
@@ -239,14 +240,15 @@ mod Cli.Validation {
             Util.Duration.zero()
         );
         let blanks = parts |> List.filterMap(match (_, b) -> b);
-        if (sum == lap#lapTime)             Nil
-        else if (isChicaneCutPattern(blanks)) Nil
-        else                                Violation.MiniSectorSum(lap, lap#lapTime, sum, blanks) :: Nil
+        if (sum == lap#lapTime)               Nil
+        else if (isTrackLimitsPattern(blanks)) Nil
+        else                                  Violation.MiniSectorSum(lap, lap#lapTime, sum, blanks) :: Nil
 
     /// True when the blank `time`-column set matches a known Ford-chicane
-    /// cut signature for Le Mans 2025. Track-ordered list, so SCL1 always
-    /// precedes FORDOUT and PITREF always precedes SCL1.
-    def isChicaneCutPattern(blanks: List[String]): Bool =
+    /// track-limits-violation signature for Le Mans 2025. Track-ordered
+    /// list, so SCL1 always precedes FORDOUT and PITREF always precedes
+    /// SCL1.
+    def isTrackLimitsPattern(blanks: List[String]): Bool =
         blanks == "scl1" :: "fordout" :: Nil
             or blanks == "pitref" :: "scl1" :: Nil
 

--- a/flix/src/Cli/Validation.flix
+++ b/flix/src/Cli/Validation.flix
@@ -5,12 +5,17 @@
 /// to stderr.
 ///
 /// Rules:
-///   1. SectorSum         — `s1 + s2 + s3 == lapTime` (per row)
-///   2. ElapsedDrift      — per car, `elapsed[n] == sum(lapTime[1..=n])`
-///                          (cumulative-sum: every row from the first drift
-///                          onward is reported)
-///   3. HourElapsedOffset — across the CSV, `(hour - elapsed) mod 24h` is
-///                          constant
+///   1. SectorSum                  — `s1 + s2 + s3 == lapTime` (per row)
+///   2. ElapsedDrift               — per car, `elapsed[n] == sum(lapTime[1..=n])`
+///                                   (cumulative-sum: every row from the first drift
+///                                   onward is reported)
+///   3. HourElapsedOffset          — across the CSV, `(hour - elapsed) mod 24h` is
+///                                   constant
+///   4. MiniSectorSum              — when mini-sectors present, `sum(time) == lapTime`
+///                                   (per row, blank `time` counted as zero)
+///   5. MiniSectorElapsedMonotonic — when mini-sectors present, `elapsed` values are
+///                                   non-decreasing in track order (reports each
+///                                   adjacent pair that goes backwards)
 ///
 /// Design notes:
 ///   - HourElapsedOffset's baseline is the **first valid row in the whole
@@ -20,11 +25,16 @@
 ///     just compares offsets with `==`.
 ///   - Report order follows CSV appearance (per-lap is naturally CSV order;
 ///     per-car uses first-seen-index to sort the car groups).
+///   - Mini-sector rules silently skip laps where `miniSectors == None`
+///     (non-Le Mans rounds, or laps where all 30 source columns were blank).
 mod Cli.Validation {
 
     use Util.Duration.Duration
     use Util.HourClock
+    use Motorsport.MiniSector
+    use Motorsport.MiniSector.MiniSectorId
     use RawLap.RawLap
+    use RawLap.RawMiniSector
 
     pub enum Violation {
         /// `s1 + s2 + s3 != lapTime`.
@@ -39,6 +49,16 @@ mod Cli.Validation {
         /// `(hour - elapsed) mod 24h` does not match the baseline.
         /// Args: lap / baseline offset (ms, signed) / actual offset (ms, signed).
         case HourElapsedOffset(RawLap, Int32, Int32)
+
+        /// `sum(miniSector.time) != lapTime` for laps with mini-sector data.
+        /// Args: lap / lapTime / sum / json keys of sub-sectors with blank time.
+        case MiniSectorSum(RawLap, Duration, Duration, List[String])
+
+        /// Mini-sector `elapsed[i] < elapsed[i-1]` for some adjacent pair
+        /// in track order (only entries where both sides are present are
+        /// compared).
+        /// Args: lap / prev id / prev elapsed / curr id / curr elapsed.
+        case MiniSectorElapsedMonotonic(RawLap, MiniSectorId, Duration, MiniSectorId, Duration)
     }
 
     pub def validate(eventName: String, laps: List[RawLap]): List[String] =
@@ -48,7 +68,8 @@ mod Cli.Validation {
         let perLap = laps |> List.filterMap(lap -> resultToOption(checkSectorSum(lap)));
         let perCar = perCarViolations(laps);
         let perRace = checkHourElapsedRaceWide(laps);
-        List.append(perLap, List.append(perCar, perRace))
+        let perMini = laps |> List.flatMap(checkMiniSectors);
+        List.append(perLap, List.append(perCar, List.append(perRace, perMini)))
 
     def resultToOption(r: Result[Violation, Unit]): Option[Violation] =
         match r {
@@ -150,6 +171,71 @@ mod Cli.Validation {
                 formatDurationPair(eventName, lap, "elapsed-drift", expected, actual)
             case Violation.HourElapsedOffset(lap, base, offset) =>
                 formatSignedMsPair(eventName, lap, "hour-offset", base, offset)
+            case Violation.MiniSectorSum(lap, lapTime, sum, blanks) =>
+                let suffix =
+                    if (List.isEmpty(blanks)) ""
+                    else " (blank: ${List.join(",", blanks)})";
+                formatDurationPair(eventName, lap, "mini-sector-sum", lapTime, sum) + suffix
+            case Violation.MiniSectorElapsedMonotonic(lap, prevId, prevElapsed, currId, currElapsed) =>
+                let kind = "mini-sector-elapsed[${MiniSector.jsonKey(prevId)}->${MiniSector.jsonKey(currId)}]";
+                formatDurationPair(eventName, lap, kind, prevElapsed, currElapsed)
+        }
+
+    /// Per-lap mini-sector checks. Skipped entirely for laps without
+    /// mini-sector data (`miniSectors == None`). Otherwise emits at most
+    /// one `MiniSectorSum` plus zero or more `MiniSectorElapsedMonotonic`
+    /// violations.
+    def checkMiniSectors(lap: RawLap): List[Violation] =
+        match lap#miniSectors {
+            case None       => Nil
+            case Some(list) =>
+                let sumViol  = checkMiniSectorSum(lap, list);
+                let monoViol = checkMiniSectorMonotonic(lap, list);
+                List.append(sumViol, monoViol)
+        }
+
+    def checkMiniSectorSum(lap: RawLap, list: List[(MiniSectorId, RawMiniSector)]): List[Violation] =
+        let parts = list |> List.map(match (id, sector) ->
+            match sector#time {
+                case Some(d) => (d, None)
+                case None    => (Util.Duration.zero(), Some(MiniSector.jsonKey(id)))
+            }
+        );
+        let sum = parts |> List.foldLeft(
+            (acc, pair) -> match pair {
+                case (d, _) => Util.Duration.add(acc, d)
+            },
+            Util.Duration.zero()
+        );
+        let blanks = parts |> List.filterMap(match (_, b) -> b);
+        if (sum == lap#lapTime) Nil
+        else Violation.MiniSectorSum(lap, lap#lapTime, sum, blanks) :: Nil
+
+    /// Walks the track-ordered list and reports each adjacent pair where
+    /// the second elapsed is strictly less than the first. Entries with
+    /// blank elapsed are skipped without breaking the chain (so we still
+    /// catch a backwards step that straddles a single missing marker).
+    def checkMiniSectorMonotonic(lap: RawLap, list: List[(MiniSectorId, RawMiniSector)]): List[Violation] =
+        let folded = list |> List.foldLeft(
+            (state, pair) -> match (state, pair) {
+                case ((prev, acc), (id, sector)) =>
+                    match sector#elapsed {
+                        case None => (prev, acc)
+                        case Some(curr) => match prev {
+                            case None => (Some((id, curr)), acc)
+                            case Some((prevId, prevElapsed)) =>
+                                if (Util.Duration.millis(curr) >= Util.Duration.millis(prevElapsed))
+                                    (Some((id, curr)), acc)
+                                else
+                                    (Some((id, curr)),
+                                     Violation.MiniSectorElapsedMonotonic(lap, prevId, prevElapsed, id, curr) :: acc)
+                        }
+                    }
+            },
+            (None, Nil)
+        );
+        match folded {
+            case (_, acc) => List.reverse(acc)
         }
 
     /// Emits `{eventName}: [car X #N] kind: expected=<fmt> (<ms>ms) actual=<fmt> (<ms>ms)`.

--- a/flix/src/Cli/Validation.flix
+++ b/flix/src/Cli/Validation.flix
@@ -199,7 +199,7 @@ mod Cli.Validation {
                 formatDurationPair(eventName, lap, "mini-sector-sum", lapTime, sum) + suffix
             case Violation.MiniSectorElapsedMonotonic(lap, prevId, prevElapsed, currId, currElapsed) =>
                 let kind = "mini-sector-elapsed[${MiniSector.jsonKey(prevId)}->${MiniSector.jsonKey(currId)}]";
-                formatDurationPair(eventName, lap, kind, prevElapsed, currElapsed)
+                formatLabelledDurationPair(eventName, lap, kind, "prev", prevElapsed, "curr", currElapsed)
         }
 
     /// Per-lap mini-sector checks. Skipped entirely for laps without
@@ -227,22 +227,23 @@ mod Cli.Validation {
         lap#crossingFinishLineInPit or lap#pitTime != None
 
     def checkMiniSectorSum(lap: RawLap, list: List[(MiniSectorId, RawMiniSector)]): List[Violation] =
-        let parts = list |> List.map(match (id, sector) ->
-            match sector#time {
-                case Some(d) => (d, None)
-                case None    => (Util.Duration.zero(), Some(MiniSector.jsonKey(id)))
-            }
-        );
-        let sum = parts |> List.foldLeft(
-            (acc, pair) -> match pair {
-                case (d, _) => Util.Duration.add(acc, d)
+        let folded = list |> List.foldLeft(
+            (state, pair) -> match (state, pair) {
+                case ((accSum, accBlanks), (id, sector)) =>
+                    match sector#time {
+                        case Some(d) => (Util.Duration.add(accSum, d), accBlanks)
+                        case None    => (accSum, MiniSector.jsonKey(id) :: accBlanks)
+                    }
             },
-            Util.Duration.zero()
+            (Util.Duration.zero(), Nil)
         );
-        let blanks = parts |> List.filterMap(match (_, b) -> b);
-        if (sum == lap#lapTime)               Nil
-        else if (isTrackLimitsPattern(blanks)) Nil
-        else                                  Violation.MiniSectorSum(lap, lap#lapTime, sum, blanks) :: Nil
+        match folded {
+            case (sum, blanksRev) =>
+                let blanks = List.reverse(blanksRev);
+                if (sum == lap#lapTime)               Nil
+                else if (isTrackLimitsPattern(blanks)) Nil
+                else                                  Violation.MiniSectorSum(lap, lap#lapTime, sum, blanks) :: Nil
+        }
 
     /// True when the blank `time`-column set matches a known Ford-chicane
     /// track-limits-violation signature for Le Mans 2025. Track-ordered
@@ -265,7 +266,7 @@ mod Cli.Validation {
                         case Some(curr) => match prev {
                             case None => (Some((id, curr)), acc)
                             case Some((prevId, prevElapsed)) =>
-                                if (Util.Duration.millis(curr) >= Util.Duration.millis(prevElapsed))
+                                if (curr >= prevElapsed)
                                     (Some((id, curr)), acc)
                                 else
                                     (Some((id, curr)),
@@ -283,7 +284,22 @@ mod Cli.Validation {
     /// The raw ms is included alongside the formatted Duration to keep the
     /// output both human-readable and grep-friendly (matches Rust output).
     def formatDurationPair(eventName: String, lap: RawLap, kind: String, expected: Duration, actual: Duration): String =
-        "${eventName}: [car ${lap#car#carNumber} #${lap#lapNumber}] ${kind}: expected=${expected} (${Util.Duration.millis(expected)}ms) actual=${actual} (${Util.Duration.millis(actual)}ms)"
+        formatLabelledDurationPair(eventName, lap, kind, "expected", expected, "actual", actual)
+
+    /// Same shape as `formatDurationPair` but with caller-supplied labels.
+    /// Used by `MiniSectorElapsedMonotonic` to emit `prev=/curr=` instead of
+    /// `expected=/actual=`, since the comparison is "previous marker vs.
+    /// current marker" rather than "what we expected vs. what we observed".
+    def formatLabelledDurationPair(
+        eventName: String,
+        lap: RawLap,
+        kind: String,
+        leftLabel: String,
+        leftValue: Duration,
+        rightLabel: String,
+        rightValue: Duration
+    ): String =
+        "${eventName}: [car ${lap#car#carNumber} #${lap#lapNumber}] ${kind}: ${leftLabel}=${leftValue} (${Util.Duration.millis(leftValue)}ms) ${rightLabel}=${rightValue} (${Util.Duration.millis(rightValue)}ms)"
 
     def formatSignedMsPair(eventName: String, lap: RawLap, kind: String, expected: Int32, actual: Int32): String =
         "${eventName}: [car ${lap#car#carNumber} #${lap#lapNumber}] ${kind}: expected=${formatSignedMs(expected)} (${expected}ms) actual=${formatSignedMs(actual)} (${actual}ms)"

--- a/flix/src/Cli/Validation.flix
+++ b/flix/src/Cli/Validation.flix
@@ -236,13 +236,13 @@ mod Cli.Validation {
     def isPitLap(lap: RawLap): Bool =
         lap#crossingFinishLineInPit or lap#pitTime != None
 
-    def checkMiniSectorSum(lap: RawLap, list: List[(MiniSectorId, Option[RawMiniSector])]): List[Violation] =
+    def checkMiniSectorSum(lap: RawLap, list: List[(MiniSectorId, RawMiniSector)]): List[Violation] =
         let folded = list |> List.foldLeft(
             (state, pair) -> match (state, pair) {
-                case ((accSum, accBlanks), (id, opt)) =>
-                    match opt {
-                        case Some(sector) => (Util.Duration.add(accSum, sector#time), accBlanks)
-                        case None         => (accSum, id :: accBlanks)
+                case ((accSum, accBlanks), (id, sector)) =>
+                    match sector#time {
+                        case Some(d) => (Util.Duration.add(accSum, d), accBlanks)
+                        case None    => (accSum, id :: accBlanks)
                     }
             },
             (Util.Duration.zero(), Nil)
@@ -274,23 +274,21 @@ mod Cli.Validation {
     /// with blank elapsed are skipped without breaking the chain (so
     /// we still catch a backwards step that straddles a single missing
     /// marker).
-    def checkMiniSectorMonotonic(lap: RawLap, list: List[(MiniSectorId, Option[RawMiniSector])]): List[Violation] =
+    def checkMiniSectorMonotonic(lap: RawLap, list: List[(MiniSectorId, RawMiniSector)]): List[Violation] =
         let folded = list |> List.foldLeft(
             (state, pair) -> match (state, pair) {
-                case ((prev, acc), (id, opt)) =>
-                    match opt {
+                case ((prev, acc), (id, sector)) =>
+                    match sector#elapsed {
                         case None => (prev, acc)
-                        case Some(sector) =>
-                            let curr = sector#elapsed;
-                            match prev {
-                                case None => (Some((id, curr)), acc)
-                                case Some((prevId, prevElapsed)) =>
-                                    if (curr > prevElapsed)
-                                        (Some((id, curr)), acc)
-                                    else
-                                        (Some((id, curr)),
-                                         Violation.MiniSectorElapsedMonotonic(lap, prevId, prevElapsed, id, curr) :: acc)
-                            }
+                        case Some(curr) => match prev {
+                            case None => (Some((id, curr)), acc)
+                            case Some((prevId, prevElapsed)) =>
+                                if (curr > prevElapsed)
+                                    (Some((id, curr)), acc)
+                                else
+                                    (Some((id, curr)),
+                                     Violation.MiniSectorElapsedMonotonic(lap, prevId, prevElapsed, id, curr) :: acc)
+                        }
                     }
             },
             (None, Nil)

--- a/flix/src/Motorsport/MiniSector.flix
+++ b/flix/src/Motorsport/MiniSector.flix
@@ -1,0 +1,83 @@
+/// Le Mans 24h mini-sectors. The 15 named segments live alongside the
+/// standard S1/S2/S3 split and only appear in the Le Mans CSV; other WEC
+/// rounds omit these columns entirely. This module is the single source of
+/// truth for the IDs, their CSV column prefixes, and their JSON object
+/// keys, mirroring `Motorsport.Circuit.LeMans.miniSectorOrder` on the Elm
+/// side.
+mod Motorsport.MiniSector {
+
+    pub enum MiniSectorId with Eq {
+        case SCL2
+        case Z4
+        case IP1
+        case Z12
+        case SCLC
+        case A7_1
+        case IP2
+        case A8_1
+        case SCLB
+        case PORIN
+        case POROUT
+        case PITREF
+        case SCL1
+        case FORDOUT
+        case FL
+    }
+
+    /// Track-order list — must match Motorsport.Circuit.LeMans.miniSectorOrder.
+    /// Order: S1 (SCL2, Z4, IP1) → S2 (Z12, SCLC, A7-1, IP2) →
+    /// S3 (A8-1, SCLB, PORIN, POROUT, PITREF, SCL1, FORDOUT, FL).
+    pub def all(): List[MiniSectorId] =
+        MiniSectorId.SCL2 :: MiniSectorId.Z4 :: MiniSectorId.IP1 ::
+        MiniSectorId.Z12 :: MiniSectorId.SCLC :: MiniSectorId.A7_1 :: MiniSectorId.IP2 ::
+        MiniSectorId.A8_1 :: MiniSectorId.SCLB :: MiniSectorId.PORIN :: MiniSectorId.POROUT ::
+        MiniSectorId.PITREF :: MiniSectorId.SCL1 :: MiniSectorId.FORDOUT :: MiniSectorId.FL ::
+        Nil
+
+    /// CSV column prefix. Each mini-sector contributes two columns:
+    /// `${csvName}_time` and `${csvName}_elapsed`. Note that A7_1 and A8_1
+    /// use a hyphen in the CSV (A7-1, A8-1) — the Flix identifier underscore
+    /// is just an identifier-syntax constraint.
+    pub def csvName(id: MiniSectorId): String =
+        match id {
+            case MiniSectorId.SCL2    => "SCL2"
+            case MiniSectorId.Z4      => "Z4"
+            case MiniSectorId.IP1     => "IP1"
+            case MiniSectorId.Z12     => "Z12"
+            case MiniSectorId.SCLC    => "SCLC"
+            case MiniSectorId.A7_1    => "A7-1"
+            case MiniSectorId.IP2     => "IP2"
+            case MiniSectorId.A8_1    => "A8-1"
+            case MiniSectorId.SCLB    => "SCLB"
+            case MiniSectorId.PORIN   => "PORIN"
+            case MiniSectorId.POROUT  => "POROUT"
+            case MiniSectorId.PITREF  => "PITREF"
+            case MiniSectorId.SCL1    => "SCL1"
+            case MiniSectorId.FORDOUT => "FORDOUT"
+            case MiniSectorId.FL      => "FL"
+        }
+
+    /// JSON object key. Lower-case form of `csvName`, with the hyphen in
+    /// A7-1 / A8-1 collapsed back to an underscore so the keys are valid
+    /// JS identifiers (matches the Elm `Motorsport.Lap.MiniSectors` field
+    /// names).
+    pub def jsonKey(id: MiniSectorId): String =
+        match id {
+            case MiniSectorId.SCL2    => "scl2"
+            case MiniSectorId.Z4      => "z4"
+            case MiniSectorId.IP1     => "ip1"
+            case MiniSectorId.Z12     => "z12"
+            case MiniSectorId.SCLC    => "sclc"
+            case MiniSectorId.A7_1    => "a7_1"
+            case MiniSectorId.IP2     => "ip2"
+            case MiniSectorId.A8_1    => "a8_1"
+            case MiniSectorId.SCLB    => "sclb"
+            case MiniSectorId.PORIN   => "porin"
+            case MiniSectorId.POROUT  => "porout"
+            case MiniSectorId.PITREF  => "pitref"
+            case MiniSectorId.SCL1    => "scl1"
+            case MiniSectorId.FORDOUT => "fordout"
+            case MiniSectorId.FL      => "fl"
+        }
+
+}

--- a/flix/src/Motorsport/MiniSector.flix
+++ b/flix/src/Motorsport/MiniSector.flix
@@ -28,11 +28,12 @@ mod Motorsport.MiniSector {
     /// Order: S1 (SCL2, Z4, IP1) → S2 (Z12, SCLC, A7-1, IP2) →
     /// S3 (A8-1, SCLB, PORIN, POROUT, PITREF, SCL1, FORDOUT, FL).
     pub def all(): List[MiniSectorId] =
-        MiniSectorId.SCL2 :: MiniSectorId.Z4 :: MiniSectorId.IP1 ::
-        MiniSectorId.Z12 :: MiniSectorId.SCLC :: MiniSectorId.A7_1 :: MiniSectorId.IP2 ::
-        MiniSectorId.A8_1 :: MiniSectorId.SCLB :: MiniSectorId.PORIN :: MiniSectorId.POROUT ::
-        MiniSectorId.PITREF :: MiniSectorId.SCL1 :: MiniSectorId.FORDOUT :: MiniSectorId.FL ::
-        Nil
+        List#{
+            MiniSectorId.SCL2, MiniSectorId.Z4, MiniSectorId.IP1,
+            MiniSectorId.Z12, MiniSectorId.SCLC, MiniSectorId.A7_1, MiniSectorId.IP2,
+            MiniSectorId.A8_1, MiniSectorId.SCLB, MiniSectorId.PORIN, MiniSectorId.POROUT,
+            MiniSectorId.PITREF, MiniSectorId.SCL1, MiniSectorId.FORDOUT, MiniSectorId.FL
+        }
 
     /// CSV column prefix. Each mini-sector contributes two columns:
     /// `${csvName}_time` and `${csvName}_elapsed`. Note that A7_1 and A8_1

--- a/flix/src/Motorsport/MiniSector.flix
+++ b/flix/src/Motorsport/MiniSector.flix
@@ -25,8 +25,7 @@ mod Motorsport.MiniSector {
     }
 
     /// Track-order list — must match Motorsport.Circuit.LeMans.miniSectorOrder.
-    /// Order: S1 (SCL2, Z4, IP1) → S2 (Z12, SCLC, A7-1, IP2) →
-    /// S3 (A8-1, SCLB, PORIN, POROUT, PITREF, SCL1, FORDOUT, FL).
+    /// Line groups correspond to S1 / S2 / S3.
     pub def all(): List[MiniSectorId] =
         List#{
             MiniSectorId.SCL2, MiniSectorId.Z4, MiniSectorId.IP1,
@@ -35,10 +34,9 @@ mod Motorsport.MiniSector {
             MiniSectorId.PITREF, MiniSectorId.SCL1, MiniSectorId.FORDOUT, MiniSectorId.FL
         }
 
-    /// CSV column prefix. Each mini-sector contributes two columns:
-    /// `${csvName}_time` and `${csvName}_elapsed`. Note that A7_1 and A8_1
-    /// use a hyphen in the CSV (A7-1, A8-1) — the Flix identifier underscore
-    /// is just an identifier-syntax constraint.
+    /// CSV column prefix. A7_1 / A8_1 map to the hyphenated `A7-1` / `A8-1`
+    /// (the Flix identifier underscore is a syntax constraint, not part of
+    /// the column name). Each prefix yields two columns: `_time` and `_elapsed`.
     pub def csvName(id: MiniSectorId): String =
         match id {
             case MiniSectorId.SCL2    => "SCL2"
@@ -58,10 +56,8 @@ mod Motorsport.MiniSector {
             case MiniSectorId.FL      => "FL"
         }
 
-    /// JSON object key. Lower-case form of `csvName`, with the hyphen in
-    /// A7-1 / A8-1 collapsed back to an underscore so the keys are valid
-    /// JS identifiers (matches the Elm `Motorsport.Lap.MiniSectors` field
-    /// names).
+    /// JSON object key — lower-case `csvName` with the hyphen reverted to an
+    /// underscore (matches the Elm `Motorsport.Lap.MiniSectors` field names).
     pub def jsonKey(id: MiniSectorId): String =
         match id {
             case MiniSectorId.SCL2    => "scl2"

--- a/flix/src/Motorsport/MiniSector.flix
+++ b/flix/src/Motorsport/MiniSector.flix
@@ -77,4 +77,11 @@ mod Motorsport.MiniSector {
             case MiniSectorId.FL      => "fl"
         }
 
+    /// True when `blanks` matches one of the known Ford-chicane track-limits
+    /// signatures observed at Le Mans 2025: `SCL1+FORDOUT` (second chicane)
+    /// or `PITREF+SCL1` (first chicane). Assumes the input is in track order.
+    pub def isTrackLimitsSignature(blanks: List[MiniSectorId]): Bool =
+        blanks == List#{MiniSectorId.SCL1, MiniSectorId.FORDOUT}
+            or blanks == List#{MiniSectorId.PITREF, MiniSectorId.SCL1}
+
 }

--- a/flix/src/RawLap.flix
+++ b/flix/src/RawLap.flix
@@ -350,14 +350,14 @@ mod RawLap {
         let prefix = MiniSector.csvName(id);
         Decode.map2(
             (time, elapsed) -> { time = time, elapsed = elapsed },
-            optionalDurationFromMaybeField("${prefix}_time"),
-            optionalDurationFromMaybeField("${prefix}_elapsed")
+            optionalDurationFromOptionalColumn("${prefix}_time"),
+            optionalDurationFromOptionalColumn("${prefix}_elapsed")
         )
 
     /// Combines `Decode.optionalField` (header missing → `None`) with
     /// `optionalDurationField` (blank value → `None`) and flattens the
     /// resulting `Option[Option[Duration]]` to `Option[Duration]`.
-    def optionalDurationFromMaybeField(name: String): Decoder[Option[Duration]] =
+    def optionalDurationFromOptionalColumn(name: String): Decoder[Option[Duration]] =
         Decode.map(Option.flatten, Decode.optionalField(name, optionalDurationField(name)))
 
     def collapseIfAllNone(list: List[(MiniSectorId, RawMiniSector)]): Option[List[(MiniSectorId, RawMiniSector)]] =

--- a/flix/src/RawLap.flix
+++ b/flix/src/RawLap.flix
@@ -47,11 +47,10 @@ mod RawLap {
         improvement = Improvement
     }
 
-    /// One Le Mans mini-sector observation. `time` is the duration of the
-    /// segment between the previous mini-sector marker and this one;
-    /// `elapsed` is the cumulative time from the start of the lap up to this
-    /// marker. Both are `Option` because the values can be blank in the CSV
-    /// (e.g. on a pit lap or when the timing system missed a marker).
+    /// One Le Mans mini-sector observation. `time` is the segment duration
+    /// from the previous marker; `elapsed` is the cumulative time from the
+    /// start of the lap. Both are `Option` because either column can be
+    /// blank (pit laps, missed markers).
     pub type alias RawMiniSector = {
         time = Option[Duration],
         elapsed = Option[Duration]
@@ -332,11 +331,9 @@ mod RawLap {
             case None     => JsonString("")
         }
 
-    /// Decodes the 15 Le Mans mini-sectors (each contributes `<NAME>_time`
-    /// and `<NAME>_elapsed`). Columns absent from the header (non-Le Mans
-    /// CSVs) and blank values both decode to `None` for that side. When
-    /// every entry is `None` for both sides the whole list collapses to
-    /// `None` so `toJson` can omit the `miniSectors` key.
+    /// Decodes the 15 Le Mans mini-sectors. Missing columns (non-Le Mans
+    /// CSVs) and blank values both decode to `None`; an all-`None` row
+    /// collapses to `None` so `toJson` can omit the `miniSectors` key.
     def miniSectorsDecoder(): Decoder[Option[List[(MiniSectorId, RawMiniSector)]]] =
         Decode.map(collapseIfAllNone, decodeMiniSectorList(MiniSector.all()))
 
@@ -354,9 +351,7 @@ mod RawLap {
             optionalDurationFromOptionalColumn("${prefix}_elapsed")
         )
 
-    /// Combines `Decode.optionalField` (header missing → `None`) with
-    /// `optionalDurationField` (blank value → `None`) and flattens the
-    /// resulting `Option[Option[Duration]]` to `Option[Duration]`.
+    /// Both "header missing" and "blank value" map to `None`.
     def optionalDurationFromOptionalColumn(name: String): Decoder[Option[Duration]] =
         Decode.map(Option.flatten, Decode.optionalField(name, optionalDurationField(name)))
 

--- a/flix/src/RawLap.flix
+++ b/flix/src/RawLap.flix
@@ -340,29 +340,17 @@ mod RawLap {
         Decode.map(collapseIfAllNone, decodeMiniSectorList(MiniSector.all()))
 
     def decodeMiniSectorList(ids: List[MiniSectorId]): Decoder[List[(MiniSectorId, RawMiniSector)]] =
-        List.foldRight(
-            (id, acc) ->
-                Decode.andThen(
-                    sector ->
-                        Decode.andThen(
-                            rest -> Decode.succeed((id, sector) :: rest),
-                            acc
-                        ),
-                    miniSectorDecoder(id)
-                ),
-            Decode.succeed(Nil),
+        Decode.traverse(
+            id -> Decode.map(sector -> (id, sector), miniSectorDecoder(id)),
             ids
         )
 
     def miniSectorDecoder(id: MiniSectorId): Decoder[RawMiniSector] =
         let prefix = MiniSector.csvName(id);
-        Decode.andThen(
-            time ->
-                Decode.andThen(
-                    elapsed -> Decode.succeed({ time = time, elapsed = elapsed }),
-                    optionalDurationFromMaybeField("${prefix}_elapsed")
-                ),
-            optionalDurationFromMaybeField("${prefix}_time")
+        Decode.map2(
+            (time, elapsed) -> { time = time, elapsed = elapsed },
+            optionalDurationFromMaybeField("${prefix}_time"),
+            optionalDurationFromMaybeField("${prefix}_elapsed")
         )
 
     /// Combines `Decode.optionalField` (header missing → `None`) with

--- a/flix/src/RawLap.flix
+++ b/flix/src/RawLap.flix
@@ -49,12 +49,16 @@ mod RawLap {
 
     /// One Le Mans mini-sector observation. `time` is the duration of the
     /// segment between the previous mini-sector marker and this one;
-    /// `elapsed` is the cumulative time from the start of the lap up to this
-    /// marker. Both are `Option` because the values can be blank in the CSV
-    /// (e.g. on a pit lap or when the timing system missed a marker).
+    /// `elapsed` is the cumulative time from the start of the lap up to
+    /// this marker. Both fields are required to be present together — the
+    /// outer `Option` (in `miniSectors: Option[List[(MiniSectorId,
+    /// Option[RawMiniSector])]]`) carries the "this marker was blank for
+    /// this lap" axis (pit lap, missed loop, track-limits cut). Half-empty
+    /// rows (one of `time`/`elapsed` set, the other blank) are rejected at
+    /// decode time so this representational state stays unreachable.
     pub type alias RawMiniSector = {
-        time = Option[Duration],
-        elapsed = Option[Duration]
+        time = Duration,
+        elapsed = Duration
     }
 
     pub type alias RawCar = {
@@ -86,7 +90,7 @@ mod RawLap {
         topSpeed = String,
         pitTime = Option[Duration],
         flagAtFl = Flag,
-        miniSectors = Option[List[(MiniSectorId, RawMiniSector)]]
+        miniSectors = Option[List[(MiniSectorId, Option[RawMiniSector])]]
     }
 
     pub def decoder(): Decoder[RawLap] =
@@ -337,21 +341,34 @@ mod RawLap {
     /// CSVs) and blank values both decode to `None` for that side. When
     /// every entry is `None` for both sides the whole list collapses to
     /// `None` so `toJson` can omit the `miniSectors` key.
-    def miniSectorsDecoder(): Decoder[Option[List[(MiniSectorId, RawMiniSector)]]] =
+    def miniSectorsDecoder(): Decoder[Option[List[(MiniSectorId, Option[RawMiniSector])]]] =
         Decode.map(collapseIfAllNone, decodeMiniSectorList(MiniSector.all()))
 
-    def decodeMiniSectorList(ids: List[MiniSectorId]): Decoder[List[(MiniSectorId, RawMiniSector)]] =
+    def decodeMiniSectorList(ids: List[MiniSectorId]): Decoder[List[(MiniSectorId, Option[RawMiniSector])]] =
         Extra.traverse(
             id -> Decode.map(sector -> (id, sector), miniSectorDecoder(id)),
             ids
         )
 
-    def miniSectorDecoder(id: MiniSectorId): Decoder[RawMiniSector] =
+    /// Decodes one mini-sector. Both columns must agree: both present →
+    /// `Some(record)`, both blank → `None`. A half-empty pair (only one
+    /// of the two columns populated) is rejected with `Decode.fail` so
+    /// the type cannot represent that asymmetric state at all.
+    def miniSectorDecoder(id: MiniSectorId): Decoder[Option[RawMiniSector]] =
         let prefix = MiniSector.csvName(id);
-        Decode.map2(
-            (time, elapsed) -> { time = time, elapsed = elapsed },
+        let pair = Decode.map2(
+            (t, e) -> (t, e),
             optionalDurationFromOptionalColumn("${prefix}_time"),
             optionalDurationFromOptionalColumn("${prefix}_elapsed")
+        );
+        Decode.andThen(
+            result -> match result {
+                case (None, None)       => Decode.succeed(None)
+                case (Some(t), Some(e)) => Decode.succeed(Some({ time = t, elapsed = e }))
+                case (Some(_), None)    => Decode.fail("mini-sector ${prefix}: ${prefix}_time present but ${prefix}_elapsed blank")
+                case (None, Some(_))    => Decode.fail("mini-sector ${prefix}: ${prefix}_elapsed present but ${prefix}_time blank")
+            },
+            pair
         )
 
     /// Combines `Decode.optionalField` (header missing → `None`) with
@@ -360,26 +377,21 @@ mod RawLap {
     def optionalDurationFromOptionalColumn(name: String): Decoder[Option[Duration]] =
         Decode.map(Option.flatten, Decode.optionalField(name, optionalDurationField(name)))
 
-    def collapseIfAllNone(list: List[(MiniSectorId, RawMiniSector)]): Option[List[(MiniSectorId, RawMiniSector)]] =
-        let hasAny = List.exists(
-            match (_, sector) -> sector#time != None or sector#elapsed != None,
-            list
-        );
+    def collapseIfAllNone(list: List[(MiniSectorId, Option[RawMiniSector])]): Option[List[(MiniSectorId, Option[RawMiniSector])]] =
+        let hasAny = List.exists(match (_, opt) -> opt != None, list);
         if (hasAny) Some(list) else None
 
-    def miniSectorsToJson(list: List[(MiniSectorId, RawMiniSector)]): Json.JsonValue =
-        let entries = list |> List.filterMap(match (id, sector) ->
-            if (sector#time == None and sector#elapsed == None)
-                None
-            else
-                Some((MiniSector.jsonKey(id), miniSectorToJson(sector)))
-        );
+    def miniSectorsToJson(list: List[(MiniSectorId, Option[RawMiniSector])]): Json.JsonValue =
+        let entries = list |> List.filterMap(match (id, opt) -> match opt {
+            case None         => None
+            case Some(sector) => Some((MiniSector.jsonKey(id), miniSectorToJson(sector)))
+        });
         JsonObject(entries)
 
     def miniSectorToJson(sector: RawMiniSector): Json.JsonValue =
         JsonObject(
-            ("time",    optionalDurationJson(sector#time)) ::
-            ("elapsed", optionalDurationJson(sector#elapsed)) ::
+            ("time",    JsonString(Util.Duration.format(sector#time))) ::
+            ("elapsed", JsonString(Util.Duration.format(sector#elapsed))) ::
             Nil
         )
 

--- a/flix/src/RawLap.flix
+++ b/flix/src/RawLap.flix
@@ -208,7 +208,7 @@ mod RawLap {
         match secondsToMillis(name, secondsRaw) {
             case Err(e)       => Err(e)
             case Ok(secondsMs) =>
-                let observed = List.filterMap(x -> x, valueMs :: largeMs :: secondsMs :: Nil);
+                let observed = List.filterMap(x -> x, List#{valueMs, largeMs, secondsMs});
                 match observed {
                     case Nil           => Ok({ value = valueMs, improvement = improvement })
                     case first :: rest =>

--- a/flix/src/RawLap.flix
+++ b/flix/src/RawLap.flix
@@ -2,6 +2,7 @@ mod RawLap {
 
     use Util.Csv.Decode
     use Util.Csv.Decode.Decoder
+    use Util.Csv.Decode.Extra
     use Util.Duration.Duration
     use Util.HourClock
     use Util.HourClock.Hour
@@ -340,7 +341,7 @@ mod RawLap {
         Decode.map(collapseIfAllNone, decodeMiniSectorList(MiniSector.all()))
 
     def decodeMiniSectorList(ids: List[MiniSectorId]): Decoder[List[(MiniSectorId, RawMiniSector)]] =
-        Decode.traverse(
+        Extra.traverse(
             id -> Decode.map(sector -> (id, sector), miniSectorDecoder(id)),
             ids
         )

--- a/flix/src/RawLap.flix
+++ b/flix/src/RawLap.flix
@@ -49,16 +49,12 @@ mod RawLap {
 
     /// One Le Mans mini-sector observation. `time` is the duration of the
     /// segment between the previous mini-sector marker and this one;
-    /// `elapsed` is the cumulative time from the start of the lap up to
-    /// this marker. Both fields are required to be present together — the
-    /// outer `Option` (in `miniSectors: Option[List[(MiniSectorId,
-    /// Option[RawMiniSector])]]`) carries the "this marker was blank for
-    /// this lap" axis (pit lap, missed loop, track-limits cut). Half-empty
-    /// rows (one of `time`/`elapsed` set, the other blank) are rejected at
-    /// decode time so this representational state stays unreachable.
+    /// `elapsed` is the cumulative time from the start of the lap up to this
+    /// marker. Both are `Option` because the values can be blank in the CSV
+    /// (e.g. on a pit lap or when the timing system missed a marker).
     pub type alias RawMiniSector = {
-        time = Duration,
-        elapsed = Duration
+        time = Option[Duration],
+        elapsed = Option[Duration]
     }
 
     pub type alias RawCar = {
@@ -90,7 +86,7 @@ mod RawLap {
         topSpeed = String,
         pitTime = Option[Duration],
         flagAtFl = Flag,
-        miniSectors = Option[List[(MiniSectorId, Option[RawMiniSector])]]
+        miniSectors = Option[List[(MiniSectorId, RawMiniSector)]]
     }
 
     pub def decoder(): Decoder[RawLap] =
@@ -341,34 +337,21 @@ mod RawLap {
     /// CSVs) and blank values both decode to `None` for that side. When
     /// every entry is `None` for both sides the whole list collapses to
     /// `None` so `toJson` can omit the `miniSectors` key.
-    def miniSectorsDecoder(): Decoder[Option[List[(MiniSectorId, Option[RawMiniSector])]]] =
+    def miniSectorsDecoder(): Decoder[Option[List[(MiniSectorId, RawMiniSector)]]] =
         Decode.map(collapseIfAllNone, decodeMiniSectorList(MiniSector.all()))
 
-    def decodeMiniSectorList(ids: List[MiniSectorId]): Decoder[List[(MiniSectorId, Option[RawMiniSector])]] =
+    def decodeMiniSectorList(ids: List[MiniSectorId]): Decoder[List[(MiniSectorId, RawMiniSector)]] =
         Extra.traverse(
             id -> Decode.map(sector -> (id, sector), miniSectorDecoder(id)),
             ids
         )
 
-    /// Decodes one mini-sector. Both columns must agree: both present →
-    /// `Some(record)`, both blank → `None`. A half-empty pair (only one
-    /// of the two columns populated) is rejected with `Decode.fail` so
-    /// the type cannot represent that asymmetric state at all.
-    def miniSectorDecoder(id: MiniSectorId): Decoder[Option[RawMiniSector]] =
+    def miniSectorDecoder(id: MiniSectorId): Decoder[RawMiniSector] =
         let prefix = MiniSector.csvName(id);
-        let pair = Decode.map2(
-            (t, e) -> (t, e),
+        Decode.map2(
+            (time, elapsed) -> { time = time, elapsed = elapsed },
             optionalDurationFromOptionalColumn("${prefix}_time"),
             optionalDurationFromOptionalColumn("${prefix}_elapsed")
-        );
-        Decode.andThen(
-            result -> match result {
-                case (None, None)       => Decode.succeed(None)
-                case (Some(t), Some(e)) => Decode.succeed(Some({ time = t, elapsed = e }))
-                case (Some(_), None)    => Decode.fail("mini-sector ${prefix}: ${prefix}_time present but ${prefix}_elapsed blank")
-                case (None, Some(_))    => Decode.fail("mini-sector ${prefix}: ${prefix}_elapsed present but ${prefix}_time blank")
-            },
-            pair
         )
 
     /// Combines `Decode.optionalField` (header missing → `None`) with
@@ -377,21 +360,26 @@ mod RawLap {
     def optionalDurationFromOptionalColumn(name: String): Decoder[Option[Duration]] =
         Decode.map(Option.flatten, Decode.optionalField(name, optionalDurationField(name)))
 
-    def collapseIfAllNone(list: List[(MiniSectorId, Option[RawMiniSector])]): Option[List[(MiniSectorId, Option[RawMiniSector])]] =
-        let hasAny = List.exists(match (_, opt) -> opt != None, list);
+    def collapseIfAllNone(list: List[(MiniSectorId, RawMiniSector)]): Option[List[(MiniSectorId, RawMiniSector)]] =
+        let hasAny = List.exists(
+            match (_, sector) -> sector#time != None or sector#elapsed != None,
+            list
+        );
         if (hasAny) Some(list) else None
 
-    def miniSectorsToJson(list: List[(MiniSectorId, Option[RawMiniSector])]): Json.JsonValue =
-        let entries = list |> List.filterMap(match (id, opt) -> match opt {
-            case None         => None
-            case Some(sector) => Some((MiniSector.jsonKey(id), miniSectorToJson(sector)))
-        });
+    def miniSectorsToJson(list: List[(MiniSectorId, RawMiniSector)]): Json.JsonValue =
+        let entries = list |> List.filterMap(match (id, sector) ->
+            if (sector#time == None and sector#elapsed == None)
+                None
+            else
+                Some((MiniSector.jsonKey(id), miniSectorToJson(sector)))
+        );
         JsonObject(entries)
 
     def miniSectorToJson(sector: RawMiniSector): Json.JsonValue =
         JsonObject(
-            ("time",    JsonString(Util.Duration.format(sector#time))) ::
-            ("elapsed", JsonString(Util.Duration.format(sector#elapsed))) ::
+            ("time",    optionalDurationJson(sector#time)) ::
+            ("elapsed", optionalDurationJson(sector#elapsed)) ::
             Nil
         )
 

--- a/flix/src/RawLap.flix
+++ b/flix/src/RawLap.flix
@@ -378,7 +378,7 @@ mod RawLap {
         Decode.map(Option.flatten, Decode.optionalField(name, optionalDurationField(name)))
 
     def collapseIfAllNone(list: List[(MiniSectorId, Option[RawMiniSector])]): Option[List[(MiniSectorId, Option[RawMiniSector])]] =
-        let hasAny = List.exists(match (_, opt) -> Option.isEmpty(opt) |> Bool.not, list);
+        let hasAny = List.exists(match (_, opt) -> not Option.isEmpty(opt), list);
         if (hasAny) Some(list) else None
 
     def miniSectorsToJson(list: List[(MiniSectorId, Option[RawMiniSector])]): Json.JsonValue =

--- a/flix/src/RawLap.flix
+++ b/flix/src/RawLap.flix
@@ -378,7 +378,7 @@ mod RawLap {
         Decode.map(Option.flatten, Decode.optionalField(name, optionalDurationField(name)))
 
     def collapseIfAllNone(list: List[(MiniSectorId, Option[RawMiniSector])]): Option[List[(MiniSectorId, Option[RawMiniSector])]] =
-        let hasAny = List.exists(match (_, opt) -> not Option.isEmpty(opt), list);
+        let hasAny = List.exists(match (_, opt) -> Option.isEmpty(opt) |> Bool.not, list);
         if (hasAny) Some(list) else None
 
     def miniSectorsToJson(list: List[(MiniSectorId, Option[RawMiniSector])]): Json.JsonValue =

--- a/flix/src/RawLap.flix
+++ b/flix/src/RawLap.flix
@@ -378,7 +378,7 @@ mod RawLap {
         Decode.map(Option.flatten, Decode.optionalField(name, optionalDurationField(name)))
 
     def collapseIfAllNone(list: List[(MiniSectorId, Option[RawMiniSector])]): Option[List[(MiniSectorId, Option[RawMiniSector])]] =
-        let hasAny = List.exists(match (_, opt) -> Option.isEmpty(opt) |> Bool.not, list);
+        let hasAny = List.exists(match (_, opt) -> opt != None, list);
         if (hasAny) Some(list) else None
 
     def miniSectorsToJson(list: List[(MiniSectorId, Option[RawMiniSector])]): Json.JsonValue =

--- a/flix/src/RawLap.flix
+++ b/flix/src/RawLap.flix
@@ -378,7 +378,7 @@ mod RawLap {
         Decode.map(Option.flatten, Decode.optionalField(name, optionalDurationField(name)))
 
     def collapseIfAllNone(list: List[(MiniSectorId, Option[RawMiniSector])]): Option[List[(MiniSectorId, Option[RawMiniSector])]] =
-        let hasAny = List.exists(match (_, opt) -> opt != None, list);
+        let hasAny = List.exists(match (_, opt) -> Option.isEmpty(opt) |> Bool.not, list);
         if (hasAny) Some(list) else None
 
     def miniSectorsToJson(list: List[(MiniSectorId, Option[RawMiniSector])]): Json.JsonValue =

--- a/flix/src/RawLap.flix
+++ b/flix/src/RawLap.flix
@@ -7,6 +7,8 @@ mod RawLap {
     use Util.HourClock.Hour
     use Util.Json
     use Util.Json.JsonValue.{JsonObject, JsonString, JsonInt, JsonArray}
+    use Motorsport.MiniSector
+    use Motorsport.MiniSector.MiniSectorId
 
     /// Improvement flag observed in WEC LAP_IMPROVEMENT and S*_IMPROVEMENT
     /// columns. Semantics derived from empirical CSV analysis:
@@ -44,6 +46,16 @@ mod RawLap {
         improvement = Improvement
     }
 
+    /// One Le Mans mini-sector observation. `time` is the duration of the
+    /// segment between the previous mini-sector marker and this one;
+    /// `elapsed` is the cumulative time from the start of the lap up to this
+    /// marker. Both are `Option` because the values can be blank in the CSV
+    /// (e.g. on a pit lap or when the timing system missed a marker).
+    pub type alias RawMiniSector = {
+        time = Option[Duration],
+        elapsed = Option[Duration]
+    }
+
     pub type alias RawCar = {
         carNumber = String,
         class = String,
@@ -72,14 +84,15 @@ mod RawLap {
         hour = Hour,
         topSpeed = String,
         pitTime = Option[Duration],
-        flagAtFl = Flag
+        flagAtFl = Flag,
+        miniSectors = Option[List[(MiniSectorId, RawMiniSector)]]
     }
 
     pub def decoder(): Decoder[RawLap] =
         Decode.intoRecord(
             car -> driver -> lapNumber -> lapTime -> lapImprovement ->
             crossingFinishLineInPit -> s1 -> s2 -> s3 -> kph -> elapsed -> hour ->
-            topSpeed -> pitTime -> flagAtFl ->
+            topSpeed -> pitTime -> flagAtFl -> miniSectors ->
                 {
                     car = car,
                     driver = driver,
@@ -95,7 +108,8 @@ mod RawLap {
                     hour = hour,
                     topSpeed = topSpeed,
                     pitTime = pitTime,
-                    flagAtFl = flagAtFl
+                    flagAtFl = flagAtFl,
+                    miniSectors = miniSectors
                 }
         )
             |> Decode.pipeline(carDecoder())
@@ -113,9 +127,10 @@ mod RawLap {
             |> Decode.pipeline(numericOrBlankStringField("TOP_SPEED"))
             |> Decode.pipeline(optionalDurationField("PIT_TIME"))
             |> Decode.pipeline(flagField("FLAG_AT_FL"))
+            |> Decode.pipeline(miniSectorsDecoder())
 
     pub def toJson(rawLap: RawLap): Json.JsonValue =
-        JsonObject(
+        let baseFields =
             ("carNumber",               JsonString(rawLap#car#carNumber)) ::
             ("driverNumber",            JsonInt(rawLap#driver#number)) ::
             ("lapNumber",               JsonInt(rawLap#lapNumber)) ::
@@ -139,8 +154,12 @@ mod RawLap {
             ("team",                    JsonString(rawLap#car#team)) ::
             ("manufacturer",            JsonString(rawLap#car#manufacturer)) ::
             ("flagAtFl",                JsonString(flagToString(rawLap#flagAtFl))) ::
-            Nil
-        )
+            Nil;
+        let miniFields = match rawLap#miniSectors {
+            case None       => Nil
+            case Some(list) => ("miniSectors", miniSectorsToJson(list)) :: Nil
+        };
+        JsonObject(List.append(baseFields, miniFields))
 
     def carDecoder(): Decoder[RawCar] =
         Decode.intoRecord(
@@ -311,5 +330,68 @@ mod RawLap {
             case Some(ms) => JsonString(Util.Duration.format(ms))
             case None     => JsonString("")
         }
+
+    /// Decodes the 15 Le Mans mini-sectors (each contributes `<NAME>_time`
+    /// and `<NAME>_elapsed`). Columns absent from the header (non-Le Mans
+    /// CSVs) and blank values both decode to `None` for that side. When
+    /// every entry is `None` for both sides the whole list collapses to
+    /// `None` so `toJson` can omit the `miniSectors` key.
+    def miniSectorsDecoder(): Decoder[Option[List[(MiniSectorId, RawMiniSector)]]] =
+        Decode.map(collapseIfAllNone, decodeMiniSectorList(MiniSector.all()))
+
+    def decodeMiniSectorList(ids: List[MiniSectorId]): Decoder[List[(MiniSectorId, RawMiniSector)]] =
+        List.foldRight(
+            (id, acc) ->
+                Decode.andThen(
+                    sector ->
+                        Decode.andThen(
+                            rest -> Decode.succeed((id, sector) :: rest),
+                            acc
+                        ),
+                    miniSectorDecoder(id)
+                ),
+            Decode.succeed(Nil),
+            ids
+        )
+
+    def miniSectorDecoder(id: MiniSectorId): Decoder[RawMiniSector] =
+        let prefix = MiniSector.csvName(id);
+        Decode.andThen(
+            time ->
+                Decode.andThen(
+                    elapsed -> Decode.succeed({ time = time, elapsed = elapsed }),
+                    optionalDurationFromMaybeField("${prefix}_elapsed")
+                ),
+            optionalDurationFromMaybeField("${prefix}_time")
+        )
+
+    /// Combines `Decode.optionalField` (header missing → `None`) with
+    /// `optionalDurationField` (blank value → `None`) and flattens the
+    /// resulting `Option[Option[Duration]]` to `Option[Duration]`.
+    def optionalDurationFromMaybeField(name: String): Decoder[Option[Duration]] =
+        Decode.map(Option.flatten, Decode.optionalField(name, optionalDurationField(name)))
+
+    def collapseIfAllNone(list: List[(MiniSectorId, RawMiniSector)]): Option[List[(MiniSectorId, RawMiniSector)]] =
+        let hasAny = List.exists(
+            match (_, sector) -> sector#time != None or sector#elapsed != None,
+            list
+        );
+        if (hasAny) Some(list) else None
+
+    def miniSectorsToJson(list: List[(MiniSectorId, RawMiniSector)]): Json.JsonValue =
+        let entries = list |> List.filterMap(match (id, sector) ->
+            if (sector#time == None and sector#elapsed == None)
+                None
+            else
+                Some((MiniSector.jsonKey(id), miniSectorToJson(sector)))
+        );
+        JsonObject(entries)
+
+    def miniSectorToJson(sector: RawMiniSector): Json.JsonValue =
+        JsonObject(
+            ("time",    optionalDurationJson(sector#time)) ::
+            ("elapsed", optionalDurationJson(sector#elapsed)) ::
+            Nil
+        )
 
 }

--- a/flix/src/Util/Csv/Decode.flix
+++ b/flix/src/Util/Csv/Decode.flix
@@ -490,26 +490,6 @@ mod Util.Csv.Decode {
     pub def pipeline(decoder: Decoder[a], decoderFn: Decoder[a -> b]): Decoder[b] =
         map2((value, fn) -> fn(value), decoder, decoderFn)
 
-    /// Apply a decoder-producing function to every element of a list and
-    /// collect the results into a single list-valued decoder.
-    ///
-    /// Equivalent to `sequence . map f` in Haskell-style notation. The
-    /// produced decoder applies each per-element decoder to the same row in
-    /// list order; failures accumulate via the underlying `map2` rather
-    /// than short-circuiting (mirrors `pipeline`).
-    ///
-    /// Prefer this over `List.foldRight` with nested `andThen` when the
-    /// per-element decoders are independent: `andThen` rebuilds inner
-    /// decoders on every row (because the continuation `next(value)` is
-    /// invoked per-row), whereas `traverse` builds the full decoder graph
-    /// once at construction time and only walks it per row.
-    pub def traverse(f: a -> Decoder[b], list: List[a]): Decoder[List[b]] =
-        List.foldRight(
-            (x, acc) -> map2((b, bs) -> b :: bs, f(x), acc),
-            succeed(Nil),
-            list
-        )
-
     ///
     /// ===== FANCY DECODING =====
     ///

--- a/flix/src/Util/Csv/Decode.flix
+++ b/flix/src/Util/Csv/Decode.flix
@@ -490,6 +490,26 @@ mod Util.Csv.Decode {
     pub def pipeline(decoder: Decoder[a], decoderFn: Decoder[a -> b]): Decoder[b] =
         map2((value, fn) -> fn(value), decoder, decoderFn)
 
+    /// Apply a decoder-producing function to every element of a list and
+    /// collect the results into a single list-valued decoder.
+    ///
+    /// Equivalent to `sequence . map f` in Haskell-style notation. The
+    /// produced decoder applies each per-element decoder to the same row in
+    /// list order; failures accumulate via the underlying `map2` rather
+    /// than short-circuiting (mirrors `pipeline`).
+    ///
+    /// Prefer this over `List.foldRight` with nested `andThen` when the
+    /// per-element decoders are independent: `andThen` rebuilds inner
+    /// decoders on every row (because the continuation `next(value)` is
+    /// invoked per-row), whereas `traverse` builds the full decoder graph
+    /// once at construction time and only walks it per row.
+    pub def traverse(f: a -> Decoder[b], list: List[a]): Decoder[List[b]] =
+        List.foldRight(
+            (x, acc) -> map2((b, bs) -> b :: bs, f(x), acc),
+            succeed(Nil),
+            list
+        )
+
     ///
     /// ===== FANCY DECODING =====
     ///

--- a/flix/src/Util/Csv/Decode/Extra.flix
+++ b/flix/src/Util/Csv/Decode/Extra.flix
@@ -7,18 +7,13 @@ mod Util.Csv.Decode.Extra {
     use Util.Csv.Decode.Decoder
 
     /// Apply a decoder-producing function to every element of a list and
-    /// collect the results into a single list-valued decoder.
+    /// collect the results into a single list-valued decoder. Equivalent
+    /// to `sequence . map f`; failures accumulate via `map2` rather than
+    /// short-circuiting (mirrors `pipeline`).
     ///
-    /// Equivalent to `sequence . map f` in Haskell-style notation. The
-    /// produced decoder applies each per-element decoder to the same row
-    /// in list order; failures accumulate via the underlying `map2`
-    /// rather than short-circuiting (mirrors `pipeline`).
-    ///
-    /// Prefer this over `List.foldRight` with nested `andThen` when the
-    /// per-element decoders are independent: `andThen` rebuilds inner
-    /// decoders on every row (because the continuation `next(value)` is
-    /// invoked per-row), whereas `traverse` builds the full decoder
-    /// graph once at construction time and only walks it per row.
+    /// Prefer this over nested `andThen` when the per-element decoders are
+    /// independent: `andThen` rebuilds them per row, whereas `traverse`
+    /// builds the decoder graph once.
     pub def traverse(f: a -> Decoder[b], list: List[a]): Decoder[List[b]] =
         List.foldRight(
             (x, acc) -> Util.Csv.Decode.map2((b, bs) -> b :: bs, f(x), acc),

--- a/flix/src/Util/Csv/Decode/Extra.flix
+++ b/flix/src/Util/Csv/Decode/Extra.flix
@@ -4,8 +4,6 @@
 /// vanilla combinators don't compose cleanly.
 mod Util.Csv.Decode.Extra {
 
-    use Util.Csv.Decode.Decoder
-
     /// Apply a decoder-producing function to every element of a list and
     /// collect the results into a single list-valued decoder.
     ///
@@ -19,7 +17,7 @@ mod Util.Csv.Decode.Extra {
     /// decoders on every row (because the continuation `next(value)` is
     /// invoked per-row), whereas `traverse` builds the full decoder
     /// graph once at construction time and only walks it per row.
-    pub def traverse(f: a -> Decoder[b], list: List[a]): Decoder[List[b]] =
+    pub def traverse(f: a -> Util.Csv.Decode.Decoder[b], list: List[a]): Util.Csv.Decode.Decoder[List[b]] =
         List.foldRight(
             (x, acc) -> Util.Csv.Decode.map2((b, bs) -> b :: bs, f(x), acc),
             Util.Csv.Decode.succeed(Nil),

--- a/flix/src/Util/Csv/Decode/Extra.flix
+++ b/flix/src/Util/Csv/Decode/Extra.flix
@@ -4,6 +4,8 @@
 /// vanilla combinators don't compose cleanly.
 mod Util.Csv.Decode.Extra {
 
+    use Util.Csv.Decode.Decoder
+
     /// Apply a decoder-producing function to every element of a list and
     /// collect the results into a single list-valued decoder.
     ///
@@ -17,7 +19,7 @@ mod Util.Csv.Decode.Extra {
     /// decoders on every row (because the continuation `next(value)` is
     /// invoked per-row), whereas `traverse` builds the full decoder
     /// graph once at construction time and only walks it per row.
-    pub def traverse(f: a -> Util.Csv.Decode.Decoder[b], list: List[a]): Util.Csv.Decode.Decoder[List[b]] =
+    pub def traverse(f: a -> Decoder[b], list: List[a]): Decoder[List[b]] =
         List.foldRight(
             (x, acc) -> Util.Csv.Decode.map2((b, bs) -> b :: bs, f(x), acc),
             Util.Csv.Decode.succeed(Nil),

--- a/flix/src/Util/Csv/Decode/Extra.flix
+++ b/flix/src/Util/Csv/Decode/Extra.flix
@@ -1,0 +1,29 @@
+/// Extensions to `Util.Csv.Decode` that go beyond the upstream
+/// BrianHicks/elm-csv `Csv.Decode` API. Kept in a separate module so
+/// the core stays a faithful port; reach for these only when the
+/// vanilla combinators don't compose cleanly.
+mod Util.Csv.Decode.Extra {
+
+    use Util.Csv.Decode.Decoder
+
+    /// Apply a decoder-producing function to every element of a list and
+    /// collect the results into a single list-valued decoder.
+    ///
+    /// Equivalent to `sequence . map f` in Haskell-style notation. The
+    /// produced decoder applies each per-element decoder to the same row
+    /// in list order; failures accumulate via the underlying `map2`
+    /// rather than short-circuiting (mirrors `pipeline`).
+    ///
+    /// Prefer this over `List.foldRight` with nested `andThen` when the
+    /// per-element decoders are independent: `andThen` rebuilds inner
+    /// decoders on every row (because the continuation `next(value)` is
+    /// invoked per-row), whereas `traverse` builds the full decoder
+    /// graph once at construction time and only walks it per row.
+    pub def traverse(f: a -> Decoder[b], list: List[a]): Decoder[List[b]] =
+        List.foldRight(
+            (x, acc) -> Util.Csv.Decode.map2((b, bs) -> b :: bs, f(x), acc),
+            Util.Csv.Decode.succeed(Nil),
+            list
+        )
+
+}

--- a/flix/test/Cli/TestValidation.flix
+++ b/flix/test/Cli/TestValidation.flix
@@ -53,12 +53,14 @@ mod Cli.TestValidation {
     /// 15 sub-sectors with the trailing FORDOUT and FL_time blanked out —
     /// the canonical "pit-entry lap" pattern observed in real Le Mans data
     /// (the car skips the main-line FORDOUT loop and crosses FL inside the
-    /// pit lane). The FL_elapsed value is preserved at lapTime so the lap
-    /// itself is still completed at the finish line.
+    /// pit lane). FORDOUT and FL are both fully blank (time + elapsed) —
+    /// the half-empty rejection rule requires the two columns to agree
+    /// per marker. The lap itself is still completed at the finish line
+    /// via the outer `RawLap.elapsed` / `lapTime` fields.
     def pitEntryMiniTail(): String =
         "8.000;8.000;8.000;16.000;8.000;24.000" +
         ";8.000;32.000;8.000;40.000;8.000;48.000;8.000;56.000" +
-        ";8.000;1:04.000;8.000;1:12.000;8.000;1:20.000;8.000;1:28.000;8.000;1:36.000;8.000;1:44.000;;;;2:00.000"
+        ";8.000;1:04.000;8.000;1:12.000;8.000;1:20.000;8.000;1:28.000;8.000;1:36.000;8.000;1:44.000;;;;"
 
     /// Track-limits violation at the second Ford chicane: SCL1 + FORDOUT
     /// loops not triggered. FL_elapsed is preserved at lapTime since the
@@ -301,9 +303,11 @@ mod Cli.TestValidation {
 
     @Test
     def testMiniSectorBlankTimeAnnotated(): Unit \ Assert =
-        // Blank Z4_time → counted as 0 ms in the sum (8 + 0 + 8 + ... = 1:52.000),
-        // so we expect a MiniSectorSum violation with Z4 in the blanks list.
-        let badTail = String.replace({src = "8.000;8.000;8.000;16.000"}, {dst = "8.000;8.000;;16.000"}, cleanMiniTail());
+        // Blank both Z4 columns (time + elapsed must agree per the
+        // half-empty rejection rule). Z4 contributes 0 to the sum
+        // (8 + 0 + 8 + ... = 1:52.000), so we expect a MiniSectorSum
+        // violation with Z4 in the blanks list.
+        let badTail = String.replace({src = "8.000;8.000;8.000;16.000"}, {dst = "8.000;8.000;;"}, cleanMiniTail());
         let lap = buildLeMansLap("7", 1, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", badTail);
         let violations = Validation.detect(lap :: Nil)
             |> List.filter(isMiniSectorSum);

--- a/flix/test/Cli/TestValidation.flix
+++ b/flix/test/Cli/TestValidation.flix
@@ -5,14 +5,32 @@ mod Cli.TestValidation {
     use Util.Duration
     use Cli.Validation
     use Cli.Validation.Violation
+    use Motorsport.MiniSector
+    use Motorsport.MiniSector.MiniSectorId
     use RawLap.RawLap
 
     def header(): String =
         "NUMBER;DRIVER_NUMBER;LAP_NUMBER;LAP_TIME;LAP_IMPROVEMENT;CROSSING_FINISH_LINE_IN_PIT;S1;S1_IMPROVEMENT;S2;S2_IMPROVEMENT;S3;S3_IMPROVEMENT;KPH;ELAPSED;HOUR;S1_LARGE;S2_LARGE;S3_LARGE;TOP_SPEED;DRIVER_NAME;PIT_TIME;CLASS;GROUP;TEAM;MANUFACTURER;FLAG_AT_FL;S1_SECONDS;S2_SECONDS;S3_SECONDS"
 
+    def leMansHeader(): String =
+        header() +
+        ";SCL2_time;SCL2_elapsed;Z4_time;Z4_elapsed;IP1_time;IP1_elapsed" +
+        ";Z12_time;Z12_elapsed;SCLC_time;SCLC_elapsed;A7-1_time;A7-1_elapsed;IP2_time;IP2_elapsed" +
+        ";A8-1_time;A8-1_elapsed;SCLB_time;SCLB_elapsed;PORIN_time;PORIN_elapsed;POROUT_time;POROUT_elapsed;PITREF_time;PITREF_elapsed;SCL1_time;SCL1_elapsed;FORDOUT_time;FORDOUT_elapsed;FL_time;FL_elapsed"
+
     def buildLap(num: String, lap: Int32, lapTime: String, s1: String, s2: String, s3: String, elapsed: String, hour: String): RawLap =
         let row = "${num};1;${lap};${lapTime};0;;${s1};0;${s2};0;${s3};0;100;${elapsed};${hour};0:${s1};0:${s2};0:${s3};200;Driver;;HYPERCAR;H;Team;Maker;GF;${s1};${s2};${s3};";
         let csv = header() + "\n" + row;
+        match Decode.decodeCustom({fieldSeparator = ';'}, FieldNames.FieldNamesFromFirstRow, RawLap.decoder(), csv) {
+            case Ok(r :: _) => r
+            case _          => unreachable!()
+        }
+
+    /// Build a Le Mans-shaped lap. `miniTail` is the raw 30-column suffix
+    /// (`time;elapsed;...`) appended after the standard fields.
+    def buildLeMansLap(num: String, lap: Int32, lapTime: String, s1: String, s2: String, s3: String, elapsed: String, hour: String, miniTail: String): RawLap =
+        let row = "${num};1;${lap};${lapTime};0;;${s1};0;${s2};0;${s3};0;100;${elapsed};${hour};0:${s1};0:${s2};0:${s3};200;Driver;;HYPERCAR;H;Team;Maker;GF;${s1};${s2};${s3};${miniTail}";
+        let csv = leMansHeader() + "\n" + row;
         match Decode.decodeCustom({fieldSeparator = ';'}, FieldNames.FieldNamesFromFirstRow, RawLap.decoder(), csv) {
             case Ok(r :: _) => r
             case _          => unreachable!()
@@ -23,6 +41,8 @@ mod Cli.TestValidation {
         case Violation.SectorSum(lap, _, _, _)      => lap#car#carNumber
         case Violation.ElapsedDrift(lap, _, _) => lap#car#carNumber
         case Violation.HourElapsedOffset(lap, _, _) => lap#car#carNumber
+        case Violation.MiniSectorSum(lap, _, _, _)  => lap#car#carNumber
+        case Violation.MiniSectorElapsedMonotonic(lap, _, _, _, _) => lap#car#carNumber
     }
 
     def isSectorSum(v: Violation): Bool = match v {
@@ -38,6 +58,16 @@ mod Cli.TestValidation {
     def isHourElapsedOffset(v: Violation): Bool = match v {
         case Violation.HourElapsedOffset(_, _, _) => true
         case _                                    => false
+    }
+
+    def isMiniSectorSum(v: Violation): Bool = match v {
+        case Violation.MiniSectorSum(_, _, _, _) => true
+        case _                                   => false
+    }
+
+    def isMiniSectorMonotonic(v: Violation): Bool = match v {
+        case Violation.MiniSectorElapsedMonotonic(_, _, _, _, _) => true
+        case _                                                    => false
     }
 
     @Test
@@ -187,6 +217,97 @@ mod Cli.TestValidation {
                 Assert.assertTrue(violationCar(v1) == "10");
                 Assert.assertTrue(violationCar(v2) == "7")
             case _ => Assert.assertTrue(false)
+        }
+
+    /// 15 sub-sectors that cleanly split the 2:00.000 lap into 8000 ms each.
+    /// The `_elapsed` column is the running total at each marker.
+    def cleanMiniTail(): String =
+        "8.000;8.000;8.000;16.000;8.000;24.000" +
+        ";8.000;32.000;8.000;40.000;8.000;48.000;8.000;56.000" +
+        ";8.000;1:04.000;8.000;1:12.000;8.000;1:20.000;8.000;1:28.000;8.000;1:36.000;8.000;1:44.000;8.000;1:52.000;8.000;2:00.000"
+
+    @Test
+    def testMiniSectorsAbsentLapProducesNoMiniViolations(): Unit \ Assert =
+        // Standard (non-Le Mans) header → miniSectors = None → mini-sector
+        // checks must be skipped entirely.
+        let lap = buildLap("7", 1, "2:00.000", "30.000", "60.000", "30.000", "2:00.000", "14:02:00.000");
+        let violations = Validation.detect(lap :: Nil);
+        Assert.assertTrue(List.isEmpty(List.filter(isMiniSectorSum, violations)));
+        Assert.assertTrue(List.isEmpty(List.filter(isMiniSectorMonotonic, violations)))
+
+    @Test
+    def testValidLeMansLapProducesNoMiniViolations(): Unit \ Assert =
+        let lap = buildLeMansLap("7", 1, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", cleanMiniTail());
+        let violations = Validation.detect(lap :: Nil);
+        Assert.assertTrue(List.isEmpty(violations))
+
+    @Test
+    def testMiniSectorSumMismatchDetected(): Unit \ Assert =
+        // Bump the FL_time from 8.000 → 8.001, leaving lapTime 2:00.000 →
+        // sum = 2:00.001, off by 1 ms. Note this also breaks the FL_elapsed
+        // monotonic chain so we filter to the SectorSum-style violation.
+        let badTail = String.replace({src = "8.000;2:00.000"}, {dst = "8.001;2:00.000"}, cleanMiniTail());
+        let lap = buildLeMansLap("7", 1, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", badTail);
+        let violations = Validation.detect(lap :: Nil)
+            |> List.filter(isMiniSectorSum);
+        Assert.assertTrue(List.length(violations) == 1);
+        match List.head(violations) {
+            case Some(Violation.MiniSectorSum(_, lapMs, sum, _)) =>
+                Assert.assertTrue(lapMs == Duration.fromMillis(120000));
+                Assert.assertTrue(sum == Duration.fromMillis(120001))
+            case _ => Assert.assertTrue(false)
+        }
+
+    @Test
+    def testMiniSectorBlankTimeAnnotated(): Unit \ Assert =
+        // Blank Z4_time → counted as 0 ms in the sum (8 + 0 + 8 + ... = 1:52.000),
+        // so we expect a MiniSectorSum violation with `z4` in the blanks list.
+        let badTail = String.replace({src = "8.000;8.000;8.000;16.000"}, {dst = "8.000;8.000;;16.000"}, cleanMiniTail());
+        let lap = buildLeMansLap("7", 1, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", badTail);
+        let violations = Validation.detect(lap :: Nil)
+            |> List.filter(isMiniSectorSum);
+        Assert.assertTrue(List.length(violations) == 1);
+        match List.head(violations) {
+            case Some(Violation.MiniSectorSum(_, _, _, blanks)) =>
+                Assert.assertTrue(List.memberOf("z4", blanks))
+            case _ => Assert.assertTrue(false)
+        }
+
+    @Test
+    def testMiniSectorElapsedMonotonicViolationDetected(): Unit \ Assert =
+        // Replace IP1_elapsed (24.000) with 20.000 — strictly less than the
+        // previous Z4_elapsed (16.000)? No, 20 > 16, so swap to a value < 16
+        // to trigger a backwards step. Replace the substring "16.000;8.000;24.000"
+        // (Z4_elapsed=16.000, then IP1_time=8.000, then IP1_elapsed=24.000)
+        // with "16.000;8.000;15.000".
+        let badTail = String.replace({src = "16.000;8.000;24.000"}, {dst = "16.000;8.000;15.000"}, cleanMiniTail());
+        let lap = buildLeMansLap("7", 1, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", badTail);
+        let violations = Validation.detect(lap :: Nil)
+            |> List.filter(isMiniSectorMonotonic);
+        Assert.assertTrue(List.length(violations) == 1);
+        match List.head(violations) {
+            case Some(Violation.MiniSectorElapsedMonotonic(_, prevId, prevElapsed, currId, currElapsed)) =>
+                Assert.assertTrue(prevId == MiniSectorId.Z4);
+                Assert.assertTrue(currId == MiniSectorId.IP1);
+                Assert.assertTrue(prevElapsed == Duration.fromMillis(16000));
+                Assert.assertTrue(currElapsed == Duration.fromMillis(15000))
+            case _ => Assert.assertTrue(false)
+        }
+
+    @Test
+    def testMiniSectorViolationFormattedString(): Unit \ Assert =
+        let badTail = String.replace({src = "8.000;2:00.000"}, {dst = "8.001;2:00.000"}, cleanMiniTail());
+        let lap = buildLeMansLap("7", 1, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", badTail);
+        let messages = Validation.validate("le_mans_24h", lap :: Nil)
+            |> List.filter(m -> String.contains({substr = "mini-sector-sum"}, m));
+        Assert.assertTrue(List.length(messages) == 1);
+        match List.head(messages) {
+            case Some(msg) =>
+                Assert.assertTrue(String.contains({substr = "le_mans_24h"}, msg));
+                Assert.assertTrue(String.contains({substr = "[car 7 #1]"}, msg));
+                Assert.assertTrue(String.contains({substr = "expected=2:00.000 (120000ms)"}, msg));
+                Assert.assertTrue(String.contains({substr = "actual=2:00.001 (120001ms)"}, msg))
+            case None => Assert.assertTrue(false)
         }
 
     @Test

--- a/flix/test/Cli/TestValidation.flix
+++ b/flix/test/Cli/TestValidation.flix
@@ -336,6 +336,26 @@ mod Cli.TestValidation {
         }
 
     @Test
+    def testMiniSectorElapsedEqualPairFlagged(): Unit \ Assert =
+        // Two adjacent timing loops cannot physically fire at the same
+        // millisecond. Replace IP1_elapsed (24.000) with 16.000 so it
+        // matches the previous Z4_elapsed exactly — the strict
+        // monotonic check should report this as a violation.
+        let badTail = String.replace({src = "16.000;8.000;24.000"}, {dst = "16.000;8.000;16.000"}, cleanMiniTail());
+        let lap = buildLeMansLap("7", 1, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", badTail);
+        let violations = Validation.detect(lap :: Nil)
+            |> List.filter(isMiniSectorMonotonic);
+        Assert.assertTrue(List.length(violations) == 1);
+        match List.head(violations) {
+            case Some(Violation.MiniSectorElapsedMonotonic(_, prevId, prevElapsed, currId, currElapsed)) =>
+                Assert.assertTrue(prevId == MiniSectorId.Z4);
+                Assert.assertTrue(currId == MiniSectorId.IP1);
+                Assert.assertTrue(prevElapsed == currElapsed);
+                Assert.assertTrue(prevElapsed == Duration.fromMillis(16000))
+            case _ => Assert.assertTrue(false)
+        }
+
+    @Test
     def testMiniSectorViolationFormattedString(): Unit \ Assert =
         let badTail = String.replace({src = "8.000;2:00.000"}, {dst = "8.001;2:00.000"}, cleanMiniTail());
         let lap = buildLeMansLap("7", 1, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", badTail);

--- a/flix/test/Cli/TestValidation.flix
+++ b/flix/test/Cli/TestValidation.flix
@@ -316,11 +316,8 @@ mod Cli.TestValidation {
 
     @Test
     def testMiniSectorElapsedMonotonicViolationDetected(): Unit \ Assert =
-        // Replace IP1_elapsed (24.000) with 20.000 — strictly less than the
-        // previous Z4_elapsed (16.000)? No, 20 > 16, so swap to a value < 16
-        // to trigger a backwards step. Replace the substring "16.000;8.000;24.000"
-        // (Z4_elapsed=16.000, then IP1_time=8.000, then IP1_elapsed=24.000)
-        // with "16.000;8.000;15.000".
+        // Replace IP1_elapsed (24.000) with 15.000 — strictly less than the
+        // previous Z4_elapsed (16.000) — to trigger a backwards step.
         let badTail = String.replace({src = "16.000;8.000;24.000"}, {dst = "16.000;8.000;15.000"}, cleanMiniTail());
         let lap = buildLeMansLap("7", 1, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", badTail);
         let violations = Validation.detect(lap :: Nil)
@@ -353,22 +350,6 @@ mod Cli.TestValidation {
                 Assert.assertTrue(prevElapsed == currElapsed);
                 Assert.assertTrue(prevElapsed == Duration.fromMillis(16000))
             case _ => Assert.assertTrue(false)
-        }
-
-    @Test
-    def testMiniSectorViolationFormattedString(): Unit \ Assert =
-        let badTail = String.replace({src = "8.000;2:00.000"}, {dst = "8.001;2:00.000"}, cleanMiniTail());
-        let lap = buildLeMansLap("7", 1, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", badTail);
-        let messages = Validation.validate("le_mans_24h", lap :: Nil)
-            |> List.filter(m -> String.contains({substr = "mini-sector-sum"}, m));
-        Assert.assertTrue(List.length(messages) == 1);
-        match List.head(messages) {
-            case Some(msg) =>
-                Assert.assertTrue(String.contains({substr = "le_mans_24h"}, msg));
-                Assert.assertTrue(String.contains({substr = "[car 7 #1]"}, msg));
-                Assert.assertTrue(String.contains({substr = "expected=2:00.000 (120000ms)"}, msg));
-                Assert.assertTrue(String.contains({substr = "actual=2:00.001 (120001ms)"}, msg))
-            case None => Assert.assertTrue(false)
         }
 
     @Test
@@ -407,9 +388,7 @@ mod Cli.TestValidation {
     @Test
     def testMiniSectorSumSkippedOnSCL1FordoutTrackLimits(): Unit \ Assert =
         // Track-limits violation at the second Ford chicane: SCL1 and
-        // FORDOUT loops are not triggered. No pit signal. Empirically the
-        // dominant non-pit pattern at Le Mans (257 of 311 post-pit-skip
-        // warnings).
+        // FORDOUT loops are not triggered. No pit signal.
         let lap = buildLeMansLapWith("7", 1, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", trackLimits_SCL1_FORDOUT_MiniTail(), "", "");
         let violations = Validation.detect(lap :: Nil)
             |> List.filter(isMiniSectorSum);
@@ -419,8 +398,7 @@ mod Cli.TestValidation {
     def testMiniSectorSumSkippedOnPitrefScl1TrackLimits(): Unit \ Assert =
         // Track-limits violation at the first Ford chicane: PITREF and
         // SCL1 loops are not triggered, but the car rejoins before
-        // FORDOUT so FORDOUT and FL fire normally. Second-most-common
-        // non-pit pattern (53 cases at Le Mans 2025).
+        // FORDOUT so FORDOUT and FL fire normally.
         let lap = buildLeMansLapWith("7", 1, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", trackLimits_PITREF_SCL1_MiniTail(), "", "");
         let violations = Validation.detect(lap :: Nil)
             |> List.filter(isMiniSectorSum);

--- a/flix/test/Cli/TestValidation.flix
+++ b/flix/test/Cli/TestValidation.flix
@@ -28,6 +28,13 @@ mod Cli.TestValidation {
 
     /// Build a Le Mans-shaped lap. `miniTail` is the raw 30-column suffix
     /// (`time;elapsed;...`) appended after the standard fields.
+    ///
+    /// Note: `s3` must be a plain-seconds string (e.g. `"64.000"`, not
+    /// `"1:04.000"`) because the Le Mans CSV has trailing `S3_SECONDS`-style
+    /// columns that go through `Float64.fromString`. Real Le Mans S3 values
+    /// run 1:30+, so this fixture is intentionally simplified — the integrity
+    /// rules under test don't care about realistic lap geometry, only the
+    /// arithmetic relationships between the columns.
     def buildLeMansLap(num: String, lap: Int32, lapTime: String, s1: String, s2: String, s3: String, elapsed: String, hour: String, miniTail: String): RawLap =
         buildLeMansLapWith(num, lap, lapTime, s1, s2, s3, elapsed, hour, miniTail, "", "")
 

--- a/flix/test/Cli/TestValidation.flix
+++ b/flix/test/Cli/TestValidation.flix
@@ -53,19 +53,19 @@ mod Cli.TestValidation {
         ";8.000;32.000;8.000;40.000;8.000;48.000;8.000;56.000" +
         ";8.000;1:04.000;8.000;1:12.000;8.000;1:20.000;8.000;1:28.000;8.000;1:36.000;8.000;1:44.000;;;;2:00.000"
 
-    /// Driver cuts the second Ford chicane: SCL1 + FORDOUT loops not
-    /// triggered. FL_elapsed is preserved at lapTime since the car still
-    /// crosses the finish line. The non-chicane markers retain their
-    /// straight-line cumulative times.
-    def chicaneCut_SCL1_FORDOUT_MiniTail(): String =
+    /// Track-limits violation at the second Ford chicane: SCL1 + FORDOUT
+    /// loops not triggered. FL_elapsed is preserved at lapTime since the
+    /// car still crosses the finish line. The on-track markers retain
+    /// their straight-line cumulative times.
+    def trackLimits_SCL1_FORDOUT_MiniTail(): String =
         "8.000;8.000;8.000;16.000;8.000;24.000" +
         ";8.000;32.000;8.000;40.000;8.000;48.000;8.000;56.000" +
         ";8.000;1:04.000;8.000;1:12.000;8.000;1:20.000;8.000;1:28.000;8.000;1:36.000;;;;;8.000;2:00.000"
 
-    /// Driver cuts the first Ford chicane: PITREF + SCL1 loops not
-    /// triggered. The car re-joins the main racing line before FORDOUT, so
-    /// FORDOUT and FL fire normally.
-    def chicaneCut_PITREF_SCL1_MiniTail(): String =
+    /// Track-limits violation at the first Ford chicane: PITREF + SCL1
+    /// loops not triggered. The car re-joins the main racing line before
+    /// FORDOUT, so FORDOUT and FL fire normally.
+    def trackLimits_PITREF_SCL1_MiniTail(): String =
         "8.000;8.000;8.000;16.000;8.000;24.000" +
         ";8.000;32.000;8.000;40.000;8.000;48.000;8.000;56.000" +
         ";8.000;1:04.000;8.000;1:12.000;8.000;1:20.000;8.000;1:28.000;;;;;8.000;1:52.000;8.000;2:00.000"
@@ -367,33 +367,34 @@ mod Cli.TestValidation {
 
     @Test
     def testMiniSectorSumStillReportsNonPitLapWithBlankTrailingMarkers(): Unit \ Assert =
-        // {fordout, fl} blank without any pit or chicane-cut signal — a
-        // genuine timing anomaly (e.g. Le Mans 2025 car 150 lap 14:
+        // {fordout, fl} blank without any pit or track-limits signal —
+        // a genuine timing anomaly (e.g. Le Mans 2025 car 150 lap 14:
         // 4:23.067 lap with FORDOUT and FL_time both blank, no pitTime,
-        // no box flag, no chicane signature). The validator must STILL
-        // flag this as a MiniSectorSum violation.
+        // no box flag, no track-limits signature). The validator must
+        // STILL flag this as a MiniSectorSum violation.
         let lap = buildLeMansLapWith("150", 14, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", pitEntryMiniTail(), "", "");
         let violations = Validation.detect(lap :: Nil)
             |> List.filter(isMiniSectorSum);
         Assert.assertTrue(List.length(violations) == 1)
 
     @Test
-    def testMiniSectorSumSkippedOnSCL1FordoutChicaneCut(): Unit \ Assert =
-        // Driver cuts the second Ford chicane: SCL1 and FORDOUT loops are
-        // not triggered. No pit signal. Empirically the dominant non-pit
-        // pattern at Le Mans (257 of 311 post-pit-skip warnings).
-        let lap = buildLeMansLapWith("7", 1, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", chicaneCut_SCL1_FORDOUT_MiniTail(), "", "");
+    def testMiniSectorSumSkippedOnSCL1FordoutTrackLimits(): Unit \ Assert =
+        // Track-limits violation at the second Ford chicane: SCL1 and
+        // FORDOUT loops are not triggered. No pit signal. Empirically the
+        // dominant non-pit pattern at Le Mans (257 of 311 post-pit-skip
+        // warnings).
+        let lap = buildLeMansLapWith("7", 1, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", trackLimits_SCL1_FORDOUT_MiniTail(), "", "");
         let violations = Validation.detect(lap :: Nil)
             |> List.filter(isMiniSectorSum);
         Assert.assertTrue(List.isEmpty(violations))
 
     @Test
-    def testMiniSectorSumSkippedOnPitrefScl1ChicaneCut(): Unit \ Assert =
-        // Driver cuts the first Ford chicane: PITREF and SCL1 loops are
-        // not triggered, but the car rejoins before FORDOUT so FORDOUT
-        // and FL fire normally. Second-most-common non-pit pattern (53
-        // cases at Le Mans 2025).
-        let lap = buildLeMansLapWith("7", 1, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", chicaneCut_PITREF_SCL1_MiniTail(), "", "");
+    def testMiniSectorSumSkippedOnPitrefScl1TrackLimits(): Unit \ Assert =
+        // Track-limits violation at the first Ford chicane: PITREF and
+        // SCL1 loops are not triggered, but the car rejoins before
+        // FORDOUT so FORDOUT and FL fire normally. Second-most-common
+        // non-pit pattern (53 cases at Le Mans 2025).
+        let lap = buildLeMansLapWith("7", 1, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", trackLimits_PITREF_SCL1_MiniTail(), "", "");
         let violations = Validation.detect(lap :: Nil)
             |> List.filter(isMiniSectorSum);
         Assert.assertTrue(List.isEmpty(violations))

--- a/flix/test/Cli/TestValidation.flix
+++ b/flix/test/Cli/TestValidation.flix
@@ -302,7 +302,7 @@ mod Cli.TestValidation {
     @Test
     def testMiniSectorBlankTimeAnnotated(): Unit \ Assert =
         // Blank Z4_time → counted as 0 ms in the sum (8 + 0 + 8 + ... = 1:52.000),
-        // so we expect a MiniSectorSum violation with `z4` in the blanks list.
+        // so we expect a MiniSectorSum violation with Z4 in the blanks list.
         let badTail = String.replace({src = "8.000;8.000;8.000;16.000"}, {dst = "8.000;8.000;;16.000"}, cleanMiniTail());
         let lap = buildLeMansLap("7", 1, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", badTail);
         let violations = Validation.detect(lap :: Nil)
@@ -310,7 +310,7 @@ mod Cli.TestValidation {
         Assert.assertTrue(List.length(violations) == 1);
         match List.head(violations) {
             case Some(Violation.MiniSectorSum(_, _, _, blanks)) =>
-                Assert.assertTrue(List.memberOf("z4", blanks))
+                Assert.assertTrue(List.memberOf(MiniSectorId.Z4, blanks))
             case _ => Assert.assertTrue(false)
         }
 

--- a/flix/test/Cli/TestValidation.flix
+++ b/flix/test/Cli/TestValidation.flix
@@ -53,14 +53,12 @@ mod Cli.TestValidation {
     /// 15 sub-sectors with the trailing FORDOUT and FL_time blanked out —
     /// the canonical "pit-entry lap" pattern observed in real Le Mans data
     /// (the car skips the main-line FORDOUT loop and crosses FL inside the
-    /// pit lane). FORDOUT and FL are both fully blank (time + elapsed) —
-    /// the half-empty rejection rule requires the two columns to agree
-    /// per marker. The lap itself is still completed at the finish line
-    /// via the outer `RawLap.elapsed` / `lapTime` fields.
+    /// pit lane). The FL_elapsed value is preserved at lapTime so the lap
+    /// itself is still completed at the finish line.
     def pitEntryMiniTail(): String =
         "8.000;8.000;8.000;16.000;8.000;24.000" +
         ";8.000;32.000;8.000;40.000;8.000;48.000;8.000;56.000" +
-        ";8.000;1:04.000;8.000;1:12.000;8.000;1:20.000;8.000;1:28.000;8.000;1:36.000;8.000;1:44.000;;;;"
+        ";8.000;1:04.000;8.000;1:12.000;8.000;1:20.000;8.000;1:28.000;8.000;1:36.000;8.000;1:44.000;;;;2:00.000"
 
     /// Track-limits violation at the second Ford chicane: SCL1 + FORDOUT
     /// loops not triggered. FL_elapsed is preserved at lapTime since the
@@ -303,11 +301,9 @@ mod Cli.TestValidation {
 
     @Test
     def testMiniSectorBlankTimeAnnotated(): Unit \ Assert =
-        // Blank both Z4 columns (time + elapsed must agree per the
-        // half-empty rejection rule). Z4 contributes 0 to the sum
-        // (8 + 0 + 8 + ... = 1:52.000), so we expect a MiniSectorSum
-        // violation with Z4 in the blanks list.
-        let badTail = String.replace({src = "8.000;8.000;8.000;16.000"}, {dst = "8.000;8.000;;"}, cleanMiniTail());
+        // Blank Z4_time → counted as 0 ms in the sum (8 + 0 + 8 + ... = 1:52.000),
+        // so we expect a MiniSectorSum violation with Z4 in the blanks list.
+        let badTail = String.replace({src = "8.000;8.000;8.000;16.000"}, {dst = "8.000;8.000;;16.000"}, cleanMiniTail());
         let lap = buildLeMansLap("7", 1, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", badTail);
         let violations = Validation.detect(lap :: Nil)
             |> List.filter(isMiniSectorSum);

--- a/flix/test/Cli/TestValidation.flix
+++ b/flix/test/Cli/TestValidation.flix
@@ -53,6 +53,23 @@ mod Cli.TestValidation {
         ";8.000;32.000;8.000;40.000;8.000;48.000;8.000;56.000" +
         ";8.000;1:04.000;8.000;1:12.000;8.000;1:20.000;8.000;1:28.000;8.000;1:36.000;8.000;1:44.000;;;;2:00.000"
 
+    /// Driver cuts the second Ford chicane: SCL1 + FORDOUT loops not
+    /// triggered. FL_elapsed is preserved at lapTime since the car still
+    /// crosses the finish line. The non-chicane markers retain their
+    /// straight-line cumulative times.
+    def chicaneCut_SCL1_FORDOUT_MiniTail(): String =
+        "8.000;8.000;8.000;16.000;8.000;24.000" +
+        ";8.000;32.000;8.000;40.000;8.000;48.000;8.000;56.000" +
+        ";8.000;1:04.000;8.000;1:12.000;8.000;1:20.000;8.000;1:28.000;8.000;1:36.000;;;;;8.000;2:00.000"
+
+    /// Driver cuts the first Ford chicane: PITREF + SCL1 loops not
+    /// triggered. The car re-joins the main racing line before FORDOUT, so
+    /// FORDOUT and FL fire normally.
+    def chicaneCut_PITREF_SCL1_MiniTail(): String =
+        "8.000;8.000;8.000;16.000;8.000;24.000" +
+        ";8.000;32.000;8.000;40.000;8.000;48.000;8.000;56.000" +
+        ";8.000;1:04.000;8.000;1:12.000;8.000;1:20.000;8.000;1:28.000;;;;;8.000;1:52.000;8.000;2:00.000"
+
     /// Pulls carNumber off the leading RawLap arg shared by every variant.
     def violationCar(v: Violation): String = match v {
         case Violation.SectorSum(lap, _, _, _)      => lap#car#carNumber
@@ -350,14 +367,36 @@ mod Cli.TestValidation {
 
     @Test
     def testMiniSectorSumStillReportsNonPitLapWithBlankTrailingMarkers(): Unit \ Assert =
-        // Same blank pattern as a pit lap but without any pit signal —
-        // this is the "real timing-loop anomaly" case (e.g. Le Mans 2025
-        // car 9 lap 189: blank scl1+fordout with no pitTime / no box flag).
-        // The validator must STILL flag this as a MiniSectorSum violation.
-        let lap = buildLeMansLapWith("9", 189, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", pitEntryMiniTail(), "", "");
+        // {fordout, fl} blank without any pit or chicane-cut signal — a
+        // genuine timing anomaly (e.g. Le Mans 2025 car 150 lap 14:
+        // 4:23.067 lap with FORDOUT and FL_time both blank, no pitTime,
+        // no box flag, no chicane signature). The validator must STILL
+        // flag this as a MiniSectorSum violation.
+        let lap = buildLeMansLapWith("150", 14, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", pitEntryMiniTail(), "", "");
         let violations = Validation.detect(lap :: Nil)
             |> List.filter(isMiniSectorSum);
         Assert.assertTrue(List.length(violations) == 1)
+
+    @Test
+    def testMiniSectorSumSkippedOnSCL1FordoutChicaneCut(): Unit \ Assert =
+        // Driver cuts the second Ford chicane: SCL1 and FORDOUT loops are
+        // not triggered. No pit signal. Empirically the dominant non-pit
+        // pattern at Le Mans (257 of 311 post-pit-skip warnings).
+        let lap = buildLeMansLapWith("7", 1, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", chicaneCut_SCL1_FORDOUT_MiniTail(), "", "");
+        let violations = Validation.detect(lap :: Nil)
+            |> List.filter(isMiniSectorSum);
+        Assert.assertTrue(List.isEmpty(violations))
+
+    @Test
+    def testMiniSectorSumSkippedOnPitrefScl1ChicaneCut(): Unit \ Assert =
+        // Driver cuts the first Ford chicane: PITREF and SCL1 loops are
+        // not triggered, but the car rejoins before FORDOUT so FORDOUT
+        // and FL fire normally. Second-most-common non-pit pattern (53
+        // cases at Le Mans 2025).
+        let lap = buildLeMansLapWith("7", 1, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", chicaneCut_PITREF_SCL1_MiniTail(), "", "");
+        let violations = Validation.detect(lap :: Nil)
+            |> List.filter(isMiniSectorSum);
+        Assert.assertTrue(List.isEmpty(violations))
 
     @Test
     def testMiniSectorMonotonicStillRunsOnPitLaps(): Unit \ Assert =

--- a/flix/test/Cli/TestValidation.flix
+++ b/flix/test/Cli/TestValidation.flix
@@ -29,12 +29,29 @@ mod Cli.TestValidation {
     /// Build a Le Mans-shaped lap. `miniTail` is the raw 30-column suffix
     /// (`time;elapsed;...`) appended after the standard fields.
     def buildLeMansLap(num: String, lap: Int32, lapTime: String, s1: String, s2: String, s3: String, elapsed: String, hour: String, miniTail: String): RawLap =
-        let row = "${num};1;${lap};${lapTime};0;;${s1};0;${s2};0;${s3};0;100;${elapsed};${hour};0:${s1};0:${s2};0:${s3};200;Driver;;HYPERCAR;H;Team;Maker;GF;${s1};${s2};${s3};${miniTail}";
+        buildLeMansLapWith(num, lap, lapTime, s1, s2, s3, elapsed, hour, miniTail, "", "")
+
+    /// Le Mans lap builder with explicit values for the
+    /// CROSSING_FINISH_LINE_IN_PIT and PIT_TIME columns. Pass `box = "B"`
+    /// to mark the lap as a pit-entry lap, or `pitTime = "30.500"` to
+    /// record a pit-stop duration.
+    def buildLeMansLapWith(num: String, lap: Int32, lapTime: String, s1: String, s2: String, s3: String, elapsed: String, hour: String, miniTail: String, box: String, pitTime: String): RawLap =
+        let row = "${num};1;${lap};${lapTime};0;${box};${s1};0;${s2};0;${s3};0;100;${elapsed};${hour};0:${s1};0:${s2};0:${s3};200;Driver;${pitTime};HYPERCAR;H;Team;Maker;GF;${s1};${s2};${s3};${miniTail}";
         let csv = leMansHeader() + "\n" + row;
         match Decode.decodeCustom({fieldSeparator = ';'}, FieldNames.FieldNamesFromFirstRow, RawLap.decoder(), csv) {
             case Ok(r :: _) => r
             case _          => unreachable!()
         }
+
+    /// 15 sub-sectors with the trailing FORDOUT and FL_time blanked out —
+    /// the canonical "pit-entry lap" pattern observed in real Le Mans data
+    /// (the car skips the main-line FORDOUT loop and crosses FL inside the
+    /// pit lane). The FL_elapsed value is preserved at lapTime so the lap
+    /// itself is still completed at the finish line.
+    def pitEntryMiniTail(): String =
+        "8.000;8.000;8.000;16.000;8.000;24.000" +
+        ";8.000;32.000;8.000;40.000;8.000;48.000;8.000;56.000" +
+        ";8.000;1:04.000;8.000;1:12.000;8.000;1:20.000;8.000;1:28.000;8.000;1:36.000;8.000;1:44.000;;;;2:00.000"
 
     /// Pulls carNumber off the leading RawLap arg shared by every variant.
     def violationCar(v: Violation): String = match v {
@@ -309,6 +326,50 @@ mod Cli.TestValidation {
                 Assert.assertTrue(String.contains({substr = "actual=2:00.001 (120001ms)"}, msg))
             case None => Assert.assertTrue(false)
         }
+
+    @Test
+    def testMiniSectorSumSkippedOnBoxedFinishLineLap(): Unit \ Assert =
+        // Real pit-entry pattern: car crosses FL inside the pit lane
+        // (CROSSING_FINISH_LINE_IN_PIT = "B"), bypasses FORDOUT and the
+        // FL_time loop. Sum of mini-sector times = 1:44.000 << lapTime
+        // = 2:00.000, but we expect NO MiniSectorSum violation because
+        // the lap is identified as a pit lap.
+        let lap = buildLeMansLapWith("7", 1, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", pitEntryMiniTail(), "B", "");
+        let violations = Validation.detect(lap :: Nil)
+            |> List.filter(isMiniSectorSum);
+        Assert.assertTrue(List.isEmpty(violations))
+
+    @Test
+    def testMiniSectorSumSkippedWhenPitTimeRecorded(): Unit \ Assert =
+        // Even without the boxed-finish-line flag, a recorded PIT_TIME
+        // also marks the lap as a pit lap and skips the sum check.
+        let lap = buildLeMansLapWith("7", 1, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", pitEntryMiniTail(), "", "30.500");
+        let violations = Validation.detect(lap :: Nil)
+            |> List.filter(isMiniSectorSum);
+        Assert.assertTrue(List.isEmpty(violations))
+
+    @Test
+    def testMiniSectorSumStillReportsNonPitLapWithBlankTrailingMarkers(): Unit \ Assert =
+        // Same blank pattern as a pit lap but without any pit signal —
+        // this is the "real timing-loop anomaly" case (e.g. Le Mans 2025
+        // car 9 lap 189: blank scl1+fordout with no pitTime / no box flag).
+        // The validator must STILL flag this as a MiniSectorSum violation.
+        let lap = buildLeMansLapWith("9", 189, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", pitEntryMiniTail(), "", "");
+        let violations = Validation.detect(lap :: Nil)
+            |> List.filter(isMiniSectorSum);
+        Assert.assertTrue(List.length(violations) == 1)
+
+    @Test
+    def testMiniSectorMonotonicStillRunsOnPitLaps(): Unit \ Assert =
+        // The Monotonic check is independent of pit context: missing
+        // markers don't break monotonicity (blank elapsed is skipped),
+        // but a backwards step must still be reported even when the lap
+        // is a pit lap.
+        let badTail = String.replace({src = "16.000;8.000;24.000"}, {dst = "16.000;8.000;15.000"}, pitEntryMiniTail());
+        let lap = buildLeMansLapWith("7", 1, "2:00.000", "24.000", "32.000", "64.000", "2:00.000", "14:02:00.000", badTail, "B", "");
+        let violations = Validation.detect(lap :: Nil);
+        Assert.assertTrue(List.isEmpty(List.filter(isMiniSectorSum, violations)));
+        Assert.assertTrue(List.length(List.filter(isMiniSectorMonotonic, violations)) == 1)
 
     @Test
     def testValidateRendersFormattedString(): Unit \ Assert =

--- a/flix/test/Motorsport/TestMetadata.flix
+++ b/flix/test/Motorsport/TestMetadata.flix
@@ -31,7 +31,8 @@ mod Motorsport.TestMetadata {
             hour                    = Hour.Hour(0),
             topSpeed                = "",
             pitTime                 = None,
-            flagAtFl                = RawLap.Flag.Green
+            flagAtFl                = RawLap.Flag.Green,
+            miniSectors             = None
         }
 
     @Test

--- a/flix/test/Motorsport/TestMiniSector.flix
+++ b/flix/test/Motorsport/TestMiniSector.flix
@@ -1,0 +1,51 @@
+mod Motorsport.TestMiniSector {
+
+    use Motorsport.MiniSector
+    use Motorsport.MiniSector.MiniSectorId
+
+    @Test
+    def testAllHasFifteenIds(): Unit \ Assert =
+        Assert.assertTrue(List.length(MiniSector.all()) == 15)
+
+    @Test
+    def testAllStartsWithS1MiniSectors(): Unit \ Assert =
+        // S1 = SCL2, Z4, IP1 (matches Motorsport.Circuit.LeMans.layout.s1).
+        match List.take(3, MiniSector.all()) {
+            case MiniSectorId.SCL2 :: MiniSectorId.Z4 :: MiniSectorId.IP1 :: Nil =>
+                Assert.assertTrue(true)
+            case _ => Assert.assertTrue(false)
+        }
+
+    @Test
+    def testAllEndsWithFinishLine(): Unit \ Assert =
+        match List.last(MiniSector.all()) {
+            case Some(MiniSectorId.FL) => Assert.assertTrue(true)
+            case _                     => Assert.assertTrue(false)
+        }
+
+    @Test
+    def testCsvNamesPreserveHyphens(): Unit \ Assert =
+        // The Flix identifier underscore in A7_1 / A8_1 must map to a hyphen
+        // in the CSV column name (the actual columns are A7-1_time / A8-1_time).
+        Assert.assertTrue(MiniSector.csvName(MiniSectorId.A7_1) == "A7-1");
+        Assert.assertTrue(MiniSector.csvName(MiniSectorId.A8_1) == "A8-1");
+        Assert.assertTrue(MiniSector.csvName(MiniSectorId.SCL2) == "SCL2");
+        Assert.assertTrue(MiniSector.csvName(MiniSectorId.FORDOUT) == "FORDOUT");
+        Assert.assertTrue(MiniSector.csvName(MiniSectorId.FL) == "FL")
+
+    @Test
+    def testJsonKeysPreserveUnderscores(): Unit \ Assert =
+        // JSON keys lowercase the CSV name and preserve underscores
+        // (matches Motorsport.Lap.MiniSectors field names on the Elm side).
+        Assert.assertTrue(MiniSector.jsonKey(MiniSectorId.A7_1) == "a7_1");
+        Assert.assertTrue(MiniSector.jsonKey(MiniSectorId.A8_1) == "a8_1");
+        Assert.assertTrue(MiniSector.jsonKey(MiniSectorId.SCL2) == "scl2");
+        Assert.assertTrue(MiniSector.jsonKey(MiniSectorId.PORIN) == "porin");
+        Assert.assertTrue(MiniSector.jsonKey(MiniSectorId.FL) == "fl")
+
+    @Test
+    def testAllIdsHaveDistinctJsonKeys(): Unit \ Assert =
+        let keys = MiniSector.all() |> List.map(MiniSector.jsonKey);
+        Assert.assertTrue(List.length(List.distinct(keys)) == 15)
+
+}

--- a/flix/test/Motorsport/TestMiniSector.flix
+++ b/flix/test/Motorsport/TestMiniSector.flix
@@ -4,44 +4,17 @@ mod Motorsport.TestMiniSector {
     use Motorsport.MiniSector.MiniSectorId
 
     @Test
-    def testAllHasFifteenIds(): Unit \ Assert =
-        Assert.assertTrue(List.length(MiniSector.all()) == 15)
-
-    @Test
-    def testAllStartsWithS1MiniSectors(): Unit \ Assert =
-        // S1 = SCL2, Z4, IP1 (matches Motorsport.Circuit.LeMans.layout.s1).
-        match List.take(3, MiniSector.all()) {
-            case MiniSectorId.SCL2 :: MiniSectorId.Z4 :: MiniSectorId.IP1 :: Nil =>
-                Assert.assertTrue(true)
-            case _ => Assert.assertTrue(false)
-        }
-
-    @Test
-    def testAllEndsWithFinishLine(): Unit \ Assert =
-        match List.last(MiniSector.all()) {
-            case Some(MiniSectorId.FL) => Assert.assertTrue(true)
-            case _                     => Assert.assertTrue(false)
-        }
-
-    @Test
     def testCsvNamesPreserveHyphens(): Unit \ Assert =
-        // The Flix identifier underscore in A7_1 / A8_1 must map to a hyphen
-        // in the CSV column name (the actual columns are A7-1_time / A8-1_time).
+        // Flix identifier `A7_1` / `A8_1` must map to the hyphenated
+        // CSV columns `A7-1_*` / `A8-1_*`.
         Assert.assertTrue(MiniSector.csvName(MiniSectorId.A7_1) == "A7-1");
-        Assert.assertTrue(MiniSector.csvName(MiniSectorId.A8_1) == "A8-1");
-        Assert.assertTrue(MiniSector.csvName(MiniSectorId.SCL2) == "SCL2");
-        Assert.assertTrue(MiniSector.csvName(MiniSectorId.FORDOUT) == "FORDOUT");
-        Assert.assertTrue(MiniSector.csvName(MiniSectorId.FL) == "FL")
+        Assert.assertTrue(MiniSector.csvName(MiniSectorId.A8_1) == "A8-1")
 
     @Test
     def testJsonKeysPreserveUnderscores(): Unit \ Assert =
-        // JSON keys lowercase the CSV name and preserve underscores
-        // (matches Motorsport.Lap.MiniSectors field names on the Elm side).
+        // JSON keys keep the underscore (matches Elm `Motorsport.Lap.MiniSectors`).
         Assert.assertTrue(MiniSector.jsonKey(MiniSectorId.A7_1) == "a7_1");
-        Assert.assertTrue(MiniSector.jsonKey(MiniSectorId.A8_1) == "a8_1");
-        Assert.assertTrue(MiniSector.jsonKey(MiniSectorId.SCL2) == "scl2");
-        Assert.assertTrue(MiniSector.jsonKey(MiniSectorId.PORIN) == "porin");
-        Assert.assertTrue(MiniSector.jsonKey(MiniSectorId.FL) == "fl")
+        Assert.assertTrue(MiniSector.jsonKey(MiniSectorId.A8_1) == "a8_1")
 
     @Test
     def testAllIdsHaveDistinctJsonKeys(): Unit \ Assert =

--- a/flix/test/TestRawLap.flix
+++ b/flix/test/TestRawLap.flix
@@ -5,10 +5,20 @@ mod TestRawLap {
     use Util.Duration
     use Util.HourClock.Hour
     use Util.Json
+    use Motorsport.MiniSector
+    use Motorsport.MiniSector.MiniSectorId
     use RawLap.RawLap
 
     def header(): String =
         "NUMBER;DRIVER_NUMBER;LAP_NUMBER;LAP_TIME;LAP_IMPROVEMENT;CROSSING_FINISH_LINE_IN_PIT;S1;S1_IMPROVEMENT;S2;S2_IMPROVEMENT;S3;S3_IMPROVEMENT;KPH;ELAPSED;HOUR;S1_LARGE;S2_LARGE;S3_LARGE;TOP_SPEED;DRIVER_NAME;PIT_TIME;CLASS;GROUP;TEAM;MANUFACTURER;FLAG_AT_FL;S1_SECONDS;S2_SECONDS;S3_SECONDS"
+
+    /// Le Mans header: base columns + 30 mini-sector columns
+    /// (`<NAME>_time;<NAME>_elapsed` for each of the 15 markers in track order).
+    def leMansHeader(): String =
+        header() +
+        ";SCL2_time;SCL2_elapsed;Z4_time;Z4_elapsed;IP1_time;IP1_elapsed" +
+        ";Z12_time;Z12_elapsed;SCLC_time;SCLC_elapsed;A7-1_time;A7-1_elapsed;IP2_time;IP2_elapsed" +
+        ";A8-1_time;A8-1_elapsed;SCLB_time;SCLB_elapsed;PORIN_time;PORIN_elapsed;POROUT_time;POROUT_elapsed;PITREF_time;PITREF_elapsed;SCL1_time;SCL1_elapsed;FORDOUT_time;FORDOUT_elapsed;FL_time;FL_elapsed"
 
     /// Decodes a single semicolon-separated CSV line (without header) and
     /// pulls the first record out of the result. The header row is prepended
@@ -125,6 +135,111 @@ mod TestRawLap {
         match decodeOne("12;1;3;2:41.963;0;;41.805;0;1:03.483;0;56.675;0;101.4;6:10.938;garbage;0:41.805;1:03.483;0:56.675;88.5;Will STEVENS;;HYPERCAR;H;Hertz Team JOTA;Porsche;SF;41.805;63.483;56.675;") {
             case Ok(_)  => Assert.assertTrue(false)
             case Err(_) => Assert.assertTrue(true)
+        }
+
+    @Test
+    def testNonLeMansCsvLeavesMiniSectorsNone(): Unit \ Assert =
+        // The standard WEC header has no mini-sector columns, so decode
+        // should succeed with `miniSectors == None` and `toJson` must omit
+        // the `miniSectors` key entirely.
+        match decodeOne("12;1;3;2:41.963;0;;41.805;0;1:03.483;0;56.675;0;101.4;6:10.938;11:06:38.429;0:41.805;1:03.483;0:56.675;88.5;Will STEVENS;;HYPERCAR;H;Hertz Team JOTA;Porsche;SF;41.805;63.483;56.675;") {
+            case Ok(r) =>
+                let isNone = match r#miniSectors {
+                    case None    => true
+                    case Some(_) => false
+                };
+                Assert.assertTrue(isNone);
+                let json = Json.render(RawLap.toJson(r));
+                Assert.assertTrue(not String.contains({substr = "miniSectors"}, json))
+            case Err(_) => Assert.assertTrue(false)
+        }
+
+    /// Decode a single Le Mans-shaped row (base 29 fields + 30 mini-sector fields).
+    def decodeLeMansOne(line: String): Result[Error, RawLap] =
+        match Decode.decodeCustom(
+            {fieldSeparator = ';'},
+            FieldNames.FieldNamesFromFirstRow,
+            RawLap.decoder(),
+            leMansHeader() + "\n" + line
+        ) {
+            case Ok(r :: _) => Ok(r)
+            case Ok(Nil)    => Err(Error.DecodingErrors(Nil))
+            case Err(e)     => Err(e)
+        }
+
+    @Test
+    def testLeMansRowDecodesAllFifteenMiniSectors(): Unit \ Assert =
+        // Real first-lap row from app/static/wec/2025/le_mans_24h.csv (car 007 lap 1).
+        let line =
+            "007;1;1;3:54.555;0;;51.908;0;1:23.252;0;1:39.395;0;206.9;3:54.555;16:03:54.555;0:51.908;1:23.252;1:39.395;328.8;Harry TINCKNELL;;HYPERCAR;;Aston Martin Thor Team;Aston Martin;GF;51.908;83.252;99.395;" +
+            "20.708;20.708;13.826;34.534;17.374;51.908;" +
+            "35.154;1:27.062;4.685;1:31.747;26.059;1:57.806;17.354;2:15.160;" +
+            "6.928;2:22.088;37.644;2:59.732;17.155;3:16.887;16.786;3:33.673;7.954;3:41.627;2.885;3:44.512;6.560;3:51.072;3.483;3:54.555";
+        match decodeLeMansOne(line) {
+            case Ok(r) =>
+                match r#miniSectors {
+                    case None       => Assert.assertTrue(false)
+                    case Some(list) =>
+                        Assert.assertTrue(List.length(list) == 15);
+                        // First entry must be SCL2 with time=20.708 (= 20708 ms).
+                        match List.head(list) {
+                            case Some((id, sector)) =>
+                                Assert.assertTrue(id == MiniSectorId.SCL2);
+                                Assert.assertTrue(sector#time == Some(Duration.fromMillis(20708)));
+                                Assert.assertTrue(sector#elapsed == Some(Duration.fromMillis(20708)))
+                            case None => Assert.assertTrue(false)
+                        };
+                        // Last entry must be FL with elapsed = lapTime (3:54.555 = 234555 ms).
+                        match List.last(list) {
+                            case Some((id, sector)) =>
+                                Assert.assertTrue(id == MiniSectorId.FL);
+                                Assert.assertTrue(sector#elapsed == Some(Duration.fromMillis(234555)))
+                            case None => Assert.assertTrue(false)
+                        }
+                }
+            case Err(_) => Assert.assertTrue(false)
+        }
+
+    @Test
+    def testLeMansRowJsonContainsMiniSectorsWithHyphenedKeys(): Unit \ Assert =
+        // Confirm A7-1 / A8-1 round-trip to a7_1 / a8_1 in the JSON output
+        // (matches Motorsport.Lap.MiniSectors field names on the Elm side).
+        let line =
+            "007;1;1;3:54.555;0;;51.908;0;1:23.252;0;1:39.395;0;206.9;3:54.555;16:03:54.555;0:51.908;1:23.252;1:39.395;328.8;Harry TINCKNELL;;HYPERCAR;;Aston Martin Thor Team;Aston Martin;GF;51.908;83.252;99.395;" +
+            "20.708;20.708;13.826;34.534;17.374;51.908;" +
+            "35.154;1:27.062;4.685;1:31.747;26.059;1:57.806;17.354;2:15.160;" +
+            "6.928;2:22.088;37.644;2:59.732;17.155;3:16.887;16.786;3:33.673;7.954;3:41.627;2.885;3:44.512;6.560;3:51.072;3.483;3:54.555";
+        match decodeLeMansOne(line) {
+            case Ok(r) =>
+                let json = Json.render(RawLap.toJson(r));
+                Assert.assertTrue(String.contains({substr = "\"miniSectors\""}, json));
+                Assert.assertTrue(String.contains({substr = "\"a7_1\""}, json));
+                Assert.assertTrue(String.contains({substr = "\"a8_1\""}, json));
+                Assert.assertTrue(not String.contains({substr = "\"a7-1\""}, json));
+                Assert.assertTrue(String.contains({substr = "\"scl2\""}, json));
+                Assert.assertTrue(String.contains({substr = "\"fl\""}, json))
+            case Err(_) => Assert.assertTrue(false)
+        }
+
+    @Test
+    def testLeMansRowAllBlankMiniSectorsCollapseToNone(): Unit \ Assert =
+        // When every mini-sector column in a Le Mans row is blank, the
+        // whole `miniSectors` field collapses to None and the JSON omits
+        // the key.
+        let blanks = ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;";
+        let line =
+            "007;1;1;3:54.555;0;;51.908;0;1:23.252;0;1:39.395;0;206.9;3:54.555;16:03:54.555;0:51.908;1:23.252;1:39.395;328.8;Harry TINCKNELL;;HYPERCAR;;Aston Martin Thor Team;Aston Martin;GF;51.908;83.252;99.395" +
+            blanks;
+        match decodeLeMansOne(line) {
+            case Ok(r) =>
+                let isNone = match r#miniSectors {
+                    case None    => true
+                    case Some(_) => false
+                };
+                Assert.assertTrue(isNone);
+                let json = Json.render(RawLap.toJson(r));
+                Assert.assertTrue(not String.contains({substr = "miniSectors"}, json))
+            case Err(_) => Assert.assertTrue(false)
         }
 
 }

--- a/flix/test/TestRawLap.flix
+++ b/flix/test/TestRawLap.flix
@@ -167,15 +167,16 @@ mod TestRawLap {
             case Err(e)     => Err(e)
         }
 
+    /// Real first-lap row from app/static/wec/2025/le_mans_24h.csv (car 007 lap 1).
+    def realLeMansLapRow(): String =
+        "007;1;1;3:54.555;0;;51.908;0;1:23.252;0;1:39.395;0;206.9;3:54.555;16:03:54.555;0:51.908;1:23.252;1:39.395;328.8;Harry TINCKNELL;;HYPERCAR;;Aston Martin Thor Team;Aston Martin;GF;51.908;83.252;99.395;" +
+        "20.708;20.708;13.826;34.534;17.374;51.908;" +
+        "35.154;1:27.062;4.685;1:31.747;26.059;1:57.806;17.354;2:15.160;" +
+        "6.928;2:22.088;37.644;2:59.732;17.155;3:16.887;16.786;3:33.673;7.954;3:41.627;2.885;3:44.512;6.560;3:51.072;3.483;3:54.555"
+
     @Test
     def testLeMansRowDecodesAllFifteenMiniSectors(): Unit \ Assert =
-        // Real first-lap row from app/static/wec/2025/le_mans_24h.csv (car 007 lap 1).
-        let line =
-            "007;1;1;3:54.555;0;;51.908;0;1:23.252;0;1:39.395;0;206.9;3:54.555;16:03:54.555;0:51.908;1:23.252;1:39.395;328.8;Harry TINCKNELL;;HYPERCAR;;Aston Martin Thor Team;Aston Martin;GF;51.908;83.252;99.395;" +
-            "20.708;20.708;13.826;34.534;17.374;51.908;" +
-            "35.154;1:27.062;4.685;1:31.747;26.059;1:57.806;17.354;2:15.160;" +
-            "6.928;2:22.088;37.644;2:59.732;17.155;3:16.887;16.786;3:33.673;7.954;3:41.627;2.885;3:44.512;6.560;3:51.072;3.483;3:54.555";
-        match decodeLeMansOne(line) {
+        match decodeLeMansOne(realLeMansLapRow()) {
             case Ok(r) =>
                 match r#miniSectors {
                     case None       => Assert.assertTrue(false)
@@ -204,12 +205,7 @@ mod TestRawLap {
     def testLeMansRowJsonContainsMiniSectorsWithHyphenedKeys(): Unit \ Assert =
         // Confirm A7-1 / A8-1 round-trip to a7_1 / a8_1 in the JSON output
         // (matches Motorsport.Lap.MiniSectors field names on the Elm side).
-        let line =
-            "007;1;1;3:54.555;0;;51.908;0;1:23.252;0;1:39.395;0;206.9;3:54.555;16:03:54.555;0:51.908;1:23.252;1:39.395;328.8;Harry TINCKNELL;;HYPERCAR;;Aston Martin Thor Team;Aston Martin;GF;51.908;83.252;99.395;" +
-            "20.708;20.708;13.826;34.534;17.374;51.908;" +
-            "35.154;1:27.062;4.685;1:31.747;26.059;1:57.806;17.354;2:15.160;" +
-            "6.928;2:22.088;37.644;2:59.732;17.155;3:16.887;16.786;3:33.673;7.954;3:41.627;2.885;3:44.512;6.560;3:51.072;3.483;3:54.555";
-        match decodeLeMansOne(line) {
+        match decodeLeMansOne(realLeMansLapRow()) {
             case Ok(r) =>
                 let json = Json.render(RawLap.toJson(r));
                 Assert.assertTrue(String.contains({substr = "\"miniSectors\""}, json));

--- a/flix/test/TestRawLap.flix
+++ b/flix/test/TestRawLap.flix
@@ -183,18 +183,18 @@ mod TestRawLap {
                         Assert.assertTrue(List.length(list) == 15);
                         // First entry must be SCL2 with time=20.708 (= 20708 ms).
                         match List.head(list) {
-                            case Some((id, sector)) =>
+                            case Some((id, Some(sector))) =>
                                 Assert.assertTrue(id == MiniSectorId.SCL2);
-                                Assert.assertTrue(sector#time == Some(Duration.fromMillis(20708)));
-                                Assert.assertTrue(sector#elapsed == Some(Duration.fromMillis(20708)))
-                            case None => Assert.assertTrue(false)
+                                Assert.assertTrue(sector#time == Duration.fromMillis(20708));
+                                Assert.assertTrue(sector#elapsed == Duration.fromMillis(20708))
+                            case _ => Assert.assertTrue(false)
                         };
                         // Last entry must be FL with elapsed = lapTime (3:54.555 = 234555 ms).
                         match List.last(list) {
-                            case Some((id, sector)) =>
+                            case Some((id, Some(sector))) =>
                                 Assert.assertTrue(id == MiniSectorId.FL);
-                                Assert.assertTrue(sector#elapsed == Some(Duration.fromMillis(234555)))
-                            case None => Assert.assertTrue(false)
+                                Assert.assertTrue(sector#elapsed == Duration.fromMillis(234555))
+                            case _ => Assert.assertTrue(false)
                         }
                 }
             case Err(_) => Assert.assertTrue(false)
@@ -240,6 +240,22 @@ mod TestRawLap {
                 let json = Json.render(RawLap.toJson(r));
                 Assert.assertTrue(not String.contains({substr = "miniSectors"}, json))
             case Err(_) => Assert.assertTrue(false)
+        }
+
+    @Test
+    def testHalfBlankMiniSectorRejected(): Unit \ Assert =
+        // SCL2_time present (20.708) but SCL2_elapsed blank — the two
+        // columns must agree (both present or both absent), so the
+        // decoder must reject this row rather than silently producing
+        // a half-empty record.
+        let line =
+            "007;1;1;3:54.555;0;;51.908;0;1:23.252;0;1:39.395;0;206.9;3:54.555;16:03:54.555;0:51.908;1:23.252;1:39.395;328.8;Harry TINCKNELL;;HYPERCAR;;Aston Martin Thor Team;Aston Martin;GF;51.908;83.252;99.395;" +
+            "20.708;;13.826;34.534;17.374;51.908;" +
+            "35.154;1:27.062;4.685;1:31.747;26.059;1:57.806;17.354;2:15.160;" +
+            "6.928;2:22.088;37.644;2:59.732;17.155;3:16.887;16.786;3:33.673;7.954;3:41.627;2.885;3:44.512;6.560;3:51.072;3.483;3:54.555";
+        match decodeLeMansOne(line) {
+            case Ok(_)  => Assert.assertTrue(false)
+            case Err(_) => Assert.assertTrue(true)
         }
 
 }

--- a/flix/test/TestRawLap.flix
+++ b/flix/test/TestRawLap.flix
@@ -183,18 +183,18 @@ mod TestRawLap {
                         Assert.assertTrue(List.length(list) == 15);
                         // First entry must be SCL2 with time=20.708 (= 20708 ms).
                         match List.head(list) {
-                            case Some((id, Some(sector))) =>
+                            case Some((id, sector)) =>
                                 Assert.assertTrue(id == MiniSectorId.SCL2);
-                                Assert.assertTrue(sector#time == Duration.fromMillis(20708));
-                                Assert.assertTrue(sector#elapsed == Duration.fromMillis(20708))
-                            case _ => Assert.assertTrue(false)
+                                Assert.assertTrue(sector#time == Some(Duration.fromMillis(20708)));
+                                Assert.assertTrue(sector#elapsed == Some(Duration.fromMillis(20708)))
+                            case None => Assert.assertTrue(false)
                         };
                         // Last entry must be FL with elapsed = lapTime (3:54.555 = 234555 ms).
                         match List.last(list) {
-                            case Some((id, Some(sector))) =>
+                            case Some((id, sector)) =>
                                 Assert.assertTrue(id == MiniSectorId.FL);
-                                Assert.assertTrue(sector#elapsed == Duration.fromMillis(234555))
-                            case _ => Assert.assertTrue(false)
+                                Assert.assertTrue(sector#elapsed == Some(Duration.fromMillis(234555)))
+                            case None => Assert.assertTrue(false)
                         }
                 }
             case Err(_) => Assert.assertTrue(false)
@@ -240,22 +240,6 @@ mod TestRawLap {
                 let json = Json.render(RawLap.toJson(r));
                 Assert.assertTrue(not String.contains({substr = "miniSectors"}, json))
             case Err(_) => Assert.assertTrue(false)
-        }
-
-    @Test
-    def testHalfBlankMiniSectorRejected(): Unit \ Assert =
-        // SCL2_time present (20.708) but SCL2_elapsed blank — the two
-        // columns must agree (both present or both absent), so the
-        // decoder must reject this row rather than silently producing
-        // a half-empty record.
-        let line =
-            "007;1;1;3:54.555;0;;51.908;0;1:23.252;0;1:39.395;0;206.9;3:54.555;16:03:54.555;0:51.908;1:23.252;1:39.395;328.8;Harry TINCKNELL;;HYPERCAR;;Aston Martin Thor Team;Aston Martin;GF;51.908;83.252;99.395;" +
-            "20.708;;13.826;34.534;17.374;51.908;" +
-            "35.154;1:27.062;4.685;1:31.747;26.059;1:57.806;17.354;2:15.160;" +
-            "6.928;2:22.088;37.644;2:59.732;17.155;3:16.887;16.786;3:33.673;7.954;3:41.627;2.885;3:44.512;6.560;3:51.072;3.483;3:54.555";
-        match decodeLeMansOne(line) {
-            case Ok(_)  => Assert.assertTrue(false)
-            case Err(_) => Assert.assertTrue(true)
         }
 
 }


### PR DESCRIPTION
## Summary
Extends the lap validation system to support Le Mans 24h mini-sectors—15 named timing segments that appear alongside the standard S1/S2/S3 split. Adds two new validation rules to detect timing anomalies specific to Le Mans data, with special handling for pit laps and track-limits violations.

## Key Changes

- **New `Motorsport.MiniSector` module**: Defines the 15 Le Mans mini-sector IDs (SCL2, Z4, IP1, Z12, SCLC, A7-1, A8-1, SCLB, PORIN, POROUT, PITREF, SCL1, FORDOUT, FL) with mappings between CSV column names (hyphenated), JSON keys (underscored), and track order.

- **Extended `RawLap` structure**: Added `miniSectors` field as `Option[List[(MiniSectorId, RawMiniSector)]]` to hold decoded mini-sector data. Non-Le Mans CSVs decode to `None`; all-blank mini-sector rows also collapse to `None` so JSON output omits the key.

- **Two new validation rules** in `Cli.Validation`:
  - `MiniSectorSum`: Verifies that the sum of mini-sector times equals lapTime. Skipped on pit laps (identified by `crossingFinishLineInPit == "B"` or `pitTime != None`) and known Ford-chicane track-limits signatures (SCL1+FORDOUT or PITREF+SCL1 blanks).
  - `MiniSectorElapsedMonotonic`: Ensures mini-sector elapsed times are strictly increasing in track order. Runs on all laps including pit laps; blank elapsed entries are skipped without breaking the chain.

- **CSV decoding support**: Added `miniSectorsDecoder()` using a new `Util.Csv.Decode.Extra.traverse()` helper to independently decode each of the 15 mini-sectors. Handles missing columns (non-Le Mans rounds) and blank values gracefully.

- **Comprehensive test coverage**: 
  - 13 new tests in `Cli.TestValidation` covering valid laps, sum mismatches, blank markers, monotonic violations, pit-lap exemptions, and track-limits signatures.
  - 4 new tests in `TestRawLap` validating Le Mans CSV decoding, JSON serialization with hyphen-to-underscore conversion, and all-blank collapse behavior.
  - 3 new tests in `Motorsport.TestMiniSector` confirming CSV/JSON name mappings and ID uniqueness.

## Implementation Details

- Mini-sector rules silently skip laps where `miniSectors == None`, making them transparent to non-Le Mans rounds.
- Track-limits detection is pattern-based: the two dominant Ford-chicane signatures (SCL1+FORDOUT and PITREF+SCL1) are recognized by their blank marker lists in track order.
- The `traverse()` helper in `Decode.Extra` builds the decoder graph once rather than per-row, improving efficiency for the 15 independent mini-sector decoders.
- Violation messages include blank marker IDs and use labeled duration pairs for flexible formatting.

https://claude.ai/code/session_01BvbnWEEyfoa3Z7MN3m1FEg