### PR TITLE
refactor(package): convert sectors once at the boundary

### DIFF
--- a/app/src/Data/Wec/Laps.elm
+++ b/app/src/Data/Wec/Laps.elm
@@ -21,6 +21,7 @@ import Motorsport.Car exposing (Car, CarNumber)
 import Motorsport.Driver as Driver
 import Motorsport.Duration as Duration exposing (Duration)
 import Motorsport.Lap exposing (Lap)
+import Motorsport.Sector as Sector exposing (BySector)
 
 
 type alias RawLap =
@@ -140,15 +141,13 @@ finalizeCarLaps raws =
 
 type alias Bests =
     { lap : Maybe Duration
-    , s1 : Maybe Duration
-    , s2 : Maybe Duration
-    , s3 : Maybe Duration
+    , sectors : BySector (Maybe Duration)
     }
 
 
 bestsInit : Bests
 bestsInit =
-    { lap = Nothing, s1 = Nothing, s2 = Nothing, s3 = Nothing }
+    { lap = Nothing, sectors = Sector.initialize (always Nothing) }
 
 
 minMaybe : Maybe Duration -> Maybe Duration -> Maybe Duration
@@ -167,11 +166,13 @@ minMaybe current new =
 accumulate : RawLap -> ( Bests, List Lap ) -> ( Bests, List Lap )
 accumulate raw ( bests, acc ) =
     let
+        -- The raw record spells the sectors out flat; this is where that stops.
+        rawSectors =
+            { s1 = raw.s1, s2 = raw.s2, s3 = raw.s3 }
+
         newBests =
             { lap = minMaybe bests.lap (Just raw.lapTime)
-            , s1 = minMaybe bests.s1 raw.s1
-            , s2 = minMaybe bests.s2 raw.s2
-            , s3 = minMaybe bests.s3 raw.s3
+            , sectors = Sector.map2 minMaybe bests.sectors rawSectors
             }
 
         lap =
@@ -181,12 +182,15 @@ accumulate raw ( bests, acc ) =
             , position = Nothing
             , time = raw.lapTime
             , best = newBests.lap |> Maybe.withDefault 0
-            , sector_1 = raw.s1 |> Maybe.withDefault 0
-            , sector_2 = raw.s2 |> Maybe.withDefault 0
-            , sector_3 = raw.s3 |> Maybe.withDefault 0
-            , s1_best = newBests.s1 |> Maybe.withDefault 0
-            , s2_best = newBests.s2 |> Maybe.withDefault 0
-            , s3_best = newBests.s3 |> Maybe.withDefault 0
+            , sectors =
+                Sector.map2
+                    (\time personalBest ->
+                        { time = time |> Maybe.withDefault 0
+                        , personalBest = personalBest |> Maybe.withDefault 0
+                        }
+                    )
+                    rawSectors
+                    newBests.sectors
             , elapsed = raw.elapsed
             , pitTime = raw.pitTime
             , miniSectors = Nothing

--- a/app/src/Page/Debug.elm
+++ b/app/src/Page/Debug.elm
@@ -20,7 +20,7 @@ import Motorsport.Leaderboard as Leaderboard exposing (bestTimeColumn, carNumber
 import Motorsport.Manufacturer
 import Motorsport.RaceControl as RaceControl
 import Motorsport.RunningOrder as RunningOrder
-import Motorsport.Sector as Sector exposing (Sector(..))
+import Motorsport.Sector as Sector
 import Motorsport.Utils exposing (compareBy)
 import Motorsport.ViewModel.BestTimes exposing (BestTimes)
 import Motorsport.ViewModel.Standings as Standings exposing (Entry, Standings)
@@ -108,12 +108,19 @@ view { viewModel, raceControl } { leaderboardState } =
                 , text (Clock.getElapsed clock |> Duration.toString)
                 ]
             , div []
-                [ div [] [ text "fastestLapTime: ", text (Duration.toString viewModel.bestTimes.fastestLapTime) ]
-                , div [] [ text "slowestLapTime: ", text (Duration.toString viewModel.bestTimes.slowestLapTime) ]
-                , div [] [ text "s1_fastest: ", text (Duration.toString viewModel.bestTimes.fastestSector_1) ]
-                , div [] [ text "s2_fastest: ", text (Duration.toString viewModel.bestTimes.fastestSector_2) ]
-                , div [] [ text "s3_fastest: ", text (Duration.toString viewModel.bestTimes.fastestSector_3) ]
-                ]
+                ([ div [] [ text "fastestLapTime: ", text (Duration.toString viewModel.bestTimes.fastestLapTime) ]
+                 , div [] [ text "slowestLapTime: ", text (Duration.toString viewModel.bestTimes.slowestLapTime) ]
+                 ]
+                    ++ (Sector.toList viewModel.bestTimes.fastestSectors
+                            |> List.map
+                                (\( sector, fastest ) ->
+                                    div []
+                                        [ text (Sector.toString sector ++ "_fastest: ")
+                                        , text (Duration.toString fastest)
+                                        ]
+                                )
+                       )
+                )
             ]
         , let
             standings =
@@ -152,15 +159,7 @@ sectorColumns : BestTimes -> List (DataView.Column Entry Msg)
 sectorColumns bestTimes =
     let
         fastest sector =
-            case sector of
-                S1 ->
-                    bestTimes.fastestSector_1
-
-                S2 ->
-                    bestTimes.fastestSector_2
-
-                S3 ->
-                    bestTimes.fastestSector_3
+            Sector.get sector bestTimes.fastestSectors
 
         times sector =
             .currentLapSectors >> Maybe.map (Sector.get sector)

--- a/package/src/Motorsport/Chart/Tracker.elm
+++ b/package/src/Motorsport/Chart/Tracker.elm
@@ -3,10 +3,9 @@ module Motorsport.Chart.Tracker exposing (view)
 import Css
 import Motorsport.Chart.Tracker.Config as Config exposing (TrackConfig)
 import Motorsport.Circuit as Circuit
-import Motorsport.Circuit.LeMans as LeMans
+import Motorsport.Circuit.LeMans as LeMans exposing (ByMiniSector)
 import Motorsport.Direction exposing (Direction(..))
 import Motorsport.Duration exposing (Duration)
-import Motorsport.Lap.Performance exposing (LeMans2025MiniSectorFastest)
 import Motorsport.Sector as Sector exposing (BySector)
 import Motorsport.ViewModel.Standings as Standings exposing (Entry, Standings)
 import Scale exposing (ContinuousScale)
@@ -98,7 +97,7 @@ view :
     ->
         { a
             | fastestSectors : BySector Duration
-            , fastestMiniSectors : LeMans2025MiniSectorFastest
+            , fastestMiniSectors : ByMiniSector Duration
         }
     -> Standings
     -> Svg msg

--- a/package/src/Motorsport/Chart/Tracker.elm
+++ b/package/src/Motorsport/Chart/Tracker.elm
@@ -7,7 +7,7 @@ import Motorsport.Circuit.LeMans as LeMans
 import Motorsport.Direction exposing (Direction(..))
 import Motorsport.Duration exposing (Duration)
 import Motorsport.Lap.Performance exposing (LeMans2025MiniSectorFastest)
-import Motorsport.Sector as Sector
+import Motorsport.Sector as Sector exposing (BySector)
 import Motorsport.ViewModel.Standings as Standings exposing (Entry, Standings)
 import Scale exposing (ContinuousScale)
 import Svg.Styled exposing (Svg, circle, g, line, svg, text, text_)
@@ -97,9 +97,7 @@ view :
     { season : Int, eventName : String }
     ->
         { a
-            | fastestSector_1 : Duration
-            , fastestSector_2 : Duration
-            , fastestSector_3 : Duration
+            | fastestSectors : BySector Duration
             , fastestMiniSectors : LeMans2025MiniSectorFastest
         }
     -> Standings

--- a/package/src/Motorsport/Chart/Tracker/Config.elm
+++ b/package/src/Motorsport/Chart/Tracker/Config.elm
@@ -16,10 +16,9 @@ module Motorsport.Chart.Tracker.Config exposing
 
 import List.Extra
 import Motorsport.Circuit as Circuit exposing (Layout)
-import Motorsport.Circuit.LeMans as LeMans exposing (LeMans2025MiniSector)
+import Motorsport.Circuit.LeMans as LeMans exposing (ByMiniSector, LeMans2025MiniSector)
 import Motorsport.Duration exposing (Duration)
 import Motorsport.Lap exposing (MiniSectorProgress, SectorProgress)
-import Motorsport.Lap.Performance exposing (LeMans2025MiniSectorFastest)
 import Motorsport.Sector as Sector exposing (BySector, Sector(..))
 import Motorsport.ViewModel.Standings exposing (Entry)
 
@@ -53,7 +52,7 @@ buildConfig :
     ->
         { a
             | fastestSectors : BySector Duration
-            , fastestMiniSectors : LeMans2025MiniSectorFastest
+            , fastestMiniSectors : ByMiniSector Duration
         }
     -> TrackConfig
 buildConfig layout bestTimes =

--- a/package/src/Motorsport/Chart/Tracker/Config.elm
+++ b/package/src/Motorsport/Chart/Tracker/Config.elm
@@ -94,17 +94,17 @@ buildConfig layout bestTimes =
     [ { sector = S1
       , start = 0
       , share = shares.s1
-      , miniSectorData = buildMiniSectors layout.s1 0 miniRatio
+      , miniSectorData = buildMiniSectors layout.sectors.s1 0 miniRatio
       }
     , { sector = S2
       , start = shares.s1
       , share = shares.s2
-      , miniSectorData = buildMiniSectors layout.s2 shares.s1 miniRatio
+      , miniSectorData = buildMiniSectors layout.sectors.s2 shares.s1 miniRatio
       }
     , { sector = S3
       , start = shares.s1 + shares.s2
       , share = shares.s3
-      , miniSectorData = buildMiniSectors layout.s3 (shares.s1 + shares.s2) miniRatio
+      , miniSectorData = buildMiniSectors layout.sectors.s3 (shares.s1 + shares.s2) miniRatio
       }
     ]
 
@@ -135,10 +135,7 @@ computeSectorShares layout bestTimes totalTime miniRatio =
                         |> List.map miniRatio
                         |> List.sum
     in
-    -- Circuit.Layout still spells its sectors out flat.
-    Sector.map2 sectorShare
-        bestTimes.fastestSectors
-        { s1 = layout.s1, s2 = layout.s2, s3 = layout.s3 }
+    Sector.map2 sectorShare bestTimes.fastestSectors layout.sectors
 
 
 buildMiniSectors : List LeMans2025MiniSector -> Float -> (LeMans2025MiniSector -> Float) -> MiniSectorData

--- a/package/src/Motorsport/Chart/Tracker/Config.elm
+++ b/package/src/Motorsport/Chart/Tracker/Config.elm
@@ -20,7 +20,7 @@ import Motorsport.Circuit.LeMans as LeMans exposing (LeMans2025MiniSector)
 import Motorsport.Duration exposing (Duration)
 import Motorsport.Lap exposing (MiniSectorProgress, SectorProgress)
 import Motorsport.Lap.Performance exposing (LeMans2025MiniSectorFastest)
-import Motorsport.Sector exposing (BySector, Sector(..))
+import Motorsport.Sector as Sector exposing (BySector, Sector(..))
 import Motorsport.ViewModel.Standings exposing (Entry)
 
 
@@ -52,9 +52,7 @@ buildConfig :
     Layout LeMans2025MiniSector
     ->
         { a
-            | fastestSector_1 : Duration
-            , fastestSector_2 : Duration
-            , fastestSector_3 : Duration
+            | fastestSectors : BySector Duration
             , fastestMiniSectors : LeMans2025MiniSectorFastest
         }
     -> TrackConfig
@@ -70,7 +68,9 @@ buildConfig layout bestTimes =
                     |> toFloat
 
             else
-                toFloat (bestTimes.fastestSector_1 + bestTimes.fastestSector_2 + bestTimes.fastestSector_3)
+                Sector.values bestTimes.fastestSectors
+                    |> List.sum
+                    |> toFloat
 
         miniRatio miniSector =
             let
@@ -111,7 +111,7 @@ buildConfig layout bestTimes =
 
 computeSectorShares :
     Layout LeMans2025MiniSector
-    -> { a | fastestSector_1 : Duration, fastestSector_2 : Duration, fastestSector_3 : Duration }
+    -> { a | fastestSectors : BySector Duration }
     -> Float
     -> (LeMans2025MiniSector -> Float)
     -> BySector Float
@@ -135,10 +135,10 @@ computeSectorShares layout bestTimes totalTime miniRatio =
                         |> List.map miniRatio
                         |> List.sum
     in
-    { s1 = sectorShare bestTimes.fastestSector_1 layout.s1
-    , s2 = sectorShare bestTimes.fastestSector_2 layout.s2
-    , s3 = sectorShare bestTimes.fastestSector_3 layout.s3
-    }
+    -- Circuit.Layout still spells its sectors out flat.
+    Sector.map2 sectorShare
+        bestTimes.fastestSectors
+        { s1 = layout.s1, s2 = layout.s2, s3 = layout.s3 }
 
 
 buildMiniSectors : List LeMans2025MiniSector -> Float -> (LeMans2025MiniSector -> Float) -> MiniSectorData

--- a/package/src/Motorsport/Circuit.elm
+++ b/package/src/Motorsport/Circuit.elm
@@ -16,6 +16,7 @@ module Motorsport.Circuit exposing
 
 import Motorsport.Circuit.LeMans as LeMans exposing (LeMans2025MiniSector)
 import Motorsport.Direction exposing (Direction(..))
+import Motorsport.Sector as Sector exposing (BySector)
 
 
 {-| Circuit information
@@ -29,12 +30,14 @@ type alias Circuit miniSector =
 {-| Circuit sector layout
 Generic layout type that can represent any circuit configuration
 The miniSector type parameter allows different circuits to use their specific mini sector types
+
+Which way the cars go round is a property of the circuit, not of any one sector,
+so it sits beside the sectors rather than among them.
+
 -}
 type alias Layout miniSector =
     { direction : Direction
-    , s1 : List miniSector
-    , s2 : List miniSector
-    , s3 : List miniSector
+    , sectors : BySector (List miniSector)
     }
 
 
@@ -43,9 +46,7 @@ type alias Layout miniSector =
 clockwise : Layout miniSector
 clockwise =
     { direction = Clockwise
-    , s1 = []
-    , s2 = []
-    , s3 = []
+    , sectors = Sector.initialize (always [])
     }
 
 
@@ -54,9 +55,7 @@ clockwise =
 counterClockwise : Layout miniSector
 counterClockwise =
     { direction = CounterClockwise
-    , s1 = []
-    , s2 = []
-    , s3 = []
+    , sectors = Sector.initialize (always [])
     }
 
 
@@ -70,8 +69,8 @@ leMans2025 =
 {-| Check if a layout contains mini sectors
 -}
 hasMiniSectors : Layout miniSector -> Bool
-hasMiniSectors { s1, s2, s3 } =
-    not (List.isEmpty s1) && not (List.isEmpty s2) && not (List.isEmpty s3)
+hasMiniSectors { sectors } =
+    Sector.values sectors |> List.all (List.isEmpty >> not)
 
 
 {-| Get the default ratio for a specific sector

--- a/package/src/Motorsport/Circuit/LeMans.elm
+++ b/package/src/Motorsport/Circuit/LeMans.elm
@@ -20,6 +20,7 @@ module Motorsport.Circuit.LeMans exposing
 
 import List.Extra
 import Motorsport.Direction exposing (Direction(..))
+import Motorsport.Sector as Sector exposing (BySector)
 
 
 {-| Le Mans 2025 specific mini sectors
@@ -155,16 +156,16 @@ values byMiniSector =
 {-| Le Mans 2025 layout (sectors with their mini sectors)
 -}
 layout :
-    { s1 : List LeMans2025MiniSector
-    , s2 : List LeMans2025MiniSector
-    , s3 : List LeMans2025MiniSector
-    , direction : Direction
+    { direction : Direction
+    , sectors : BySector (List LeMans2025MiniSector)
     }
 layout =
-    { s1 = [ SCL2, Z4, IP1 ]
-    , s2 = [ Z12, SCLC, A7_1, IP2 ]
-    , s3 = [ A8_1, SCLB, PORIN, POROUT, PITREF, SCL1, FORDOUT, FL ]
-    , direction = Clockwise
+    { direction = Clockwise
+    , sectors =
+        { s1 = [ SCL2, Z4, IP1 ]
+        , s2 = [ Z12, SCLC, A7_1, IP2 ]
+        , s3 = [ A8_1, SCLB, PORIN, POROUT, PITREF, SCL1, FORDOUT, FL ]
+        }
     }
 
 
@@ -172,7 +173,7 @@ layout =
 -}
 miniSectorOrder : List LeMans2025MiniSector
 miniSectorOrder =
-    layout.s1 ++ layout.s2 ++ layout.s3
+    Sector.values layout.sectors |> List.concat
 
 
 {-| Convert a mini sector to its string representation

--- a/package/src/Motorsport/Lap.elm
+++ b/package/src/Motorsport/Lap.elm
@@ -1,9 +1,10 @@
 module Motorsport.Lap exposing
     ( Lap, empty
+    , SectorTime, SectorTimes
     , MiniSectors, MiniSectorData
     , compareAt
     , completedLapsAt, findLastLapAt, findCurrentLap
-    , Segment, sectors, sectorStart
+    , Segment, segments, sectorStart
     , SectorProgress, progressAt, currentSector
     , MiniSectorProgress, currentMiniSector, miniSectorProgressAt
     )
@@ -11,6 +12,7 @@ module Motorsport.Lap exposing
 {-|
 
 @docs Lap, empty
+@docs SectorTime, SectorTimes
 @docs MiniSectors, MiniSectorData
 @docs compareAt
 @docs completedLapsAt, findLastLapAt, findCurrentLap
@@ -18,7 +20,7 @@ module Motorsport.Lap exposing
 
 ## Sectors as segments of the lap
 
-@docs Segment, sectors, sectorStart
+@docs Segment, segments, sectorStart
 
 
 ## Where the car is on the lap
@@ -42,16 +44,29 @@ type alias Lap =
     , position : Maybe Int
     , time : Duration
     , best : Duration
-    , sector_1 : Duration
-    , sector_2 : Duration
-    , sector_3 : Duration
-    , s1_best : Duration
-    , s2_best : Duration
-    , s3_best : Duration
+    , sectors : SectorTimes
     , elapsed : Duration
     , pitTime : Maybe Duration
     , miniSectors : Maybe MiniSectors
     }
+
+
+{-| How long one sector of this lap took, next to the driver's best for that
+sector up to and including this lap — the baseline a time is rated against.
+
+The two are kept together because nothing reads one without the other.
+
+-}
+type alias SectorTime =
+    { time : Duration
+    , personalBest : Duration
+    }
+
+
+{-| A lap's three sector times.
+-}
+type alias SectorTimes =
+    BySector SectorTime
 
 
 type alias MiniSectors =
@@ -72,12 +87,7 @@ empty =
     , lap = 0
     , position = Nothing
     , time = 0
-    , sector_1 = 0
-    , sector_2 = 0
-    , sector_3 = 0
-    , s1_best = 0
-    , s2_best = 0
-    , s3_best = 0
+    , sectors = Sector.initialize (always { time = 0, personalBest = 0 })
     , best = 0
     , elapsed = 0
     , pitTime = Nothing
@@ -215,15 +225,15 @@ end and duration, never the previous lap's, which may be missing or not
 adjacent.
 
 -}
-sectors : Lap -> BySector Segment
-sectors lap =
+segments : Lap -> BySector Segment
+segments lap =
     let
         start =
             lap.elapsed - lap.time
     in
-    { s1 = { start = start, time = lap.sector_1 }
-    , s2 = { start = start + lap.sector_1, time = lap.sector_2 }
-    , s3 = { start = start + lap.sector_1 + lap.sector_2, time = lap.sector_3 }
+    { s1 = { start = start, time = lap.sectors.s1.time }
+    , s2 = { start = start + lap.sectors.s1.time, time = lap.sectors.s2.time }
+    , s3 = { start = start + lap.sectors.s1.time + lap.sectors.s2.time, time = lap.sectors.s3.time }
     }
 
 
@@ -242,13 +252,13 @@ already over.
 currentSegment : Clock -> Lap -> ( Sector, Segment )
 currentSegment clock lap =
     let
-        segments =
-            sectors lap
+        lapSegments =
+            segments lap
     in
-    segments
+    lapSegments
         |> Sector.toList
         |> List.Extra.find (\( _, segment ) -> contains clock.elapsed segment)
-        |> Maybe.withDefault ( S3, segments.s3 )
+        |> Maybe.withDefault ( S3, lapSegments.s3 )
 
 
 currentSector : Clock -> Lap -> Sector
@@ -286,7 +296,7 @@ car is not in, or a lap it is not on.
 -}
 sectorStart : Sector -> Lap -> Duration
 sectorStart sector lap =
-    (Sector.get sector (sectors lap)).start
+    (Sector.get sector (segments lap)).start
 
 
 miniSectorOrder : List LeMans2025MiniSector

--- a/package/src/Motorsport/Lap/Performance.elm
+++ b/package/src/Motorsport/Lap/Performance.elm
@@ -1,6 +1,6 @@
 module Motorsport.Lap.Performance exposing
     ( findPersonalBest, findFastest, findFastestBy, findSlowest
-    , calculateMiniSectorFastest, LeMans2025MiniSectorFastest
+    , calculateMiniSectorFastest
     , RatedTime
     , PerformanceLevel(..), performanceLevel
     , isStandard
@@ -10,7 +10,7 @@ module Motorsport.Lap.Performance exposing
 {-|
 
 @docs findPersonalBest, findFastest, findFastestBy, findSlowest
-@docs calculateMiniSectorFastest, LeMans2025MiniSectorFastest
+@docs calculateMiniSectorFastest
 
 @docs RatedTime
 
@@ -99,14 +99,10 @@ toColorVariable level =
 
 
 
--- LeMans2025MiniSectorFastest
+-- FASTEST MINI SECTORS
 
 
-type alias LeMans2025MiniSectorFastest =
-    ByMiniSector Duration
-
-
-calculateMiniSectorFastest : List (List Lap) -> LeMans2025MiniSectorFastest
+calculateMiniSectorFastest : List (List Lap) -> ByMiniSector Duration
 calculateMiniSectorFastest laps =
     let
         validLaps =

--- a/package/src/Motorsport/Leaderboard.elm
+++ b/package/src/Motorsport/Leaderboard.elm
@@ -60,12 +60,12 @@ import Html.Styled.Attributes exposing (alt, css, src)
 import Html.Styled.Lazy as Lazy
 import Motorsport.Car as Car exposing (Status)
 import Motorsport.Chart.Histogram as Histogram
-import Motorsport.Circuit.LeMans as LeMans
+import Motorsport.Circuit.LeMans as LeMans exposing (ByMiniSector)
 import Motorsport.Class as Class exposing (Class)
 import Motorsport.Driver as Driver exposing (Driver)
 import Motorsport.Duration as Duration exposing (Duration)
 import Motorsport.Lap exposing (Lap, MiniSectorProgress, MiniSectors, SectorProgress)
-import Motorsport.Lap.Performance as Performance exposing (LeMans2025MiniSectorFastest, RatedTime, performanceLevel)
+import Motorsport.Lap.Performance as Performance exposing (RatedTime, performanceLevel)
 import Motorsport.Manufacturer as Manufacturer exposing (Manufacturer)
 import Motorsport.Sector as Sector
 import Motorsport.Utils exposing (compareBy)
@@ -441,7 +441,7 @@ currentLapColumn_LeMans24h :
                 , miniSector : Maybe MiniSectorProgress
             }
     , sorter : data -> data -> Order
-    , bestTimes : { b | fastestLapTime : Duration, fastestMiniSectors : LeMans2025MiniSectorFastest }
+    , bestTimes : { b | fastestLapTime : Duration, fastestMiniSectors : ByMiniSector Duration }
     }
     -> Column data msg
 currentLapColumn_LeMans24h { getter, sorter, bestTimes } =
@@ -453,7 +453,7 @@ currentLapColumn_LeMans24h { getter, sorter, bestTimes } =
 
 
 viewCurrentLapColumn_LeMans24h :
-    { b | fastestLapTime : Duration, fastestMiniSectors : LeMans2025MiniSectorFastest }
+    { b | fastestLapTime : Duration, fastestMiniSectors : ByMiniSector Duration }
     ->
         { a
             | status : Status

--- a/package/src/Motorsport/Sector.elm
+++ b/package/src/Motorsport/Sector.elm
@@ -159,6 +159,12 @@ get sector bySector =
 
 {-| Combine two sets of per-sector values sector by sector — a time with the
 fastest time to rate it against, a progress with its rating.
+
+Pairing is by sector, never by position, so the two sets cannot be misaligned.
+
+    map2 (++) (initialize toString) (initialize toString)
+    --> { s1 = "S1S1", s2 = "S2S2", s3 = "S3S3" }
+
 -}
 map2 : (a -> b -> c) -> BySector a -> BySector b -> BySector c
 map2 f a b =

--- a/package/src/Motorsport/Sector.elm
+++ b/package/src/Motorsport/Sector.elm
@@ -104,9 +104,11 @@ toString sector =
 {-| Three values, one per sector — a sector time, a progress percentage, a
 fastest time to compare against.
 
-Source records spell this out flat (`sector_1`, `sector_2`, `sector_3`), which
-leaves callers writing the same three-way `case` to pick one out. Convert once
-at the boundary and the picking becomes [`get`](#get).
+The wire formats spell this out flat (`sector_1`, `sector_2`, `sector_3`), which
+would leave callers writing the same three-way `case` to pick one out. Converting
+once at the boundary — `Data.Wec.Laps.accumulate` and
+`Motorsport.TimelineEvent.lapDecoder`, the two places a `Lap` is built — makes
+the picking [`get`](#get) everywhere after.
 
 A transparent record, not an opaque type: there is no invariant to protect, and
 an opaque type would be built from three positional arguments of the same type

--- a/package/src/Motorsport/TimelineEvent.elm
+++ b/package/src/Motorsport/TimelineEvent.elm
@@ -14,12 +14,12 @@ module Motorsport.TimelineEvent exposing
 
 import Json.Decode as Decode exposing (Decoder, field, int, string)
 import Json.Decode.Extra
-import Json.Decode.Pipeline exposing (optional, required)
+import Json.Decode.Pipeline exposing (custom, optional, required)
 import List.Extra
 import Motorsport.Car exposing (Car, CarNumber)
 import Motorsport.Driver as Driver
 import Motorsport.Duration as Duration exposing (Duration)
-import Motorsport.Lap exposing (Lap)
+import Motorsport.Lap as Lap exposing (Lap)
 
 
 type alias TimelineEvent =
@@ -247,15 +247,27 @@ lapDecoder =
         |> required "position" (Decode.maybe int)
         |> required "time" durationDecoder
         |> required "best" durationDecoder
-        |> required "sector_1" durationDecoder
-        |> required "sector_2" durationDecoder
-        |> required "sector_3" durationDecoder
-        |> required "s1_best" durationDecoder
-        |> required "s2_best" durationDecoder
-        |> required "s3_best" durationDecoder
+        |> custom sectorsDecoder
         |> required "elapsed" durationDecoder
         |> optional "pit_time" (Decode.maybe durationDecoder) Nothing
         |> optional "miniSectors" (Decode.maybe miniSectorsDecoder) Nothing
+
+
+{-| The wire format still spells the sectors out flat, and pairs each time with
+its best under a differently shaped key. This is where that stops.
+-}
+sectorsDecoder : Decoder Lap.SectorTimes
+sectorsDecoder =
+    let
+        sectorTime timeKey bestKey =
+            Decode.map2 (\time personalBest -> { time = time, personalBest = personalBest })
+                (field timeKey durationDecoder)
+                (field bestKey durationDecoder)
+    in
+    Decode.map3 (\s1 s2 s3 -> { s1 = s1, s2 = s2, s3 = s3 })
+        (sectorTime "sector_1" "s1_best")
+        (sectorTime "sector_2" "s2_best")
+        (sectorTime "sector_3" "s3_best")
 
 
 type alias MiniSectors =

--- a/package/src/Motorsport/ViewModel/BestTimes.elm
+++ b/package/src/Motorsport/ViewModel/BestTimes.elm
@@ -14,14 +14,13 @@ import Motorsport.Duration exposing (Duration)
 import Motorsport.Lap exposing (completedLapsAt)
 import Motorsport.Lap.Performance exposing (LeMans2025MiniSectorFastest, calculateMiniSectorFastest, findFastest, findFastestBy, findSlowest)
 import Motorsport.RunningOrder as RunningOrder exposing (RunningOrder)
+import Motorsport.Sector as Sector exposing (BySector)
 
 
 type alias BestTimes =
     { fastestLapTime : Duration
     , slowestLapTime : Duration
-    , fastestSector_1 : Duration
-    , fastestSector_2 : Duration
-    , fastestSector_3 : Duration
+    , fastestSectors : BySector Duration
     , fastestMiniSectors : LeMans2025MiniSectorFastest
     }
 
@@ -56,8 +55,12 @@ compute scope { clock, cars } =
     in
     { fastestLapTime = lapsByCar |> findFastest |> Maybe.map .time |> Maybe.withDefault 0
     , slowestLapTime = lapsByCar |> findSlowest |> Maybe.map .time |> Maybe.withDefault 0
-    , fastestSector_1 = lapsByCar |> findFastestBy (.sectors >> .s1 >> .time) |> Maybe.withDefault 0
-    , fastestSector_2 = lapsByCar |> findFastestBy (.sectors >> .s2 >> .time) |> Maybe.withDefault 0
-    , fastestSector_3 = lapsByCar |> findFastestBy (.sectors >> .s3 >> .time) |> Maybe.withDefault 0
+    , fastestSectors =
+        Sector.initialize
+            (\sector ->
+                lapsByCar
+                    |> findFastestBy (.sectors >> Sector.get sector >> .time)
+                    |> Maybe.withDefault 0
+            )
     , fastestMiniSectors = calculateMiniSectorFastest lapsByCar
     }

--- a/package/src/Motorsport/ViewModel/BestTimes.elm
+++ b/package/src/Motorsport/ViewModel/BestTimes.elm
@@ -9,10 +9,11 @@ individual times. Built by scanning the domain model (RunningOrder).
 
 -}
 
+import Motorsport.Circuit.LeMans exposing (ByMiniSector)
 import Motorsport.Clock as Clock
 import Motorsport.Duration exposing (Duration)
 import Motorsport.Lap exposing (completedLapsAt)
-import Motorsport.Lap.Performance exposing (LeMans2025MiniSectorFastest, calculateMiniSectorFastest, findFastest, findFastestBy, findSlowest)
+import Motorsport.Lap.Performance exposing (calculateMiniSectorFastest, findFastest, findFastestBy, findSlowest)
 import Motorsport.RunningOrder as RunningOrder exposing (RunningOrder)
 import Motorsport.Sector as Sector exposing (BySector)
 
@@ -21,7 +22,7 @@ type alias BestTimes =
     { fastestLapTime : Duration
     , slowestLapTime : Duration
     , fastestSectors : BySector Duration
-    , fastestMiniSectors : LeMans2025MiniSectorFastest
+    , fastestMiniSectors : ByMiniSector Duration
     }
 
 

--- a/package/src/Motorsport/ViewModel/BestTimes.elm
+++ b/package/src/Motorsport/ViewModel/BestTimes.elm
@@ -56,8 +56,8 @@ compute scope { clock, cars } =
     in
     { fastestLapTime = lapsByCar |> findFastest |> Maybe.map .time |> Maybe.withDefault 0
     , slowestLapTime = lapsByCar |> findSlowest |> Maybe.map .time |> Maybe.withDefault 0
-    , fastestSector_1 = lapsByCar |> findFastestBy .sector_1 |> Maybe.withDefault 0
-    , fastestSector_2 = lapsByCar |> findFastestBy .sector_2 |> Maybe.withDefault 0
-    , fastestSector_3 = lapsByCar |> findFastestBy .sector_3 |> Maybe.withDefault 0
+    , fastestSector_1 = lapsByCar |> findFastestBy (.sectors >> .s1 >> .time) |> Maybe.withDefault 0
+    , fastestSector_2 = lapsByCar |> findFastestBy (.sectors >> .s2 >> .time) |> Maybe.withDefault 0
+    , fastestSector_3 = lapsByCar |> findFastestBy (.sectors >> .s3 >> .time) |> Maybe.withDefault 0
     , fastestMiniSectors = calculateMiniSectorFastest lapsByCar
     }

--- a/package/src/Motorsport/ViewModel/Standings.elm
+++ b/package/src/Motorsport/ViewModel/Standings.elm
@@ -1,6 +1,6 @@
 module Motorsport.ViewModel.Standings exposing
     ( Standings, Entry, ClassInfo
-    , SectorTimes, CurrentSectorStates
+    , CurrentSectorStates
     , SectorPerformance, MiniSectorPerformance
     , compute, fromLaps, fromList
     , toList, toClassList, leader, lapCount, elapsed
@@ -11,7 +11,7 @@ module Motorsport.ViewModel.Standings exposing
 {-|
 
 @docs Standings, Entry, ClassInfo
-@docs SectorTimes, CurrentSectorStates
+@docs CurrentSectorStates
 @docs SectorPerformance, MiniSectorPerformance
 @docs compute, fromLaps, fromList
 
@@ -68,13 +68,6 @@ type alias ClassInfo =
     }
 
 
-{-| A lap's three sector times, each with that driver's best for the sector to
-rate it against.
--}
-type alias SectorTimes =
-    Lap.SectorTimes
-
-
 type alias SectorPerformance =
     BySector RatedTime
 
@@ -97,7 +90,7 @@ type alias Entry =
 
     -- currentLapSectors holds raw times (for data display such as the Debug page).
     -- currentLapSectorStates is the single source of truth for progress and performance rating.
-    , currentLapSectors : Maybe SectorTimes
+    , currentLapSectors : Maybe Lap.SectorTimes
     , currentLapSectorStates : Maybe CurrentSectorStates
     , currentLapMiniSectors : Maybe MiniSectors
     , currentLapElapsed : Duration

--- a/package/src/Motorsport/ViewModel/Standings.elm
+++ b/package/src/Motorsport/ViewModel/Standings.elm
@@ -125,9 +125,7 @@ type alias CurrentSectorStates =
 compute :
     { a
         | fastestLapTime : Duration
-        , fastestSector_1 : Duration
-        , fastestSector_2 : Duration
-        , fastestSector_3 : Duration
+        , fastestSectors : BySector Duration
         , fastestMiniSectors : LeMans2025MiniSectorFastest
     }
     -> { elapsed : Duration, lapCount : Int, cars : RunningOrder }
@@ -230,9 +228,13 @@ fromLaps baseMetadata laps =
     let
         bestTimes =
             { fastestLapTime = laps |> List.map .time |> List.filter ((/=) 0) |> List.minimum |> Maybe.withDefault 0
-            , fastestSector_1 = [ laps ] |> findFastestBy (.sectors >> .s1 >> .time) |> Maybe.withDefault 0
-            , fastestSector_2 = [ laps ] |> findFastestBy (.sectors >> .s2 >> .time) |> Maybe.withDefault 0
-            , fastestSector_3 = [ laps ] |> findFastestBy (.sectors >> .s3 >> .time) |> Maybe.withDefault 0
+            , fastestSectors =
+                Sector.initialize
+                    (\sector ->
+                        [ laps ]
+                            |> findFastestBy (.sectors >> Sector.get sector >> .time)
+                            |> Maybe.withDefault 0
+                    )
             , fastestMiniSectors = calculateMiniSectorFastest [ laps ]
             }
 
@@ -320,7 +322,7 @@ rateTime fastest { time, personalBest } =
 
 
 extractCurrentSectorStates :
-    { a | fastestSector_1 : Duration, fastestSector_2 : Duration, fastestSector_3 : Duration }
+    { a | fastestSectors : BySector Duration }
     -> Maybe Lap.SectorProgress
     -> Lap
     -> CurrentSectorStates
@@ -350,24 +352,11 @@ extractCurrentSectorStates bestTimes sectorProgress lap =
 
 
 extractSectorPerformance :
-    { a | fastestSector_1 : Duration, fastestSector_2 : Duration, fastestSector_3 : Duration }
+    { a | fastestSectors : BySector Duration }
     -> Lap
     -> SectorPerformance
 extractSectorPerformance bestTimes lap =
-    Sector.map2 rateTime (fastestBySector bestTimes) lap.sectors
-
-
-{-| Turns the best-times record's flat `fastestSector_1` / `_2` / `_3` into
-per-sector values; `extractSectorTimes` does the same for a lap.
--}
-fastestBySector :
-    { a | fastestSector_1 : Duration, fastestSector_2 : Duration, fastestSector_3 : Duration }
-    -> BySector Duration
-fastestBySector bestTimes =
-    { s1 = bestTimes.fastestSector_1
-    , s2 = bestTimes.fastestSector_2
-    , s3 = bestTimes.fastestSector_3
-    }
+    Sector.map2 rateTime bestTimes.fastestSectors lap.sectors
 
 
 extractMiniSectorPerformance :

--- a/package/src/Motorsport/ViewModel/Standings.elm
+++ b/package/src/Motorsport/ViewModel/Standings.elm
@@ -72,7 +72,7 @@ type alias ClassInfo =
 rate it against.
 -}
 type alias SectorTimes =
-    BySector { time : Duration, personalBest : Duration }
+    Lap.SectorTimes
 
 
 type alias SectorPerformance =
@@ -182,7 +182,7 @@ compute bestTimes config =
                         , lapsCompleted = lastLap.lap
                         , currentLapTime = currentLap |> Maybe.map .time
                         , currentLapBest = currentLap |> Maybe.map .best
-                        , currentLapSectors = currentLap |> Maybe.map extractSectorTimes
+                        , currentLapSectors = currentLap |> Maybe.map .sectors
                         , currentLapSectorStates = currentLap |> Maybe.map (extractCurrentSectorStates bestTimes timing.sector)
                         , currentLapMiniSectors = currentLap |> Maybe.andThen .miniSectors
                         , currentLapElapsed = timing.currentLapElapsed
@@ -230,9 +230,9 @@ fromLaps baseMetadata laps =
     let
         bestTimes =
             { fastestLapTime = laps |> List.map .time |> List.filter ((/=) 0) |> List.minimum |> Maybe.withDefault 0
-            , fastestSector_1 = [ laps ] |> findFastestBy .sector_1 |> Maybe.withDefault 0
-            , fastestSector_2 = [ laps ] |> findFastestBy .sector_2 |> Maybe.withDefault 0
-            , fastestSector_3 = [ laps ] |> findFastestBy .sector_3 |> Maybe.withDefault 0
+            , fastestSector_1 = [ laps ] |> findFastestBy (.sectors >> .s1 >> .time) |> Maybe.withDefault 0
+            , fastestSector_2 = [ laps ] |> findFastestBy (.sectors >> .s2 >> .time) |> Maybe.withDefault 0
+            , fastestSector_3 = [ laps ] |> findFastestBy (.sectors >> .s3 >> .time) |> Maybe.withDefault 0
             , fastestMiniSectors = calculateMiniSectorFastest [ laps ]
             }
 
@@ -248,7 +248,7 @@ fromLaps baseMetadata laps =
                         , lapsCompleted = lap.lap
                         , currentLapTime = Just lap.time
                         , currentLapBest = Just lap.best
-                        , currentLapSectors = Just (extractSectorTimes lap)
+                        , currentLapSectors = Just lap.sectors
                         , currentLapSectorStates = Just (extractCurrentSectorStates bestTimes Nothing lap)
                         , currentLapMiniSectors = lap.miniSectors
                         , currentLapElapsed = 0
@@ -319,14 +319,6 @@ rateTime fastest { time, personalBest } =
     }
 
 
-extractSectorTimes : Lap -> SectorTimes
-extractSectorTimes lap =
-    { s1 = { time = lap.sector_1, personalBest = lap.s1_best }
-    , s2 = { time = lap.sector_2, personalBest = lap.s2_best }
-    , s3 = { time = lap.sector_3, personalBest = lap.s3_best }
-    }
-
-
 extractCurrentSectorStates :
     { a | fastestSector_1 : Duration, fastestSector_2 : Duration, fastestSector_3 : Duration }
     -> Maybe Lap.SectorProgress
@@ -362,7 +354,7 @@ extractSectorPerformance :
     -> Lap
     -> SectorPerformance
 extractSectorPerformance bestTimes lap =
-    Sector.map2 rateTime (fastestBySector bestTimes) (extractSectorTimes lap)
+    Sector.map2 rateTime (fastestBySector bestTimes) lap.sectors
 
 
 {-| Turns the best-times record's flat `fastestSector_1` / `_2` / `_3` into

--- a/package/src/Motorsport/ViewModel/Standings.elm
+++ b/package/src/Motorsport/ViewModel/Standings.elm
@@ -32,7 +32,7 @@ import Motorsport.Driver exposing (Driver)
 import Motorsport.Duration exposing (Duration)
 import Motorsport.Gap as Gap exposing (Gap)
 import Motorsport.Lap as Lap exposing (Lap, MiniSectors)
-import Motorsport.Lap.Performance exposing (LeMans2025MiniSectorFastest, RatedTime, calculateMiniSectorFastest, findFastestBy, performanceLevel)
+import Motorsport.Lap.Performance exposing (RatedTime, calculateMiniSectorFastest, findFastestBy, performanceLevel)
 import Motorsport.Ordering as Ordering exposing (ByPosition)
 import Motorsport.RunningOrder as RunningOrder exposing (RunningOrder)
 import Motorsport.Sector as Sector exposing (BySector)
@@ -126,7 +126,7 @@ compute :
     { a
         | fastestLapTime : Duration
         , fastestSectors : BySector Duration
-        , fastestMiniSectors : LeMans2025MiniSectorFastest
+        , fastestMiniSectors : ByMiniSector Duration
     }
     -> { elapsed : Duration, lapCount : Int, cars : RunningOrder }
     -> Standings
@@ -360,7 +360,7 @@ extractSectorPerformance bestTimes lap =
 
 
 extractMiniSectorPerformance :
-    { a | fastestMiniSectors : LeMans2025MiniSectorFastest }
+    { a | fastestMiniSectors : ByMiniSector Duration }
     -> Lap
     -> Maybe MiniSectorPerformance
 extractMiniSectorPerformance bestTimes lap =

--- a/package/tests/Motorsport/GapTest.elm
+++ b/package/tests/Motorsport/GapTest.elm
@@ -55,9 +55,11 @@ lap lapNumber =
         | lap = lapNumber
         , time = 10000
         , elapsed = lapNumber * 10000
-        , sector_1 = 2000
-        , sector_2 = 3000
-        , sector_3 = 5000
+        , sectors =
+            { s1 = { time = 2000, personalBest = 0 }
+            , s2 = { time = 3000, personalBest = 0 }
+            , s3 = { time = 5000, personalBest = 0 }
+            }
     }
 
 

--- a/package/tests/Motorsport/LapTest.elm
+++ b/package/tests/Motorsport/LapTest.elm
@@ -13,9 +13,11 @@ lap =
     { empty
         | time = 6000
         , elapsed = 10000
-        , sector_1 = 1000
-        , sector_2 = 2000
-        , sector_3 = 3000
+        , sectors =
+            { s1 = { time = 1000, personalBest = 0 }
+            , s2 = { time = 2000, personalBest = 0 }
+            , s3 = { time = 3000, personalBest = 0 }
+            }
     }
 
 
@@ -27,20 +29,20 @@ empty =
 tests : Test
 tests =
     describe "Motorsport.Lap"
-        [ describe "sectors"
+        [ describe "segments"
             [ test "starts each sector where the one before it ended" <|
                 \_ ->
-                    Lap.sectors lap
+                    Lap.segments lap
                         |> Sector.values
                         |> List.map .start
                         |> Expect.equal [ 4000, 5000, 7000 ]
             , test "measures the first sector from the start of the lap, not the previous lap record" <|
                 \_ ->
-                    (Lap.sectors lap).s1.start
+                    (Lap.segments lap).s1.start
                         |> Expect.equal (lap.elapsed - lap.time)
             , test "ends the last sector where the lap ended" <|
                 \_ ->
-                    (Lap.sectors lap).s3
+                    (Lap.segments lap).s3
                         |> (\segment -> segment.start + segment.time)
                         |> Expect.equal lap.elapsed
             ]

--- a/package/tests/Motorsport/ViewModel/BestTimesTest.elm
+++ b/package/tests/Motorsport/ViewModel/BestTimesTest.elm
@@ -1,0 +1,133 @@
+module Motorsport.ViewModel.BestTimesTest exposing (tests)
+
+import Expect
+import Motorsport.Car as Car exposing (Car, Status(..))
+import Motorsport.Class as Class
+import Motorsport.Clock as Clock
+import Motorsport.Driver as Driver
+import Motorsport.Duration exposing (Duration)
+import Motorsport.Lap as Lap exposing (Lap)
+import Motorsport.Manufacturer as Manufacturer
+import Motorsport.RunningOrder as RunningOrder exposing (RunningOrder)
+import Motorsport.Sector as Sector
+import Motorsport.ViewModel.BestTimes as BestTimes exposing (Scope(..))
+import Test exposing (Test, describe, test)
+import Time exposing (millisToPosix)
+
+
+tests : Test
+tests =
+    describe "Motorsport.ViewModel.BestTimes"
+        [ describe "fastestSectors"
+            [ test "takes each sector from whichever car was quickest through it" <|
+                \_ ->
+                    -- No car holds all three: car 1 owns S1, car 2 owns S2 and S3.
+                    [ car "1" [ lap 1 6000 ( 1000, 2000, 3000 ) ]
+                    , car "2" [ lap 1 6000 ( 1100, 1900, 2900 ) ]
+                    ]
+                        |> fastestSectors WholeRace
+                        |> Expect.equal (Just [ 1000, 1900, 2900 ])
+            , test "ignores a sector with no recorded time rather than calling it the quickest" <|
+                \_ ->
+                    [ car "1" [ lap 1 6000 ( 1000, 2000, 3000 ) ]
+                    , car "2" [ lap 1 6000 ( 0, 0, 0 ) ]
+                    ]
+                        |> fastestSectors WholeRace
+                        |> Expect.equal (Just [ 1000, 2000, 3000 ])
+            ]
+        , describe "Scope"
+            [ test "UpToElapsed ignores laps the clock has not reached yet" <|
+                \_ ->
+                    -- The quicker lap ends at 12.000, after the clock at 6.000.
+                    [ car "1"
+                        [ lap 1 6000 ( 1000, 2000, 3000 )
+                        , lap 2 6000 ( 900, 1900, 2900 )
+                        ]
+                    ]
+                        |> fastestSectorsAt 6000 UpToElapsed
+                        |> Expect.equal (Just [ 1000, 2000, 3000 ])
+            , test "WholeRace counts every lap, whatever the clock says" <|
+                \_ ->
+                    [ car "1"
+                        [ lap 1 6000 ( 1000, 2000, 3000 )
+                        , lap 2 6000 ( 900, 1900, 2900 )
+                        ]
+                    ]
+                        |> fastestSectorsAt 6000 WholeRace
+                        |> Expect.equal (Just [ 900, 1900, 2900 ])
+            ]
+        ]
+
+
+
+-- HELPERS
+
+
+{-| The three fastest sector times in sector order, or `Nothing` if the cars
+could not be put into a running order.
+-}
+fastestSectors : Scope -> List Car -> Maybe (List Duration)
+fastestSectors =
+    fastestSectorsAt 0
+
+
+fastestSectorsAt : Duration -> Scope -> List Car -> Maybe (List Duration)
+fastestSectorsAt elapsed scope cars =
+    runningOrder cars
+        |> Maybe.map
+            (\order ->
+                BestTimes.compute scope { clock = clockAt elapsed, cars = order }
+                    |> .fastestSectors
+                    |> Sector.values
+            )
+
+
+runningOrder : List Car -> Maybe RunningOrder
+runningOrder =
+    RunningOrder.fromList { elapsed = 0 }
+
+
+clockAt : Duration -> Clock.Model
+clockAt elapsed =
+    Clock.update (millisToPosix 0) (Clock.Set elapsed) Clock.init
+
+
+{-| A lap of `time`, split into the three given sector times, running from the
+end of the previous lap of the same length.
+-}
+lap : Int -> Duration -> ( Duration, Duration, Duration ) -> Lap
+lap lapNumber time ( s1, s2, s3 ) =
+    { empty
+        | lap = lapNumber
+        , time = time
+        , elapsed = lapNumber * time
+        , sectors =
+            { s1 = { time = s1, personalBest = s1 }
+            , s2 = { time = s2, personalBest = s2 }
+            , s3 = { time = s3, personalBest = s3 }
+            }
+    }
+
+
+empty : Lap
+empty =
+    Lap.empty
+
+
+car : Car.CarNumber -> List Lap -> Car
+car carNumber laps =
+    { metadata =
+        { carNumber = carNumber
+        , class = Class.none
+        , group = "Test Group"
+        , team = "Test Team"
+        , drivers = [ Driver.fromName "Test Driver" ]
+        , manufacturer = Manufacturer.Other
+        }
+    , startPosition = 0
+    , laps = laps
+    , currentLap = List.head laps
+    , lastLap = List.head (List.reverse laps)
+    , status = Racing
+    , currentDriver = Nothing
+    }

--- a/package/tests/Motorsport/ViewModel/StandingsTest.elm
+++ b/package/tests/Motorsport/ViewModel/StandingsTest.elm
@@ -137,12 +137,11 @@ sectorFixtureLap =
         | lap = 1
         , time = 6000
         , elapsed = 6000
-        , sector_1 = 1000
-        , sector_2 = 2000
-        , sector_3 = 3000
-        , s1_best = 900
-        , s2_best = 1900
-        , s3_best = 2900
+        , sectors =
+            { s1 = { time = 1000, personalBest = 900 }
+            , s2 = { time = 2000, personalBest = 1900 }
+            , s3 = { time = 3000, personalBest = 2900 }
+            }
     }
 
 


### PR DESCRIPTION
`4196d13` added `Motorsport.Sector`, whose docstring said to convert the flat `sector_1` / `sector_2` / `sector_3` triples once at the boundary so that picking one out becomes `get`. That never reached the domain model: `Lap` kept all six flat fields, three adapters stood in for the single boundary, the same three-field signature was copied into four modules, and `Page/Debug` still held the three-way `case`.

This moves the conversion to the boundary and deletes what stood in for it.

| Commit | |
| --- | --- |
| `32294d0` | `Lap` holds `sectors : BySector SectorTime` |
| `305bf0b` | `BestTimes` holds `fastestSectors : BySector Duration`; adds the module's first tests |
| `d7edbdc` | `Circuit.Layout` holds `sectors : BySector (List miniSector)`; `direction` moves out from among the sectors |
| `882e9c3` | Doctest for `Sector.map2` |
| `ba8bf31` | Drops `LeMans2025MiniSectorFastest`, an alias for `ByMiniSector Duration` |
| `3c13a2a` | Drops `Standings.SectorTimes`, an alias for `Lap.SectorTimes` |

`extractSectorTimes`, `fastestBySector`, the reshape in `Tracker.Config`, four copies of the three-field signature, and the `case` in `Page/Debug` are all gone; `extractSectorPerformance` is now `Sector.map2 rateTime bestTimes.fastestSectors lap.sectors`. `case sector of` no longer appears outside `Sector.elm`, and the remaining flat triples are all at a wire boundary.