### PR TITLE
env: update Flix to 0.73.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,10 +74,10 @@
           };
 
         flix = pkgs.flix.overrideAttrs (old: rec {
-          version = "0.72.0";
+          version = "0.73.0";
           src = pkgs.fetchurl {
             url = "https://github.com/flix/flix/releases/download/v${version}/flix.jar";
-            hash = "sha256-87WDphvCBJf5M46NtKGCTEu6k0g6SF/yttmRrEA8Nis=";
+            hash = "sha256-X2kiXS4qXAKau1qJswbJfi/gsty49RMW355+yYaBGUM=";
           };
         });
 

--- a/flix/flix.toml
+++ b/flix/flix.toml
@@ -2,5 +2,5 @@
 name        = "flix"
 description = "test"
 version     = "0.1.0"
-flix        = "0.71.0"
+flix        = "0.73.0"
 authors     = ["John Doe <john@example.com>"]

--- a/flix/src/Cli/Stages/Transform.flix
+++ b/flix/src/Cli/Stages/Transform.flix
@@ -1,7 +1,7 @@
 mod Cli.Stages.Transform {
 
-    use Util.Json
-    use Util.Json.JsonValue.JsonArray
+    use Util.Json.Encode
+    use Util.Json.Encode.JsonValue.JsonArray
     use Motorsport.Metadata
     use Motorsport.Wec
     use Motorsport.Wec.RawLap
@@ -14,8 +14,8 @@ mod Cli.Stages.Transform {
 
     pub def transform(eventId: String, rawLaps: List[RawLap]): Rendered =
         let metadata     = Metadata.fromRawLaps(eventId, rawLaps);
-        let metadataJson = Json.render(Metadata.toJson(metadata));
-        let lapsJson     = Json.render(JsonArray(List.map(Wec.toJson, rawLaps)));
+        let metadataJson = Encode.render(Metadata.toJson(metadata));
+        let lapsJson     = Encode.render(JsonArray(List.map(Wec.toJson, rawLaps)));
         {
             lapCount     = List.length(rawLaps),
             metadataJson = metadataJson,

--- a/flix/src/Motorsport/Metadata.flix
+++ b/flix/src/Motorsport/Metadata.flix
@@ -1,8 +1,8 @@
 mod Motorsport.Metadata {
 
     use Util.Duration.Duration
-    use Util.Json
-    use Util.Json.JsonValue.{JsonObject, JsonString, JsonInt, JsonArray}
+    use Util.Json.Encode
+    use Util.Json.Encode.JsonValue.{JsonObject, JsonString, JsonInt, JsonArray}
     use Motorsport.Car.Car
     use Motorsport.Events
     use Motorsport.Wec.RawLap
@@ -85,21 +85,21 @@ mod Motorsport.Metadata {
             { position = pos, car = b#car }
         )
 
-    pub def toJson(meta: Metadata): Json.JsonValue =
+    pub def toJson(meta: Metadata): Encode.JsonValue =
         JsonObject(
             ("name",         JsonString(meta#name)) ::
             ("startingGrid", JsonArray(meta#startingGrid |> List.map(toGridEntryJson))) ::
             Nil
         )
 
-    def toGridEntryJson(entry: StartingGrid): Json.JsonValue =
+    def toGridEntryJson(entry: StartingGrid): Encode.JsonValue =
         JsonObject(
             ("position", JsonInt(entry#position)) ::
             ("car",      carToJson(entry#car)) ::
             Nil
         )
 
-    def carToJson(car: Car): Json.JsonValue =
+    def carToJson(car: Car): Encode.JsonValue =
         JsonObject(
             ("carNumber",    JsonString(car#carNumber)) ::
             ("drivers",      JsonArray(car#drivers |> List.map(driverToJson))) ::
@@ -110,7 +110,7 @@ mod Motorsport.Metadata {
             Nil
         )
 
-    def driverToJson(name: String): Json.JsonValue =
+    def driverToJson(name: String): Encode.JsonValue =
         JsonObject(("name", JsonString(name)) :: Nil)
 
 }

--- a/flix/src/Motorsport/Wec.flix
+++ b/flix/src/Motorsport/Wec.flix
@@ -6,8 +6,8 @@ mod Motorsport.Wec {
     use Util.Duration.Duration
     use Util.HourClock
     use Util.HourClock.Hour
-    use Util.Json
-    use Util.Json.JsonValue.{JsonObject, JsonString, JsonInt, JsonArray}
+    use Util.Json.Encode
+    use Util.Json.Encode.JsonValue.{JsonObject, JsonString, JsonInt, JsonArray}
     use Motorsport.MiniSector
     use Motorsport.MiniSector.MiniSectorId
 
@@ -129,7 +129,7 @@ mod Motorsport.Wec {
             |> Decode.pipeline(flagField("FLAG_AT_FL"))
             |> Decode.pipeline(miniSectorsDecoder())
 
-    pub def toJson(rawLap: RawLap): Json.JsonValue =
+    pub def toJson(rawLap: RawLap): Encode.JsonValue =
         let baseFields =
             ("carNumber",               JsonString(rawLap#car#carNumber)) ::
             ("driverNumber",            JsonInt(rawLap#driver#number)) ::
@@ -325,7 +325,7 @@ mod Motorsport.Wec {
             case Flag.Red              => "RF"
         }
 
-    def optionalDurationJson(d: Option[Duration]): Json.JsonValue =
+    def optionalDurationJson(d: Option[Duration]): Encode.JsonValue =
         match d {
             case Some(ms) => JsonString(Util.Duration.format(ms))
             case None     => JsonString("")
@@ -362,7 +362,7 @@ mod Motorsport.Wec {
         );
         if (hasAny) Some(list) else None
 
-    def miniSectorsToJson(list: List[(MiniSectorId, RawMiniSector)]): Json.JsonValue =
+    def miniSectorsToJson(list: List[(MiniSectorId, RawMiniSector)]): Encode.JsonValue =
         let entries = list |> List.filterMap(match (id, sector) ->
             if (sector#time == None and sector#elapsed == None)
                 None
@@ -371,7 +371,7 @@ mod Motorsport.Wec {
         );
         JsonObject(entries)
 
-    def miniSectorToJson(sector: RawMiniSector): Json.JsonValue =
+    def miniSectorToJson(sector: RawMiniSector): Encode.JsonValue =
         JsonObject(
             ("time",    optionalDurationJson(sector#time)) ::
             ("elapsed", optionalDurationJson(sector#elapsed)) ::

--- a/flix/src/Util.flix
+++ b/flix/src/Util.flix
@@ -1,1 +1,0 @@
-mod Util { }

--- a/flix/src/Util/Json/Encode.flix
+++ b/flix/src/Util/Json/Encode.flix
@@ -1,4 +1,4 @@
-mod Util.Json {
+mod Util.Json.Encode {
 
     pub enum JsonValue with ToString {
         case JsonNull

--- a/flix/test/Motorsport/TestMetadata.flix
+++ b/flix/test/Motorsport/TestMetadata.flix
@@ -5,7 +5,7 @@ mod Motorsport.TestMetadata {
     use Motorsport.Wec.RawLap
     use Util.Duration
     use Util.HourClock.Hour
-    use Util.Json
+    use Util.Json.Encode
 
     /// 検査用ヘルパー: 22 列のうちテストに必要なものだけ埋めた RawLap を作る。
     def mkLap(carNumber: String, lapNumber: Int32, elapsed: String, driverName: String, class: String, group: String, team: String, manufacturer: String): RawLap =
@@ -127,7 +127,7 @@ mod Motorsport.TestMetadata {
     def testToJsonRendersExpectedKeys(): Unit \ Assert =
         let laps = mkLap("7", 1, "1:33.291", "KOBAYASHI", "HYPERCAR", "H", "Toyota", "Toyota") :: Nil;
         let meta = Metadata.fromRawLaps("le_mans_24h", laps);
-        let json = Json.render(Metadata.toJson(meta));
+        let json = Encode.render(Metadata.toJson(meta));
         // 主要キーが出現することを確認 (構造アサーション)。
         Assert.assertTrue(String.contains({substr = "\"name\""}, json));
         Assert.assertTrue(String.contains({substr = "\"24 Hours of Le Mans\""}, json));

--- a/flix/test/Motorsport/TestWec.flix
+++ b/flix/test/Motorsport/TestWec.flix
@@ -4,7 +4,7 @@ mod Motorsport.TestWec {
     use Util.Csv.Decode.{FieldNames, Error}
     use Util.Duration
     use Util.HourClock.Hour
-    use Util.Json
+    use Util.Json.Encode
     use Motorsport.MiniSector
     use Motorsport.MiniSector.MiniSectorId
     use Motorsport.Wec
@@ -77,7 +77,7 @@ mod Motorsport.TestWec {
         // KPH is rendered as a JSON string, preserving the CSV value.
         match decodeOne("12;1;3;2:41.963;0;;41.805;0;1:03.483;0;56.675;0;86.0;6:10.938;11:06:38.429;0:41.805;1:03.483;0:56.675;88.5;Will STEVENS;;HYPERCAR;H;Hertz Team JOTA;Porsche;SF;41.805;63.483;56.675;") {
             case Ok(r) =>
-                let json = Json.render(Wec.toJson(r));
+                let json = Encode.render(Wec.toJson(r));
                 Assert.assertTrue(String.contains({substr = "\"kph\": \"86.0\""}, json))
             case Err(_) => Assert.assertTrue(false)
         }
@@ -150,7 +150,7 @@ mod Motorsport.TestWec {
                     case Some(_) => false
                 };
                 Assert.assertTrue(isNone);
-                let json = Json.render(Wec.toJson(r));
+                let json = Encode.render(Wec.toJson(r));
                 Assert.assertTrue(not String.contains({substr = "miniSectors"}, json))
             case Err(_) => Assert.assertTrue(false)
         }
@@ -208,7 +208,7 @@ mod Motorsport.TestWec {
         // (matches Motorsport.Lap.MiniSectors field names on the Elm side).
         match decodeLeMansOne(realLeMansLapRow()) {
             case Ok(r) =>
-                let json = Json.render(Wec.toJson(r));
+                let json = Encode.render(Wec.toJson(r));
                 Assert.assertTrue(String.contains({substr = "\"miniSectors\""}, json));
                 Assert.assertTrue(String.contains({substr = "\"a7_1\""}, json));
                 Assert.assertTrue(String.contains({substr = "\"a8_1\""}, json));
@@ -234,7 +234,7 @@ mod Motorsport.TestWec {
                     case Some(_) => false
                 };
                 Assert.assertTrue(isNone);
-                let json = Json.render(Wec.toJson(r));
+                let json = Encode.render(Wec.toJson(r));
                 Assert.assertTrue(not String.contains({substr = "miniSectors"}, json))
             case Err(_) => Assert.assertTrue(false)
         }

--- a/flix/test/Util/TestJson.flix
+++ b/flix/test/Util/TestJson.flix
@@ -1,52 +1,52 @@
 mod Util.TestJson {
 
-    use Util.Json
-    use Util.Json.JsonValue.{JsonNull, JsonBool, JsonInt, JsonFloat, JsonString, JsonArray, JsonObject}
+    use Util.Json.Encode
+    use Util.Json.Encode.JsonValue.{JsonNull, JsonBool, JsonInt, JsonFloat, JsonString, JsonArray, JsonObject}
 
     @Test
     def testRenderNull(): Unit \ Assert =
-        Assert.assertTrue(Json.render(JsonNull) == "null")
+        Assert.assertTrue(Encode.render(JsonNull) == "null")
 
     @Test
     def testRenderBoolTrue(): Unit \ Assert =
-        Assert.assertTrue(Json.render(JsonBool(true)) == "true")
+        Assert.assertTrue(Encode.render(JsonBool(true)) == "true")
 
     @Test
     def testRenderBoolFalse(): Unit \ Assert =
-        Assert.assertTrue(Json.render(JsonBool(false)) == "false")
+        Assert.assertTrue(Encode.render(JsonBool(false)) == "false")
 
     @Test
     def testRenderInt(): Unit \ Assert =
-        Assert.assertTrue(Json.render(JsonInt(42)) == "42")
+        Assert.assertTrue(Encode.render(JsonInt(42)) == "42")
 
     @Test
     def testRenderString(): Unit \ Assert =
-        Assert.assertTrue(Json.render(JsonString("hello")) == "\"hello\"")
+        Assert.assertTrue(Encode.render(JsonString("hello")) == "\"hello\"")
 
     @Test
     def testRenderStringWithQuotes(): Unit \ Assert =
-        let result = Json.render(JsonString("say \"hi\""));
+        let result = Encode.render(JsonString("say \"hi\""));
         Assert.assertTrue(String.contains({substr = "\\\""}, result))
 
     @Test
     def testRenderEmptyArray(): Unit \ Assert =
-        Assert.assertTrue(Json.render(JsonArray(Nil)) == "[]")
+        Assert.assertTrue(Encode.render(JsonArray(Nil)) == "[]")
 
     @Test
     def testRenderEmptyObject(): Unit \ Assert =
-        Assert.assertTrue(Json.render(JsonObject(Nil)) == "{}")
+        Assert.assertTrue(Encode.render(JsonObject(Nil)) == "{}")
 
     @Test
     def testRenderObject(): Unit \ Assert =
         let obj = JsonObject(("name", JsonString("test")) :: ("value", JsonInt(1)) :: Nil);
-        let result = Json.render(obj);
+        let result = Encode.render(obj);
         Assert.assertTrue(String.contains({substr = "\"name\": \"test\""}, result));
         Assert.assertTrue(String.contains({substr = "\"value\": 1"}, result))
 
     @Test
     def testRenderArray(): Unit \ Assert =
         let arr = JsonArray(JsonInt(1) :: JsonInt(2) :: Nil);
-        let result = Json.render(arr);
+        let result = Encode.render(arr);
         Assert.assertTrue(String.contains({substr = "1"}, result));
         Assert.assertTrue(String.contains({substr = "2"}, result))
 


### PR DESCRIPTION
## Overview
Update Flix to 0.73.0 (latest release).

## Changes
- `flake.nix`: Flix `0.72.0` → `0.73.0` (updated the jar's sha256 hash)
- `flix/flix.toml`: `flix = "0.71.0"` → `"0.73.0"`

## Handling 0.73.0 breaking changes
0.73.0 adds `Util` / `Util.Json` to the standard library and also introduces a "no module reopening" rule, which collided with our own modules. Resolved as follows:
- Removed the empty marker `mod Util { }` (`src/Util.flix`) — no longer needed since the stdlib now provides `Util`
- Renamed our `Util.Json` to `Util.Json.Encode` (moved to `src/Util/Json/Encode.flix`)
- Updated all references (Wec / Metadata / Transform and their tests) to `use Util.Json.Encode` / `Encode.render` / `Encode.JsonValue`

## Notes for reviewers
- Our `Util.Json.Encode` must preserve **insertion order** of object keys in the output JSON, so we keep it rather than switching to the stdlib `Util.Json` (which is `Map`-based and sorts keys).
- Verification: `flix-build` succeeds, `flix-test` passes 192 tests. `flix-run` output matches byte-for-byte on 6 of 7 files (the remaining file is a pre-existing stale data diff unrelated to this change, so it is excluded), confirming the formatting is preserved.