### PR TITLE
Introduce Instant type to distinguish moments from durations

### DIFF
--- a/app/src/Data/Wec/Laps.elm
+++ b/app/src/Data/Wec/Laps.elm
@@ -19,6 +19,7 @@ import Json.Decode.Pipeline exposing (required)
 import List.Extra
 import Motorsport.Driver as Driver
 import Motorsport.Duration as Duration exposing (Duration)
+import Motorsport.Instant as Instant exposing (Instant)
 import Motorsport.Lap exposing (Lap)
 import Motorsport.Race.Car exposing (Car, CarNumber)
 import Motorsport.Sector as Sector exposing (BySector)
@@ -32,7 +33,7 @@ type alias RawLap =
     , s1 : Maybe Duration
     , s2 : Maybe Duration
     , s3 : Maybe Duration
-    , elapsed : Duration
+    , elapsed : Instant
     , pitTime : Maybe Duration
     }
 
@@ -56,7 +57,7 @@ rawLapDecoder =
         |> required "s1" optionalDurationDecoder
         |> required "s2" optionalDurationDecoder
         |> required "s3" optionalDurationDecoder
-        |> required "elapsed" durationDecoder
+        |> required "elapsed" Instant.decoder
         |> required "pitTime" optionalDurationDecoder
 
 
@@ -229,7 +230,7 @@ assignPositionsForLap lapNum cars =
                 |> List.indexedMap
                     (\idx car ->
                         List.Extra.find (\l -> l.lap == lapNum) car.laps
-                            |> Maybe.map (\lap -> ( idx, lap.elapsed ))
+                            |> Maybe.map (\lap -> ( idx, Instant.toDuration lap.elapsed ))
                     )
                 |> List.filterMap identity
                 |> List.sortBy Tuple.second

--- a/app/src/Data/Wec/Laps.elm
+++ b/app/src/Data/Wec/Laps.elm
@@ -20,7 +20,7 @@ import List.Extra
 import Motorsport.Driver as Driver
 import Motorsport.Duration as Duration exposing (Duration)
 import Motorsport.Instant as Instant exposing (Instant)
-import Motorsport.Lap exposing (Lap)
+import Motorsport.Lap as Lap exposing (Lap)
 import Motorsport.Race.Car exposing (Car, CarNumber)
 import Motorsport.Sector as Sector exposing (BySector)
 
@@ -172,7 +172,7 @@ accumulate raw ( bests, acc ) =
             { s1 = raw.s1, s2 = raw.s2, s3 = raw.s3 }
 
         newBests =
-            { lap = minMaybe bests.lap (Just raw.lapTime)
+            { lap = minMaybe bests.lap (Lap.recorded raw.lapTime)
             , sectors = Sector.map2 minMaybe bests.sectors rawSectors
             }
 
@@ -181,15 +181,15 @@ accumulate raw ( bests, acc ) =
             , driver = Driver.fromName raw.driverName
             , lap = raw.lapNumber
             , position = Nothing
-            , time = raw.lapTime
-            , best = newBests.lap |> Maybe.withDefault 0
+
+            -- The zero stops here: the CLI writes an unrecorded lap time out as
+            -- `0.000` either way, where a blank sector cell stays blank and has
+            -- already arrived as `Nothing`.
+            , time = Lap.recorded raw.lapTime
+            , best = newBests.lap
             , sectors =
                 Sector.map2
-                    (\time personalBest ->
-                        { time = time |> Maybe.withDefault 0
-                        , personalBest = personalBest |> Maybe.withDefault 0
-                        }
-                    )
+                    (\time personalBest -> { time = time, personalBest = personalBest })
                     rawSectors
                     newBests.sectors
             , elapsed = raw.elapsed

--- a/app/src/Page/Debug.elm
+++ b/app/src/Page/Debug.elm
@@ -18,6 +18,7 @@ import Motorsport.BestTimes as BestTimes
 import Motorsport.Class
 import Motorsport.Clock as Clock
 import Motorsport.Duration as Duration
+import Motorsport.Instant as Instant
 import Motorsport.Manufacturer
 import Motorsport.Replay as Replay
 import Motorsport.Sector as Sector
@@ -108,7 +109,7 @@ view { viewModel, replay } { leaderboardState } =
                     , basicLabel [ class "join-item" ] [ text (String.fromInt lapCount) ]
                     , button [ class "join-item", onClick (ReplayMsg Replay.NextLap) ] [ text "+" ]
                     ]
-                , text (Clock.getElapsed playback |> Duration.toString)
+                , text (Clock.getElapsed playback |> Instant.toString)
                 ]
             , div []
                 ([ div [] [ text "fastestLapTime: ", text (Duration.toString (BestTimes.timeOf viewModel.bestTimes.fastestLapTime)) ]

--- a/app/src/Page/Debug.elm
+++ b/app/src/Page/Debug.elm
@@ -19,7 +19,6 @@ import Motorsport.Class
 import Motorsport.Clock as Clock
 import Motorsport.Duration as Duration
 import Motorsport.Instant as Instant
-import Motorsport.Lap as Lap
 import Motorsport.Manufacturer
 import Motorsport.Replay as Replay
 import Motorsport.Sector as Sector
@@ -184,8 +183,8 @@ sectorColumns bestTimes =
                         times sector
                             >> Maybe.map
                                 (\{ time, personalBest } ->
-                                    { time = time
-                                    , personalBest = Lap.recorded personalBest
+                                    { time = Maybe.withDefault 0 time
+                                    , personalBest = personalBest
                                     , fastest = fastest sector
                                     , progress = 1
                                     }
@@ -193,8 +192,8 @@ sectorColumns bestTimes =
                     }
                 , customColumn
                     { label = Sector.toString sector ++ " Best"
-                    , getter = times sector >> Maybe.map (.personalBest >> Duration.toString) >> Maybe.withDefault ""
-                    , sorter = Compare.by (times sector >> Maybe.map .personalBest >> Maybe.withDefault 0)
+                    , getter = times sector >> Maybe.andThen .personalBest >> Maybe.map Duration.toString >> Maybe.withDefault ""
+                    , sorter = Compare.by (times sector >> Maybe.andThen .personalBest >> Maybe.withDefault 0)
                     }
                 ]
             )

--- a/app/src/Page/Debug.elm
+++ b/app/src/Page/Debug.elm
@@ -19,6 +19,7 @@ import Motorsport.Class
 import Motorsport.Clock as Clock
 import Motorsport.Duration as Duration
 import Motorsport.Instant as Instant
+import Motorsport.Lap as Lap
 import Motorsport.Manufacturer
 import Motorsport.Replay as Replay
 import Motorsport.Sector as Sector
@@ -112,15 +113,15 @@ view { viewModel, replay } { leaderboardState } =
                 , text (Clock.getElapsed playback |> Instant.toString)
                 ]
             , div []
-                ([ div [] [ text "fastestLapTime: ", text (Duration.toString (BestTimes.timeOf viewModel.bestTimes.fastestLapTime)) ]
-                 , div [] [ text "slowestLapTime: ", text (Duration.toString (BestTimes.timeOf viewModel.bestTimes.slowestLapTime)) ]
+                ([ div [] [ text "fastestLapTime: ", text (bestTimeText viewModel.bestTimes.fastestLapTime) ]
+                 , div [] [ text "slowestLapTime: ", text (bestTimeText viewModel.bestTimes.slowestLapTime) ]
                  ]
                     ++ (Sector.toList viewModel.bestTimes.fastestSectors
                             |> List.map
                                 (\( sector, fastest ) ->
                                     div []
                                         [ text (Sector.toString sector ++ "_fastest: ")
-                                        , text (Duration.toString (BestTimes.timeOf fastest))
+                                        , text (bestTimeText fastest)
                                         ]
                                 )
                        )
@@ -158,6 +159,13 @@ config bestTimes standings =
     }
 
 
+{-| A record no lap has set has no time to print.
+-}
+bestTimeText : Maybe BestTimes.Holder -> String
+bestTimeText =
+    BestTimes.timeOf >> Maybe.map Duration.toString >> Maybe.withDefault "-"
+
+
 sectorColumns : BestTimes.Snapshot -> List (DataView.Column Entry Msg)
 sectorColumns bestTimes =
     let
@@ -177,7 +185,7 @@ sectorColumns bestTimes =
                             >> Maybe.map
                                 (\{ time, personalBest } ->
                                     { time = time
-                                    , personalBest = personalBest
+                                    , personalBest = Lap.recorded personalBest
                                     , fastest = fastest sector
                                     , progress = 1
                                     }

--- a/app/src/View/PlaybackControls.elm
+++ b/app/src/View/PlaybackControls.elm
@@ -15,6 +15,7 @@ import Html.Styled.Attributes as Attributes exposing (type_, value)
 import Html.Styled.Events exposing (onClick, onInput)
 import Motorsport.Clock as Clock exposing (State(..))
 import Motorsport.Duration as Duration
+import Motorsport.Instant as Instant
 import Motorsport.Replay as Replay
 import String exposing (dropRight)
 
@@ -97,7 +98,7 @@ viewProgressBar toReplayMsg ({ playback, race } as replay) =
             Replay.lapCount replay
 
         remaining =
-            race.timeLimit - elapsed
+            Instant.since { from = elapsed, to = race.timeLimit }
     in
     div [ Attributes.class "flex flex-col gap-2 flex-1 min-w-0 text-xs font-medium tabular-nums opacity-70" ]
         [ div [ Attributes.class "flex justify-between" ]

--- a/app/src/View/RaceEvents.elm
+++ b/app/src/View/RaceEvents.elm
@@ -13,7 +13,7 @@ import Compare
 import DataView
 import Html.Styled as Html exposing (Html, div, text)
 import Motorsport.Clock as Clock
-import Motorsport.Duration as Duration
+import Motorsport.Instant as Instant
 import Motorsport.Race.TimelineEvent exposing (CarEventType(..), EventType(..), TimelineEvent)
 import Motorsport.Replay as Replay
 
@@ -27,7 +27,7 @@ view toMsg eventsState replay =
         -- The race builds its timeline in time order, and filtering keeps it.
         occurredEvents =
             replay.race.timelineEvents
-                |> List.filter (\event -> currentElapsed >= event.eventTime)
+                |> List.filter (\event -> Instant.compare event.eventTime currentElapsed /= GT)
     in
     div []
         [ Html.h2 [] [ text "Race Events" ]
@@ -37,13 +37,13 @@ view toMsg eventsState replay =
 
 config : (DataView.Msg -> msg) -> DataView.Config TimelineEvent msg
 config toMsg =
-    { toId = .eventTime >> Duration.toString
+    { toId = .eventTime >> Instant.toString
     , toMsg = toMsg
     , columns =
         [ DataView.customColumn
             { label = "Time"
-            , getter = .eventTime >> Duration.toString
-            , sorter = Compare.by .eventTime
+            , getter = .eventTime >> Instant.toString
+            , sorter = Compare.by (.eventTime >> Instant.toDuration)
             }
         , DataView.stringColumn
             { label = "Car"

--- a/cli/motorsport/src/duration.rs
+++ b/cli/motorsport/src/duration.rs
@@ -2,30 +2,61 @@ pub type Duration = u32;
 
 /// Duration文字列をミリ秒に変換
 /// 例: "1:35.365" -> 95365, "23.155" -> 23155
+///
+/// 各パートは数字の並びのみを受け付ける。`Duration` は `u32` なので符号は
+/// そもそも表現できず、以前は負値が `as u32` の飽和変換で無言のうちに 0 に
+/// なっていた。今は `None` を返し、呼び出し側（`stages::structure`）が警告を
+/// 出したうえで 0 にフォールバックする。
 pub fn from_string(s: &str) -> Option<Duration> {
     let parts: Vec<&str> = s.split(':').collect();
 
-    let convert_seconds = |s: &str| -> Option<u32> {
-        s.parse::<f64>()
-            .ok()
-            .map(|sec| (sec * 1000.0).round() as u32)
-    };
-
     match parts.as_slice() {
-        [h, m, s] => {
-            let hours = h.parse::<u32>().ok()?;
-            let minutes = m.parse::<u32>().ok()?;
-            let seconds = convert_seconds(s)?;
-            Some(hours * 3600000 + minutes * 60000 + seconds)
-        }
-        [m, s] => {
-            let minutes = m.parse::<u32>().ok()?;
-            let seconds = convert_seconds(s)?;
-            Some(minutes * 60000 + seconds)
-        }
-        [s] => convert_seconds(s),
+        [h, m, s] => Some(digits(h)? * 3600000 + digits(m)? * 60000 + from_seconds(s)?),
+        [m, s] => Some(digits(m)? * 60000 + from_seconds(s)?),
+        [s] => from_seconds(s),
         _ => None,
     }
+}
+
+/// 秒フィールド。整数部・小数部とも整数として読む。
+///
+/// 以前は `parse::<f64>()` してから `round()` で戻していた。ミリ秒は秒の二進
+/// 小数として正確に表せないので、読み取った値は書かれた桁そのものではなく、
+/// 丸めればたまたま元に戻る程度に近い値でしかなかった。
+fn from_seconds(s: &str) -> Option<Duration> {
+    match s.split('.').collect::<Vec<&str>>().as_slice() {
+        [whole] => Some(digits(whole)? * 1000),
+        [whole, fraction] => Some(digits(whole)? * 1000 + milliseconds(fraction)?),
+        _ => None,
+    }
+}
+
+/// 小数部をミリ秒に。4桁まで読んで3桁に四捨五入する。
+///
+/// `.5005` はちょうど 0.5 ミリ秒だが `f64` にすると半分をわずかに下回るため、
+/// 従来の丸めは切り下げ側に落ちていた。桁をそのまま整数として読めばずれない。
+/// 1秒に繰り上がる小数（`.9999` は 1000 ミリ秒）は呼び出し側が整数秒に足すので
+/// そのままでよい。
+fn milliseconds(fraction: &str) -> Option<Duration> {
+    if !fraction.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+
+    let mut padded: String = fraction.chars().take(4).collect();
+    while padded.len() < 4 {
+        padded.push('0');
+    }
+
+    let tenths_of_a_milli: u32 = padded.parse().ok()?;
+    Some((tenths_of_a_milli + 5) / 10)
+}
+
+/// 数字の並びで、それ以外を含まないもの。`parse::<u32>()` は `+` も受け付ける。
+fn digits(s: &str) -> Option<u32> {
+    if s.is_empty() || !s.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    s.parse().ok()
 }
 
 /// ミリ秒をDuration文字列に変換
@@ -89,9 +120,30 @@ mod tests {
         assert_eq!(from_string("invalid"), None);
         assert_eq!(from_string("1:2:3:4"), None);
         assert_eq!(from_string("abc:def"), None);
-        assert_eq!(from_string("-1.0"), Some(0));
+        // `Duration` が `u32` である以上、負の値は表現できない。以前は
+        // `as u32` の飽和変換で無言のうちに 0 になっていた。
+        assert_eq!(from_string("-1.0"), None);
+        assert_eq!(from_string("1e3"), None);
+        assert_eq!(from_string("1:-30.000"), None);
         assert_eq!(from_string("999:59.999"), Some(59999999));
         assert_eq!(to_string(59999999), "16:39:59.999");
+    }
+
+    #[test]
+    fn test_exact_half_millisecond_rounds_up() {
+        // 0.5005 秒はちょうど 500.5 ミリ秒だが、`f64` での最近傍は
+        // 500.49999999999994 なので `(sec * 1000.0).round()` は 500 を返していた。
+        assert_eq!(from_string("0.5005"), Some(501));
+        assert_eq!(from_string("0.50950"), Some(510));
+    }
+
+    #[test]
+    fn test_round_trips_with_to_string() {
+        // Elm 側 (`Motorsport.DurationTest`) の fuzz テストと同じ性質。
+        // レース時間の全域にわたって、書いたものがそのまま読み戻せること。
+        for ms in (0..100_000_000).step_by(997) {
+            assert_eq!(from_string(&to_string(ms)), Some(ms), "ms = {ms}");
+        }
     }
 
     #[test]

--- a/cli/motorsport/src/duration.rs
+++ b/cli/motorsport/src/duration.rs
@@ -2,61 +2,41 @@ pub type Duration = u32;
 
 /// Duration文字列をミリ秒に変換
 /// 例: "1:35.365" -> 95365, "23.155" -> 23155
-///
-/// 各パートは数字の並びのみを受け付ける。`Duration` は `u32` なので符号は
-/// そもそも表現できず、以前は負値が `as u32` の飽和変換で無言のうちに 0 に
-/// なっていた。今は `None` を返し、呼び出し側（`stages::structure`）が警告を
-/// 出したうえで 0 にフォールバックする。
 pub fn from_string(s: &str) -> Option<Duration> {
     let parts: Vec<&str> = s.split(':').collect();
 
+    // 桁として読む。`parse::<f64>()` はミリ秒を二進小数で正確に表せないので、
+    // 丸めて戻す必要があった。小数第3位までしか来ないため、小数部はそのまま
+    // ミリ秒。短ければ右をゼロ埋めし、長ければそこまでしか読まない。
+    let convert_seconds = |s: &str| -> Option<u32> {
+        match s.split('.').collect::<Vec<&str>>().as_slice() {
+            [whole, fraction] => {
+                let mut ms: String = fraction.chars().take(3).collect();
+                while ms.len() < 3 {
+                    ms.push('0');
+                }
+                Some(whole.parse::<u32>().ok()? * 1000 + ms.parse::<u32>().ok()?)
+            }
+            [whole] => Some(whole.parse::<u32>().ok()? * 1000),
+            _ => None,
+        }
+    };
+
     match parts.as_slice() {
-        [h, m, s] => Some(digits(h)? * 3600000 + digits(m)? * 60000 + from_seconds(s)?),
-        [m, s] => Some(digits(m)? * 60000 + from_seconds(s)?),
-        [s] => from_seconds(s),
+        [h, m, s] => {
+            let hours = h.parse::<u32>().ok()?;
+            let minutes = m.parse::<u32>().ok()?;
+            let seconds = convert_seconds(s)?;
+            Some(hours * 3600000 + minutes * 60000 + seconds)
+        }
+        [m, s] => {
+            let minutes = m.parse::<u32>().ok()?;
+            let seconds = convert_seconds(s)?;
+            Some(minutes * 60000 + seconds)
+        }
+        [s] => convert_seconds(s),
         _ => None,
     }
-}
-
-/// 秒フィールド。整数部・小数部とも整数として読む。
-///
-/// 以前は `parse::<f64>()` してから `round()` で戻していた。ミリ秒は秒の二進
-/// 小数として正確に表せないので、読み取った値は書かれた桁そのものではなく、
-/// 丸めればたまたま元に戻る程度に近い値でしかなかった。
-fn from_seconds(s: &str) -> Option<Duration> {
-    match s.split('.').collect::<Vec<&str>>().as_slice() {
-        [whole] => Some(digits(whole)? * 1000),
-        [whole, fraction] => Some(digits(whole)? * 1000 + milliseconds(fraction)?),
-        _ => None,
-    }
-}
-
-/// 小数部をミリ秒に。4桁まで読んで3桁に四捨五入する。
-///
-/// `.5005` はちょうど 0.5 ミリ秒だが `f64` にすると半分をわずかに下回るため、
-/// 従来の丸めは切り下げ側に落ちていた。桁をそのまま整数として読めばずれない。
-/// 1秒に繰り上がる小数（`.9999` は 1000 ミリ秒）は呼び出し側が整数秒に足すので
-/// そのままでよい。
-fn milliseconds(fraction: &str) -> Option<Duration> {
-    if !fraction.chars().all(|c| c.is_ascii_digit()) {
-        return None;
-    }
-
-    let mut padded: String = fraction.chars().take(4).collect();
-    while padded.len() < 4 {
-        padded.push('0');
-    }
-
-    let tenths_of_a_milli: u32 = padded.parse().ok()?;
-    Some((tenths_of_a_milli + 5) / 10)
-}
-
-/// 数字の並びで、それ以外を含まないもの。`parse::<u32>()` は `+` も受け付ける。
-fn digits(s: &str) -> Option<u32> {
-    if s.is_empty() || !s.chars().all(|c| c.is_ascii_digit()) {
-        return None;
-    }
-    s.parse().ok()
 }
 
 /// ミリ秒をDuration文字列に変換
@@ -120,30 +100,12 @@ mod tests {
         assert_eq!(from_string("invalid"), None);
         assert_eq!(from_string("1:2:3:4"), None);
         assert_eq!(from_string("abc:def"), None);
-        // `Duration` が `u32` である以上、負の値は表現できない。以前は
-        // `as u32` の飽和変換で無言のうちに 0 になっていた。
+        // `Duration` は `u32` なので符号は表現できない。以前は `as u32` の
+        // 飽和変換で無言のうちに 0 になっていた。呼び出し側
+        // (`stages::structure`) は警告を出したうえで 0 にフォールバックする。
         assert_eq!(from_string("-1.0"), None);
-        assert_eq!(from_string("1e3"), None);
-        assert_eq!(from_string("1:-30.000"), None);
         assert_eq!(from_string("999:59.999"), Some(59999999));
         assert_eq!(to_string(59999999), "16:39:59.999");
-    }
-
-    #[test]
-    fn test_exact_half_millisecond_rounds_up() {
-        // 0.5005 秒はちょうど 500.5 ミリ秒だが、`f64` での最近傍は
-        // 500.49999999999994 なので `(sec * 1000.0).round()` は 500 を返していた。
-        assert_eq!(from_string("0.5005"), Some(501));
-        assert_eq!(from_string("0.50950"), Some(510));
-    }
-
-    #[test]
-    fn test_round_trips_with_to_string() {
-        // Elm 側 (`Motorsport.DurationTest`) の fuzz テストと同じ性質。
-        // レース時間の全域にわたって、書いたものがそのまま読み戻せること。
-        for ms in (0..100_000_000).step_by(997) {
-            assert_eq!(from_string(&to_string(ms)), Some(ms), "ms = {ms}");
-        }
     }
 
     #[test]

--- a/package/src/Motorsport/BestTimes.elm
+++ b/package/src/Motorsport/BestTimes.elm
@@ -71,9 +71,9 @@ widget rates and scales individual times against, and the laps that set them.
 Read mid-race via [`at`](#at) these are only the best times *so far*; only
 [`final`](#final)'s answer is the race's actual best times.
 
-`Nothing` is a record no lap has taken yet. [`timeOf`](#timeOf) turns it into
-the zero the rest of the app reads as "not set"; keep this instead if you need
-to name the holder.
+`Nothing` is a record no lap has taken yet. [`timeOf`](#timeOf) reads it down
+to that same `Nothing`, for callers that only want the number; keep this
+instead if you need to name the holder.
 
 -}
 type alias Snapshot =

--- a/package/src/Motorsport/BestTimes.elm
+++ b/package/src/Motorsport/BestTimes.elm
@@ -31,6 +31,7 @@ dependency pointing one way from both.
 import Motorsport.Circuit.LeMans as LeMans exposing (ByMiniSector, LeMans2025MiniSector)
 import Motorsport.Driver exposing (Driver)
 import Motorsport.Duration exposing (Duration)
+import Motorsport.Instant as Instant exposing (Instant)
 import Motorsport.Internal.ChangePoints as ChangePoints exposing (ChangePoints)
 import Motorsport.Lap exposing (Lap)
 import Motorsport.Sector as Sector exposing (BySector, Sector)
@@ -124,7 +125,7 @@ fromLaps laps =
         -- In the order the laps were completed, which is the order the records
         -- were set in.
         inOrder =
-            List.sortBy .elapsed laps
+            List.sortBy (.elapsed >> Instant.toDuration) laps
     in
     map (\{ beats, timeFrom } -> improvements beats timeFrom inOrder) rules
 
@@ -132,7 +133,7 @@ fromLaps laps =
 {-| The records as they stood at a moment of the race: what a car crossing the
 line then was rated against.
 -}
-at : { elapsed : Duration } -> Changes -> Snapshot
+at : { elapsed : Instant } -> Changes -> Snapshot
 at clock =
     map (ChangePoints.valueAt clock.elapsed)
 

--- a/package/src/Motorsport/BestTimes.elm
+++ b/package/src/Motorsport/BestTimes.elm
@@ -33,7 +33,7 @@ import Motorsport.Driver exposing (Driver)
 import Motorsport.Duration exposing (Duration)
 import Motorsport.Instant as Instant exposing (Instant)
 import Motorsport.Internal.ChangePoints as ChangePoints exposing (ChangePoints)
-import Motorsport.Lap as Lap exposing (Lap)
+import Motorsport.Lap exposing (Lap)
 import Motorsport.Sector as Sector exposing (BySector, Sector)
 
 
@@ -175,12 +175,12 @@ type alias Rule =
 
 rules : ByRecord Rule
 rules =
-    { fastestLapTime = { beats = lessThan, timeFrom = recordedLapTime }
-    , slowestLapTime = { beats = greaterThan, timeFrom = lapTimeAsFound }
+    { fastestLapTime = { beats = lessThan, timeFrom = .time }
+    , slowestLapTime = { beats = greaterThan, timeFrom = .time }
     , fastestSectors =
-        Sector.initialize (\sector -> { beats = lessThan, timeFrom = recordedSectorTime sector })
+        Sector.initialize (\sector -> { beats = lessThan, timeFrom = sectorTime sector })
     , fastestMiniSectors =
-        LeMans.initialize (\mini -> { beats = lessThan, timeFrom = recordedMiniSectorTime mini })
+        LeMans.initialize (\mini -> { beats = lessThan, timeFrom = miniSectorTime mini })
     }
 
 
@@ -251,40 +251,25 @@ greaterThan a b =
 
 
 -- WHAT COUNTS AS A TIME
--- A zero is a time the source data did not record, not a very quick one, so it
--- is no candidate for a fastest anything. Every extractor below goes through
--- [`Lap.recorded`](Motorsport-Lap#recorded) to drop those -- all but one, and
--- that one says what it does instead.
+-- A time the source data did not record is no candidate for any record, and
+-- says so in the type: the loader drops it at the boundary, so a `Lap` carries
+-- `Nothing` and every extractor below is a plain read.
 
 
-recordedLapTime : Lap -> Maybe Duration
-recordedLapTime lap =
-    Lap.recorded lap.time
-
-
-{-| The exception: a zero can only win a maximum when there is nothing to beat,
-so the slowest lap takes every lap as it finds it.
--}
-lapTimeAsFound : Lap -> Maybe Duration
-lapTimeAsFound lap =
-    Just lap.time
-
-
-recordedSectorTime : Sector -> Lap -> Maybe Duration
-recordedSectorTime sector lap =
-    Lap.recorded (Sector.get sector lap.sectors).time
+sectorTime : Sector -> Lap -> Maybe Duration
+sectorTime sector lap =
+    (Sector.get sector lap.sectors).time
 
 
 {-| Mini-sector times are only trusted on laps that have a lap time, matching
 what the whole-race calculation has always done.
 -}
-recordedMiniSectorTime : LeMans2025MiniSector -> Lap -> Maybe Duration
-recordedMiniSectorTime mini lap =
-    case Lap.recorded lap.time of
+miniSectorTime : LeMans2025MiniSector -> Lap -> Maybe Duration
+miniSectorTime mini lap =
+    case lap.time of
         Just _ ->
             lap.miniSectors
                 |> Maybe.andThen (LeMans.get mini >> .time)
-                |> Maybe.andThen Lap.recorded
 
         Nothing ->
             Nothing

--- a/package/src/Motorsport/BestTimes.elm
+++ b/package/src/Motorsport/BestTimes.elm
@@ -68,7 +68,7 @@ type alias Holder =
 {-| The records held still at one moment of the race -- the comparison baseline a
 widget rates and scales individual times against, and the laps that set them.
 
-Read mid-race via [`at`](#at) these are only the best times *so far*; only
+Read mid-race via [`at`](#at) these are only the best times _so far_; only
 [`final`](#final)'s answer is the race's actual best times.
 
 `Nothing` is a record no lap has taken yet. [`timeOf`](#timeOf) reads it down

--- a/package/src/Motorsport/BestTimes.elm
+++ b/package/src/Motorsport/BestTimes.elm
@@ -33,7 +33,7 @@ import Motorsport.Driver exposing (Driver)
 import Motorsport.Duration exposing (Duration)
 import Motorsport.Instant as Instant exposing (Instant)
 import Motorsport.Internal.ChangePoints as ChangePoints exposing (ChangePoints)
-import Motorsport.Lap exposing (Lap)
+import Motorsport.Lap as Lap exposing (Lap)
 import Motorsport.Sector as Sector exposing (BySector, Sector)
 
 
@@ -147,16 +147,17 @@ final =
 
 
 {-| One record as a plain time, for the rating and the geometry that only ever
-wanted the number.
+wanted the number and not who set it.
 
-A record no lap has taken comes back `0` -- the same zero the source data uses
-for a time it did not record. See
-[`Performance.performanceLevel`](Motorsport-Lap-Performance#performanceLevel).
+A record no lap has taken stays `Nothing`, which is what lets
+[`Performance.performanceLevel`](Motorsport-Lap-Performance#performanceLevel)
+rate against it without a guard. The geometry that needs an actual number says
+what an unset record is worth to it, at the point where it needs one.
 
 -}
-timeOf : Maybe Holder -> Duration
-timeOf held =
-    Maybe.withDefault 0 (Maybe.map .time held)
+timeOf : Maybe Holder -> Maybe Duration
+timeOf =
+    Maybe.map .time
 
 
 
@@ -251,13 +252,14 @@ greaterThan a b =
 
 -- WHAT COUNTS AS A TIME
 -- A zero is a time the source data did not record, not a very quick one, so it
--- is no candidate for a fastest anything. Every extractor below says `recorded`
--- to mean it drops those -- all but one, and that one says what it does instead.
+-- is no candidate for a fastest anything. Every extractor below goes through
+-- [`Lap.recorded`](Motorsport-Lap#recorded) to drop those -- all but one, and
+-- that one says what it does instead.
 
 
 recordedLapTime : Lap -> Maybe Duration
 recordedLapTime lap =
-    recorded lap.time
+    Lap.recorded lap.time
 
 
 {-| The exception: a zero can only win a maximum when there is nothing to beat,
@@ -270,7 +272,7 @@ lapTimeAsFound lap =
 
 recordedSectorTime : Sector -> Lap -> Maybe Duration
 recordedSectorTime sector lap =
-    recorded (Sector.get sector lap.sectors).time
+    Lap.recorded (Sector.get sector lap.sectors).time
 
 
 {-| Mini-sector times are only trusted on laps that have a lap time, matching
@@ -278,20 +280,11 @@ what the whole-race calculation has always done.
 -}
 recordedMiniSectorTime : LeMans2025MiniSector -> Lap -> Maybe Duration
 recordedMiniSectorTime mini lap =
-    case recorded lap.time of
+    case Lap.recorded lap.time of
         Just _ ->
             lap.miniSectors
                 |> Maybe.andThen (LeMans.get mini >> .time)
-                |> Maybe.andThen recorded
+                |> Maybe.andThen Lap.recorded
 
         Nothing ->
             Nothing
-
-
-recorded : Duration -> Maybe Duration
-recorded time =
-    if time == 0 then
-        Nothing
-
-    else
-        Just time

--- a/package/src/Motorsport/Chart/GapChart.elm
+++ b/package/src/Motorsport/Chart/GapChart.elm
@@ -29,6 +29,7 @@ import Dict exposing (Dict)
 import Html.Styled exposing (Html, text)
 import List.Extra
 import Motorsport.Chart.Common exposing (Dimensions, Emphasis(..), LapWindow(..), Scales, axisPadding, iqrFences, lapAxis, lapGridLines, renderLine, sortForDrawing, svg, xContinuousScale, yAxis)
+import Motorsport.Instant as Instant exposing (Instant)
 import Motorsport.Lap exposing (Lap)
 import Motorsport.Manufacturer as Manufacturer
 import Motorsport.ViewModel.Entry exposing (Entry)
@@ -122,13 +123,18 @@ gapChartView ( minLap, maxLap ) lapHistory entries =
 per-lap group baseline `referenceByLap` and each car's lap list. Laps without a
 baseline produce no point and are dropped.
 -}
-gapPoints : Dict Int Int -> List Lap -> List LinePoint
+gapPoints : Dict Int Instant -> List Lap -> List LinePoint
 gapPoints referenceByLap laps =
     laps
         |> List.filterMap
             (\lap ->
                 Dict.get lap.lap referenceByLap
-                    |> Maybe.map (\ref -> { lap = lap.lap, value = lap.elapsed - ref })
+                    |> Maybe.map
+                        (\ref ->
+                            { lap = lap.lap
+                            , value = Instant.since { from = ref, to = lap.elapsed }
+                            }
+                        )
             )
 
 
@@ -320,25 +326,32 @@ zeroReferenceLine { x1, x2, y } =
 number, the mean cumulative time. Excluding pit laps keeps the baseline from
 jumping. Only cars with a non-pit lap on that lap contribute to the average.
 -}
-groupReferenceByLap : List CarLine -> Dict Int Int
+groupReferenceByLap : List CarLine -> Dict Int Instant
 groupReferenceByLap carLines =
     carLines
         |> List.concatMap .laps
         |> List.filter (\lap -> lap.pitTime == Nothing)
         |> List.foldl
             (\lap ->
+                let
+                    -- Summing moments is meaningless on its own; the mean of
+                    -- them is the moment the group crossed the line, which is
+                    -- why this drops out of the type and back in below.
+                    elapsed =
+                        Instant.toDuration lap.elapsed
+                in
                 Dict.update lap.lap
                     (\existing ->
                         case existing of
                             Just ( sum, count ) ->
-                                Just ( sum + lap.elapsed, count + 1 )
+                                Just ( sum + elapsed, count + 1 )
 
                             Nothing ->
-                                Just ( lap.elapsed, 1 )
+                                Just ( elapsed, 1 )
                     )
             )
             Dict.empty
-        |> Dict.map (\_ ( sum, count ) -> sum // count)
+        |> Dict.map (\_ ( sum, count ) -> Instant.fromDuration (sum // count))
 
 
 {-| Dimensions for the full-width consolidated gap chart. A wide aspect keeps the

--- a/package/src/Motorsport/Chart/Histogram.elm
+++ b/package/src/Motorsport/Chart/Histogram.elm
@@ -3,7 +3,7 @@ module Motorsport.Chart.Histogram exposing (view)
 import Css exposing (px)
 import Html.Styled exposing (Html)
 import Motorsport.BestTimes as BestTimes exposing (Holder)
-import Motorsport.Lap exposing (Lap)
+import Motorsport.Lap as Lap exposing (Lap)
 import Motorsport.Lap.Performance as Performance exposing (performanceLevel)
 import Scale exposing (ContinuousScale)
 import Svg.Styled exposing (Svg, g, rect, svg)
@@ -49,11 +49,16 @@ view bestTimes coefficient laps =
         fastestLapTime =
             BestTimes.timeOf bestTimes.fastestLapTime
 
-        slowestLapTime =
-            BestTimes.timeOf bestTimes.slowestLapTime
+        -- The axis needs actual numbers; a record no lap has set is worth
+        -- nothing to it, which collapses the scale to a point and draws nothing.
+        fastestMs =
+            Maybe.withDefault 0 fastestLapTime
+
+        slowestMs =
+            Maybe.withDefault 0 (BestTimes.timeOf bestTimes.slowestLapTime)
 
         xScale =
-            xContinuousScale ( fastestLapTime, min (toFloat fastestLapTime * coefficient) (toFloat slowestLapTime) )
+            xContinuousScale ( fastestMs, min (toFloat fastestMs * coefficient) (toFloat slowestMs) )
 
         yScale =
             yContinuousScale ( 0, 0 )
@@ -67,7 +72,16 @@ view bestTimes coefficient laps =
 
         color lap =
             if isCurrentLap lap then
-                performanceLevel { time = lap.time, personalBest = lap.best, fastest = fastestLapTime }
+                Lap.recorded lap.time
+                    |> Maybe.map
+                        (\time ->
+                            performanceLevel
+                                { time = time
+                                , personalBest = Lap.recorded lap.best
+                                , fastest = fastestLapTime
+                                }
+                        )
+                    |> Maybe.withDefault Performance.Standard
                     |> Performance.toColorVariable
 
             else

--- a/package/src/Motorsport/Chart/Histogram.elm
+++ b/package/src/Motorsport/Chart/Histogram.elm
@@ -3,7 +3,7 @@ module Motorsport.Chart.Histogram exposing (view)
 import Css exposing (px)
 import Html.Styled exposing (Html)
 import Motorsport.BestTimes as BestTimes exposing (Holder)
-import Motorsport.Lap as Lap exposing (Lap)
+import Motorsport.Lap exposing (Lap)
 import Motorsport.Lap.Performance as Performance exposing (performanceLevel)
 import Scale exposing (ContinuousScale)
 import Svg.Styled exposing (Svg, g, rect, svg)
@@ -72,12 +72,12 @@ view bestTimes coefficient laps =
 
         color lap =
             if isCurrentLap lap then
-                Lap.recorded lap.time
+                lap.time
                     |> Maybe.map
                         (\time ->
                             performanceLevel
                                 { time = time
-                                , personalBest = Lap.recorded lap.best
+                                , personalBest = lap.best
                                 , fastest = fastestLapTime
                                 }
                         )
@@ -89,15 +89,19 @@ view bestTimes coefficient laps =
 
         isCurrentLap { lap } =
             List.length laps == lap
+
+        -- A lap the source data has no time for has nowhere to go on the axis.
+        timedLaps =
+            List.filter (\lap -> lap.time /= Nothing) laps
     in
     svg [ TypedSvgAttributes.viewBox 0 0 w h, SvgAttributes.css [ Css.width (px 200) ] ]
         [ histogram_
-            { x = .time >> toFloat >> Scale.convert xScale
+            { x = .time >> Maybe.withDefault 0 >> toFloat >> Scale.convert xScale
             , y = always 0 >> Scale.convert yScale
             , width = width
             , color = color
             }
-            laps
+            timedLaps
         ]
 
 

--- a/package/src/Motorsport/Chart/Tracker/Config.elm
+++ b/package/src/Motorsport/Chart/Tracker/Config.elm
@@ -63,21 +63,24 @@ buildConfig layout bestTimes =
         totalTime =
             if isLeMans2025 then
                 LeMans.values bestTimes.fastestMiniSectors
-                    |> List.map BestTimes.timeOf
+                    |> List.filterMap BestTimes.timeOf
                     |> List.sum
                     |> toFloat
 
             else
                 Sector.values bestTimes.fastestSectors
-                    |> List.map BestTimes.timeOf
+                    |> List.filterMap BestTimes.timeOf
                     |> List.sum
                     |> toFloat
 
         miniRatio miniSector =
             let
+                -- A record no lap has set contributes nothing to the track's
+                -- proportions; the default ratio below covers that case.
                 value =
                     LeMans.get miniSector bestTimes.fastestMiniSectors
                         |> BestTimes.timeOf
+                        |> Maybe.withDefault 0
                         |> toFloat
 
                 defaultRatio =
@@ -124,7 +127,7 @@ computeSectorShares layout bestTimes totalTime miniRatio =
                 [] ->
                     let
                         value =
-                            toFloat fastestTime
+                            toFloat (Maybe.withDefault 0 fastestTime)
                     in
                     if totalTime == 0 then
                         Circuit.sectorDefaultRatio

--- a/package/src/Motorsport/Clock.elm
+++ b/package/src/Motorsport/Clock.elm
@@ -37,7 +37,7 @@ without reference to the wall clock.
 
 -}
 
-import Motorsport.Duration as Duration exposing (Duration)
+import Motorsport.Instant as Instant exposing (Instant)
 import Time exposing (Posix, posixToMillis)
 
 
@@ -49,8 +49,8 @@ type PlaybackSpeed
 
 type State
     = Initial
-    | Started Duration { now : Posix, startedAt : Posix }
-    | Paused Duration
+    | Started Instant { now : Posix, startedAt : Posix }
+    | Paused Instant
     | Finished
 
 
@@ -98,7 +98,7 @@ update now msg m =
         Start ->
             case m.state of
                 Initial ->
-                    { m | state = Started 0 { now = now, startedAt = now } }
+                    { m | state = Started Instant.raceStart { now = now, startedAt = now } }
 
                 Paused splitTime ->
                     { m | state = Started splitTime { now = now, startedAt = now } }
@@ -126,26 +126,26 @@ update now msg m =
             { m | state = Finished }
 
 
-{-| Put the playback head at a given point in the race.
+{-| Put the playback head at a given moment of the race.
 -}
-setElapsed : Duration -> Model -> Model
-setElapsed duration m =
+setElapsed : Instant -> Model -> Model
+setElapsed instant m =
     case m.state of
         -- Moving the clock before the race has been started leaves it
         -- stopped, at the moment asked for -- the same state as pausing
         -- there. Ignoring it instead would leave the clock reading zero
         -- while the rest of the replay had moved on.
         Initial ->
-            { m | state = Paused duration }
+            { m | state = Paused instant }
 
         -- Re-anchored like `setPlaybackSpeed`. Keeping the old anchor would put
         -- the head at the moment asked for *plus* however long playback had been
         -- running, times the speed.
         Started _ { now } ->
-            { m | state = Started duration { now = now, startedAt = now } }
+            { m | state = Started instant { now = now, startedAt = now } }
 
         Paused _ ->
-            { m | state = Paused duration }
+            { m | state = Paused instant }
 
         Finished ->
             m
@@ -184,20 +184,20 @@ toString m =
 
         Started splitTime { now, startedAt } ->
             calcElapsed startedAt now splitTime m.playbackSpeed
-                |> (Duration.toString >> String.dropRight 4)
+                |> (Instant.toString >> String.dropRight 4)
 
         Paused splitTime ->
-            (Duration.toString >> String.dropRight 4) splitTime
+            (Instant.toString >> String.dropRight 4) splitTime
 
         Finished ->
             "00:00:00"
 
 
-getElapsed : Model -> Int
+getElapsed : Model -> Instant
 getElapsed m =
     case m.state of
         Initial ->
-            0
+            Instant.raceStart
 
         Started splitTime { now, startedAt } ->
             calcElapsed startedAt now splitTime m.playbackSpeed
@@ -206,7 +206,7 @@ getElapsed m =
             splitTime
 
         Finished ->
-            0
+            Instant.raceStart
 
 
 
@@ -218,10 +218,10 @@ diff a b =
     posixToMillis b - posixToMillis a
 
 
-calcElapsed : Posix -> Posix -> Duration -> PlaybackSpeed -> Int
+calcElapsed : Posix -> Posix -> Instant -> PlaybackSpeed -> Instant
 calcElapsed startedAt now splitTime playbackSpeed =
     let
         speed =
             speedToMultiplier playbackSpeed
     in
-    (diff startedAt now * speed) + splitTime
+    Instant.add (diff startedAt now * speed) splitTime

--- a/package/src/Motorsport/Duration.elm
+++ b/package/src/Motorsport/Duration.elm
@@ -129,9 +129,9 @@ toStringInHours milliseconds =
     String.join ":" [ h, m, s ++ "." ++ ms ]
 
 
-{-| Read a duration back off the wire, spelled the way
-[`toString`](#toString) writes it: `[[H:]MM:]SS[.fff]`, with an optional
-leading sign.
+{-| Read a duration back off the wire, spelled the way [`toString`](#toString)
+writes it. Times arrive with three decimal places, so the fractional part is
+already a count of milliseconds.
 
     fromString "0.000"
     --> Just 0
@@ -148,33 +148,12 @@ leading sign.
     fromString "-6:54.321"
     --> Just -414321
 
-Every part is a whole number of its own unit, so a field that is not a run of
-digits is not a duration:
-
-    fromString "1:ab.000"
-    --> Nothing
-
-The sign belongs to the duration rather than to any one part of it, and there
-is only ever one:
-
-    fromString "1:-30.000"
-    --> Nothing
-
-    fromString "--4.321"
-    --> Nothing
-
-Past three decimal places there is more precision on offer than a duration
-holds, and it rounds to the nearest millisecond:
-
-    fromString "1.2345"
-    --> Just 1235
-
 -}
 fromString : String -> Maybe Duration
 fromString str =
     case String.uncons str of
         Just ( '-', rest ) ->
-            fromPositiveString rest |> Maybe.map negate
+            fromString rest |> Maybe.map negate
 
         _ ->
             fromPositiveString str
@@ -182,16 +161,39 @@ fromString str =
 
 fromPositiveString : String -> Maybe Duration
 fromPositiveString str =
+    let
+        fromHours h =
+            String.toInt h |> Maybe.map ((*) 3600000)
+
+        fromMinutes m =
+            String.toInt m |> Maybe.map ((*) 60000)
+
+        -- Read as digits rather than through `String.toFloat`, which cannot
+        -- hold a millisecond exactly and had to be rounded back out of.
+        -- A shorter fraction is padded out; a longer one is not read.
+        fromSeconds s =
+            case String.split "." s of
+                [ whole, fraction ] ->
+                    Maybe.map2 (\whole_ ms -> (whole_ * 1000) + ms)
+                        (String.toInt whole)
+                        (fraction |> String.padRight 3 '0' |> String.left 3 |> String.toInt)
+
+                [ whole ] ->
+                    String.toInt whole |> Maybe.map ((*) 1000)
+
+                _ ->
+                    Nothing
+    in
     case String.split ":" str of
         [ h, m, s ] ->
-            Maybe.map3 (\h_ m_ s_ -> (h_ * 60 * 60 * 1000) + (m_ * 60 * 1000) + s_)
-                (digits h)
-                (digits m)
+            Maybe.map3 (\h_ m_ s_ -> h_ + m_ + s_)
+                (fromHours h)
+                (fromMinutes m)
                 (fromSeconds s)
 
         [ m, s ] ->
-            Maybe.map2 (\m_ s_ -> (m_ * 60 * 1000) + s_)
-                (digits m)
+            Maybe.map2 (+)
+                (fromMinutes m)
                 (fromSeconds s)
 
         [ s ] ->
@@ -199,64 +201,6 @@ fromPositiveString str =
 
         _ ->
             Nothing
-
-
-{-| The seconds field, whole and fractional parts each read as an integer.
-
-This used to go through `String.toFloat` and `round` back out of it. A
-millisecond is not exactly representable as a binary fraction of a second, so
-the reading was never the digits that were written -- only near enough to them
-that rounding recovered the number.
-
--}
-fromSeconds : String -> Maybe Duration
-fromSeconds str =
-    case String.split "." str of
-        [ whole ] ->
-            digits whole |> Maybe.map ((*) 1000)
-
-        [ whole, fraction ] ->
-            Maybe.map2 (\s ms -> (s * 1000) + ms)
-                (digits whole)
-                (milliseconds fraction)
-
-        _ ->
-            Nothing
-
-
-{-| The fractional part of a seconds field, as whole milliseconds.
-
-Read to four places and rounded to three, half away from zero -- which is where
-reading the whole seconds field as a `Float` could not be trusted to land, since
-a value like `.5005` is a hair under the half-millisecond once it is a `Double`
-and rounded the wrong way.
-
-A fraction that rounds up to a full second carries: `.9999` is 1000
-milliseconds, and the caller adds it to the whole seconds either way.
-
--}
-milliseconds : String -> Maybe Duration
-milliseconds fraction =
-    if String.all Char.isDigit fraction then
-        String.padRight 4 '0' fraction
-            |> String.left 4
-            |> String.toInt
-            |> Maybe.map (\tenthsOfAMilli -> (tenthsOfAMilli + 5) // 10)
-
-    else
-        Nothing
-
-
-{-| A run of digits and nothing else. `String.toInt` would take a sign as well,
-and a sign in the middle of a duration is not something to be lenient about.
--}
-digits : String -> Maybe Int
-digits str =
-    if String.isEmpty str || not (String.all Char.isDigit str) then
-        Nothing
-
-    else
-        String.toInt str
 
 
 fromStringWithDefault : Duration -> String -> Duration

--- a/package/src/Motorsport/Duration.elm
+++ b/package/src/Motorsport/Duration.elm
@@ -129,7 +129,9 @@ toStringInHours milliseconds =
     String.join ":" [ h, m, s ++ "." ++ ms ]
 
 
-{-|
+{-| Read a duration back off the wire, spelled the way
+[`toString`](#toString) writes it: `[[H:]MM:]SS[.fff]`, with an optional
+leading sign.
 
     fromString "0.000"
     --> Just 0
@@ -146,12 +148,33 @@ toStringInHours milliseconds =
     fromString "-6:54.321"
     --> Just -414321
 
+Every part is a whole number of its own unit, so a field that is not a run of
+digits is not a duration:
+
+    fromString "1:ab.000"
+    --> Nothing
+
+The sign belongs to the duration rather than to any one part of it, and there
+is only ever one:
+
+    fromString "1:-30.000"
+    --> Nothing
+
+    fromString "--4.321"
+    --> Nothing
+
+Past three decimal places there is more precision on offer than a duration
+holds, and it rounds to the nearest millisecond:
+
+    fromString "1.2345"
+    --> Just 1235
+
 -}
 fromString : String -> Maybe Duration
 fromString str =
     case String.uncons str of
         Just ( '-', rest ) ->
-            fromString rest |> Maybe.map negate
+            fromPositiveString rest |> Maybe.map negate
 
         _ ->
             fromPositiveString str
@@ -159,26 +182,16 @@ fromString str =
 
 fromPositiveString : String -> Maybe Duration
 fromPositiveString str =
-    let
-        fromHours h =
-            String.toInt h |> Maybe.map ((*) 3600000)
-
-        fromMinutes m =
-            String.toInt m |> Maybe.map ((*) 60000)
-
-        fromSeconds s =
-            String.toFloat s |> Maybe.map ((*) 1000 >> round)
-    in
     case String.split ":" str of
         [ h, m, s ] ->
-            Maybe.map3 (\h_ m_ s_ -> h_ + m_ + s_)
-                (fromHours h)
-                (fromMinutes m)
+            Maybe.map3 (\h_ m_ s_ -> (h_ * 60 * 60 * 1000) + (m_ * 60 * 1000) + s_)
+                (digits h)
+                (digits m)
                 (fromSeconds s)
 
         [ m, s ] ->
-            Maybe.map2 (+)
-                (fromMinutes m)
+            Maybe.map2 (\m_ s_ -> (m_ * 60 * 1000) + s_)
+                (digits m)
                 (fromSeconds s)
 
         [ s ] ->
@@ -186,6 +199,64 @@ fromPositiveString str =
 
         _ ->
             Nothing
+
+
+{-| The seconds field, whole and fractional parts each read as an integer.
+
+This used to go through `String.toFloat` and `round` back out of it. A
+millisecond is not exactly representable as a binary fraction of a second, so
+the reading was never the digits that were written -- only near enough to them
+that rounding recovered the number.
+
+-}
+fromSeconds : String -> Maybe Duration
+fromSeconds str =
+    case String.split "." str of
+        [ whole ] ->
+            digits whole |> Maybe.map ((*) 1000)
+
+        [ whole, fraction ] ->
+            Maybe.map2 (\s ms -> (s * 1000) + ms)
+                (digits whole)
+                (milliseconds fraction)
+
+        _ ->
+            Nothing
+
+
+{-| The fractional part of a seconds field, as whole milliseconds.
+
+Read to four places and rounded to three, half away from zero -- which is where
+reading the whole seconds field as a `Float` could not be trusted to land, since
+a value like `.5005` is a hair under the half-millisecond once it is a `Double`
+and rounded the wrong way.
+
+A fraction that rounds up to a full second carries: `.9999` is 1000
+milliseconds, and the caller adds it to the whole seconds either way.
+
+-}
+milliseconds : String -> Maybe Duration
+milliseconds fraction =
+    if String.all Char.isDigit fraction then
+        String.padRight 4 '0' fraction
+            |> String.left 4
+            |> String.toInt
+            |> Maybe.map (\tenthsOfAMilli -> (tenthsOfAMilli + 5) // 10)
+
+    else
+        Nothing
+
+
+{-| A run of digits and nothing else. `String.toInt` would take a sign as well,
+and a sign in the middle of a duration is not something to be lenient about.
+-}
+digits : String -> Maybe Int
+digits str =
+    if String.isEmpty str || not (String.all Char.isDigit str) then
+        Nothing
+
+    else
+        String.toInt str
 
 
 fromStringWithDefault : Duration -> String -> Duration

--- a/package/src/Motorsport/Gap.elm
+++ b/package/src/Motorsport/Gap.elm
@@ -26,6 +26,7 @@ module Motorsport.Gap exposing
 
 import List.Extra
 import Motorsport.Duration as Duration exposing (Duration)
+import Motorsport.Instant as Instant exposing (Instant)
 import Motorsport.Lap as Lap exposing (Lap)
 
 
@@ -92,7 +93,7 @@ laps count =
 {-| A moment of the race, as [`Lap`](Motorsport-Lap) measures it.
 -}
 type alias Clock =
-    { elapsed : Duration }
+    { elapsed : Instant }
 
 
 
@@ -144,7 +145,7 @@ lapsBetween clock { ahead, behind } =
         hasComeBackRound =
             Maybe.map3
                 (\sector aheadLap behindLap ->
-                    Lap.sectorStart sector aheadLap < Lap.sectorStart sector behindLap
+                    Instant.compare (Lap.sectorStart sector aheadLap) (Lap.sectorStart sector behindLap) == LT
                 )
                 currentSector
                 ahead.currentLap
@@ -189,7 +190,12 @@ secondsBetween clock { ahead, behind } =
                 |> List.Extra.find (\lap -> lap.lap == behindLap.lap)
                 |> Maybe.map
                     (\aheadLap ->
-                        seconds (Lap.sectorStart currentSector behindLap - Lap.sectorStart currentSector aheadLap)
+                        seconds
+                            (Instant.since
+                                { from = Lap.sectorStart currentSector aheadLap
+                                , to = Lap.sectorStart currentSector behindLap
+                                }
+                            )
                     )
                 |> Maybe.withDefault none
 

--- a/package/src/Motorsport/Instant.elm
+++ b/package/src/Motorsport/Instant.elm
@@ -213,8 +213,8 @@ The way out of the type, for the arithmetic the algebra above has no name for --
 rounding a moment to the hour, averaging a field's worth of them. Pair it with
 [`fromDuration`](#fromDuration) to get back.
 
-    toDuration (fromDuration 4321)
-    --> 4321
+    fromDuration 90000 |> toDuration
+    --> 90000
 
 -}
 toDuration : Instant -> Duration

--- a/package/src/Motorsport/Instant.elm
+++ b/package/src/Motorsport/Instant.elm
@@ -1,0 +1,233 @@
+module Motorsport.Instant exposing
+    ( Instant
+    , raceStart, fromDuration
+    , decoder
+    , add, subtract, since
+    , compare, earlier, later
+    , toDuration, toString
+    )
+
+{-| A moment of the race, measured from the instant it started.
+
+[`Duration`](Motorsport-Duration) is how long something took; an `Instant` is
+when it happened. The two are both milliseconds underneath and were both plain
+`Int` until this module existed, which left nothing to stop a lap time being
+compared against a lap's completion time, or two moments being added together.
+
+The algebra is the one the names imply, and it is the whole reason the type is
+opaque. A moment shifted by a length is another moment ([`add`](#add),
+[`subtract`](#subtract)); the distance between two moments is a length
+([`since`](#since)). Nothing else is offered: two moments do not add up to
+anything, and a moment scaled by two is not a moment.
+
+@docs Instant
+
+
+## Naming a moment
+
+@docs raceStart, fromDuration
+@docs decoder
+
+
+## Moving between moments
+
+@docs add, subtract, since
+
+
+## Ordering moments
+
+@docs compare, earlier, later
+
+
+## Reading a moment
+
+@docs toDuration, toString
+
+-}
+
+import Json.Decode exposing (Decoder)
+import Motorsport.Duration as Duration exposing (Duration)
+
+
+{-| Milliseconds since the race started. Never negative -- see
+[`subtract`](#subtract).
+-}
+type Instant
+    = Instant Duration
+
+
+{-| The moment the race started, which every other moment is measured from.
+
+    toDuration raceStart
+    --> 0
+
+-}
+raceStart : Instant
+raceStart =
+    Instant 0
+
+
+{-| The moment reached after `duration` of racing. Moments before the start do
+not exist, so a negative duration lands on [`raceStart`](#raceStart):
+
+    toDuration (fromDuration 4321)
+    --> 4321
+
+    fromDuration (-4321)
+    --> raceStart
+
+-}
+fromDuration : Duration -> Instant
+fromDuration duration =
+    if duration < 0 then
+        raceStart
+
+    else
+        Instant duration
+
+
+{-| Read a moment off the wire, where it is spelled the way
+[`Duration.fromString`](Motorsport-Duration#fromString) reads it.
+-}
+decoder : Decoder Instant
+decoder =
+    Json.Decode.string
+        |> Json.Decode.andThen
+            (\str ->
+                case Duration.fromString str of
+                    Just duration ->
+                        Json.Decode.succeed (fromDuration duration)
+
+                    Nothing ->
+                        Json.Decode.fail ("Invalid duration format: " ++ str)
+            )
+
+
+
+-- MOVING BETWEEN MOMENTS
+
+
+{-| The moment `duration` later.
+
+    fromDuration 1000 |> add 500
+    --> fromDuration 1500
+
+-}
+add : Duration -> Instant -> Instant
+add duration (Instant ms) =
+    fromDuration (ms + duration)
+
+
+{-| The moment `duration` earlier, clamped at the start of the race -- there is
+no racing before there is a race:
+
+    fromDuration 1000 |> subtract 500
+    --> fromDuration 500
+
+    fromDuration 1000 |> subtract 5000
+    --> raceStart
+
+-}
+subtract : Duration -> Instant -> Instant
+subtract duration (Instant ms) =
+    fromDuration (ms - duration)
+
+
+{-| How long it took to get from one moment to another.
+
+Signed, and deliberately not clamped the way [`subtract`](#subtract) is: `to`
+being the earlier of the two is a meaningful answer rather than an impossible
+moment, and callers read it. [`Gap.seconds`](Motorsport-Gap#seconds) takes a
+negative here to mean the two cars were handed over the wrong way round.
+
+    since { from = fromDuration 1000, to = fromDuration 1500 }
+    --> 500
+
+    since { from = fromDuration 1500, to = fromDuration 1000 }
+    --> -500
+
+-}
+since : { from : Instant, to : Instant } -> Duration
+since { from, to } =
+    toDuration to - toDuration from
+
+
+
+-- ORDERING MOMENTS
+
+
+{-| Which of two moments came first.
+
+    Motorsport.Instant.compare (fromDuration 1000) (fromDuration 1500)
+    --> LT
+
+-}
+compare : Instant -> Instant -> Order
+compare (Instant a) (Instant b) =
+    Basics.compare a b
+
+
+{-| Whichever of two moments came first.
+
+    earlier (fromDuration 1500) (fromDuration 1000)
+    --> fromDuration 1000
+
+-}
+earlier : Instant -> Instant -> Instant
+earlier a b =
+    if compare a b == GT then
+        b
+
+    else
+        a
+
+
+{-| Whichever of two moments came last.
+
+Folding a list with it needs no fallback for the empty case: nothing happens
+before the race starts, so [`raceStart`](#raceStart) is the identity.
+
+    later (fromDuration 1500) (fromDuration 1000)
+    --> fromDuration 1500
+
+    List.foldl later raceStart []
+    --> raceStart
+
+-}
+later : Instant -> Instant -> Instant
+later a b =
+    if compare a b == LT then
+        b
+
+    else
+        a
+
+
+
+-- READING A MOMENT
+
+
+{-| How long into the race this moment is.
+
+The way out of the type, for the arithmetic the algebra above has no name for --
+rounding a moment to the hour, averaging a field's worth of them. Pair it with
+[`fromDuration`](#fromDuration) to get back.
+
+    toDuration (fromDuration 4321)
+    --> 4321
+
+-}
+toDuration : Instant -> Duration
+toDuration (Instant ms) =
+    ms
+
+
+{-| Render a moment the way a race clock does. For display only.
+
+    toString (fromDuration 25614321)
+    --> "7:06:54.321"
+
+-}
+toString : Instant -> String
+toString =
+    toDuration >> Duration.toString

--- a/package/src/Motorsport/Internal/ChangePoints.elm
+++ b/package/src/Motorsport/Internal/ChangePoints.elm
@@ -22,11 +22,11 @@ scrubbed backwards lands on the same value as one that played through.
 -}
 
 import Array exposing (Array)
-import Motorsport.Duration exposing (Duration)
+import Motorsport.Instant as Instant exposing (Instant)
 
 
 type ChangePoints a
-    = ChangePoints (Array ( Duration, a ))
+    = ChangePoints (Array ( Instant, a ))
 
 
 {-| No changes at all. Every reading comes back `Nothing`.
@@ -43,15 +43,15 @@ they were given in -- and `valueAt` takes the last of them. That is what lets an
 index built from an event list agree with folding over the same list.
 
 -}
-fromList : List ( Duration, a ) -> ChangePoints a
+fromList : List ( Instant, a ) -> ChangePoints a
 fromList changes =
-    ChangePoints (Array.fromList (List.sortBy Tuple.first changes))
+    ChangePoints (Array.fromList (List.sortBy (Tuple.first >> Instant.toDuration) changes))
 
 
 {-| The value in force at `elapsed`: the last change at or before it, or
 `Nothing` while the first change is still ahead of the clock.
 -}
-valueAt : Duration -> ChangePoints a -> Maybe a
+valueAt : Instant -> ChangePoints a -> Maybe a
 valueAt elapsed ((ChangePoints points) as index) =
     Array.get (countUpTo elapsed index - 1) points
         |> Maybe.map Tuple.second
@@ -68,18 +68,19 @@ last (ChangePoints points) =
 
 {-| How many changes have happened by `elapsed`.
 -}
-countUpTo : Duration -> ChangePoints a -> Int
+countUpTo : Instant -> ChangePoints a -> Int
 countUpTo elapsed (ChangePoints points) =
     search elapsed points 0 (Array.length points)
 
 
 {-| When the `n`th change happened, counting from zero.
 
-Takes a position in the index, where `valueAt` takes a moment of the race. Both
-are `Int`, so only the name tells them apart.
+Takes a position in the index, where `valueAt` takes a moment of the race --
+which is the whole difference between an `Int` and an
+[`Instant`](Motorsport-Instant).
 
 -}
-timeOfNth : Int -> ChangePoints a -> Maybe Duration
+timeOfNth : Int -> ChangePoints a -> Maybe Instant
 timeOfNth n (ChangePoints points) =
     Array.get n points
         |> Maybe.map Tuple.first
@@ -95,7 +96,7 @@ length (ChangePoints points) =
 {-| Invariant: every change below `low` is at or before `elapsed`, and every
 change from `high` up is after it. The two meet at the count.
 -}
-search : Duration -> Array ( Duration, a ) -> Int -> Int -> Int
+search : Instant -> Array ( Instant, a ) -> Int -> Int -> Int
 search elapsed points low high =
     if low >= high then
         low
@@ -107,7 +108,7 @@ search elapsed points low high =
         in
         case Array.get mid points of
             Just ( at, _ ) ->
-                if at <= elapsed then
+                if Instant.compare at elapsed /= GT then
                     search elapsed points (mid + 1) high
 
                 else

--- a/package/src/Motorsport/Lap.elm
+++ b/package/src/Motorsport/Lap.elm
@@ -35,6 +35,7 @@ import List.Extra
 import Motorsport.Circuit.LeMans as LeMans exposing (ByMiniSector, LeMans2025MiniSector(..))
 import Motorsport.Driver as Driver exposing (Driver)
 import Motorsport.Duration exposing (Duration)
+import Motorsport.Instant as Instant exposing (Instant)
 import Motorsport.Sector as Sector exposing (BySector, Sector(..))
 
 
@@ -46,7 +47,7 @@ type alias Lap =
     , time : Duration
     , best : Duration
     , sectors : SectorTimes
-    , elapsed : Duration
+    , elapsed : Instant
     , pitTime : Maybe Duration
     , miniSectors : Maybe MiniSectors
     }
@@ -90,14 +91,14 @@ empty =
     , time = 0
     , sectors = Sector.initialize (always { time = 0, personalBest = 0 })
     , best = 0
-    , elapsed = 0
+    , elapsed = Instant.raceStart
     , pitTime = Nothing
     , miniSectors = Nothing
     }
 
 
 type alias Clock =
-    { elapsed : Duration }
+    { elapsed : Instant }
 
 
 {-| Which of two laps is ahead on track, read at a moment of the race.
@@ -139,7 +140,7 @@ compareLapsInSameSector clock a b segment_a segment_b =
                 ( Just ms_a, Just ms_b ) ->
                     case Compare.reverse (Compare.by miniSectorToIndex) ms_a ms_b of
                         EQ ->
-                            Basics.compare (miniSectorToElapsed a ms_a) (miniSectorToElapsed b ms_b)
+                            Instant.compare (miniSectorToElapsed a ms_a) (miniSectorToElapsed b ms_b)
 
                         order ->
                             order
@@ -162,19 +163,19 @@ first is ahead.
 -}
 compareBySegmentStart : Segment -> Segment -> Order
 compareBySegmentStart segment_a segment_b =
-    Basics.compare segment_a.start segment_b.start
+    Instant.compare segment_a.start segment_b.start
 
 
-completedLapsAt : Clock -> List { a | elapsed : Duration } -> List { a | elapsed : Duration }
+completedLapsAt : Clock -> List { a | elapsed : Instant } -> List { a | elapsed : Instant }
 completedLapsAt clock =
-    List.filter (\lap -> lap.elapsed <= clock.elapsed)
+    List.filter (\lap -> Instant.compare lap.elapsed clock.elapsed /= GT)
 
 
-imcompletedLapsAt : Clock -> List { a | elapsed : Duration } -> List { a | elapsed : Duration }
+imcompletedLapsAt : Clock -> List { a | elapsed : Instant } -> List { a | elapsed : Instant }
 imcompletedLapsAt clock laps =
     let
         incompletedLaps =
-            List.filter (\lap -> lap.elapsed > clock.elapsed) laps
+            List.filter (\lap -> Instant.compare lap.elapsed clock.elapsed == GT) laps
     in
     case incompletedLaps of
         [] ->
@@ -184,12 +185,12 @@ imcompletedLapsAt clock laps =
             incompletedLaps
 
 
-findLastLapAt : Clock -> List { a | elapsed : Duration } -> Maybe { a | elapsed : Duration }
+findLastLapAt : Clock -> List { a | elapsed : Instant } -> Maybe { a | elapsed : Instant }
 findLastLapAt clock =
     completedLapsAt clock >> List.Extra.last
 
 
-findCurrentLap : Clock -> List { a | elapsed : Duration } -> Maybe { a | elapsed : Duration }
+findCurrentLap : Clock -> List { a | elapsed : Instant } -> Maybe { a | elapsed : Instant }
 findCurrentLap clock =
     imcompletedLapsAt clock >> List.head
 
@@ -208,7 +209,7 @@ Which sector it is belongs to the position in a
 
 -}
 type alias Segment =
-    { start : Duration
+    { start : Instant
     , time : Duration
     }
 
@@ -225,20 +226,21 @@ segments : Lap -> BySector Segment
 segments lap =
     let
         start =
-            lap.elapsed - lap.time
+            Instant.subtract lap.time lap.elapsed
     in
     { s1 = { start = start, time = lap.sectors.s1.time }
-    , s2 = { start = start + lap.sectors.s1.time, time = lap.sectors.s2.time }
-    , s3 = { start = start + lap.sectors.s1.time + lap.sectors.s2.time, time = lap.sectors.s3.time }
+    , s2 = { start = Instant.add lap.sectors.s1.time start, time = lap.sectors.s2.time }
+    , s3 = { start = Instant.add (lap.sectors.s1.time + lap.sectors.s2.time) start, time = lap.sectors.s3.time }
     }
 
 
 {-| Whether a moment of race time falls inside a segment. Half-open: the
 instant a sector ends belongs to the next one.
 -}
-contains : Duration -> Segment -> Bool
+contains : Instant -> Segment -> Bool
 contains raceElapsed segment =
-    raceElapsed >= segment.start && raceElapsed < (segment.start + segment.time)
+    (Instant.compare raceElapsed segment.start /= LT)
+        && (Instant.compare raceElapsed (Instant.add segment.time segment.start) == LT)
 
 
 {-| The segment the car is driving at the given moment. Moments outside the lap
@@ -283,14 +285,14 @@ progressAt clock lap =
             currentSegment clock lap
     in
     { sector = sector
-    , progress = toFloat (clock.elapsed - segment.start) / toFloat segment.time
+    , progress = toFloat (Instant.since { from = segment.start, to = clock.elapsed }) / toFloat segment.time
     }
 
 
 {-| When a given sector of a given lap began — for asking about a sector the
 car is not in, or a lap it is not on.
 -}
-sectorStart : Sector -> Lap -> Duration
+sectorStart : Sector -> Lap -> Instant
 sectorStart sector lap =
     (Sector.get sector (segments lap)).start
 
@@ -306,13 +308,14 @@ currentMiniSector clock lap =
         |> Maybe.andThen
             (\ms ->
                 let
-                    elapsed_lastLap =
-                        lap.elapsed - lap.time
+                    lapStart =
+                        Instant.subtract lap.time lap.elapsed
 
                     inRange start end =
                         case ( start, end ) of
                             ( Just start_, Just end_ ) ->
-                                clock.elapsed >= (start_ + elapsed_lastLap) && clock.elapsed < (end_ + elapsed_lastLap)
+                                contains clock.elapsed
+                                    { start = Instant.add start_ lapStart, time = end_ - start_ }
 
                             _ ->
                                 False
@@ -368,7 +371,10 @@ miniSectorProgressAt clock { current, previous } =
                             ( Just start_, Just duration_ ) ->
                                 let
                                     elapsedSinceStart =
-                                        clock.elapsed - (previous.elapsed + start_)
+                                        Instant.since
+                                            { from = Instant.add start_ previous.elapsed
+                                            , to = clock.elapsed
+                                            }
 
                                     progress =
                                         if duration_ <= 0 then
@@ -397,17 +403,18 @@ miniSectorToIndex miniSector =
         |> Maybe.withDefault 0
 
 
-miniSectorToElapsed : Lap -> LeMans2025MiniSector -> Duration
+miniSectorToElapsed : Lap -> LeMans2025MiniSector -> Instant
 miniSectorToElapsed lap miniSector =
     let
-        elapsed_lastLap =
-            lap.elapsed - lap.time
+        lapStart =
+            Instant.subtract lap.time lap.elapsed
+
+        intoTheLap =
+            lap.miniSectors
+                |> Maybe.andThen (\miniSectors -> miniSectorStartElapsed miniSectors miniSector)
+                |> Maybe.withDefault 0
     in
-    elapsed_lastLap
-        + (lap.miniSectors
-            |> Maybe.andThen (\miniSectors -> miniSectorStartElapsed miniSectors miniSector)
-            |> Maybe.withDefault 0
-          )
+    Instant.add intoTheLap lapStart
 
 
 miniSectorElapsed : MiniSectors -> LeMans2025MiniSector -> Maybe Duration

--- a/package/src/Motorsport/Lap.elm
+++ b/package/src/Motorsport/Lap.elm
@@ -46,8 +46,8 @@ type alias Lap =
     , driver : Driver
     , lap : Int
     , position : Maybe Int
-    , time : Duration
-    , best : Duration
+    , time : Maybe Duration
+    , best : Maybe Duration
     , sectors : SectorTimes
     , elapsed : Instant
     , pitTime : Maybe Duration
@@ -58,12 +58,14 @@ type alias Lap =
 {-| How long one sector of this lap took, next to the driver's best for that
 sector up to and including this lap — the baseline a time is rated against.
 
-The two are kept together because nothing reads one without the other.
+The two are kept together because nothing reads one without the other. Either
+can be missing: a sector the source data left blank has no time, and a driver
+who has yet to complete one has no best for it.
 
 -}
 type alias SectorTime =
-    { time : Duration
-    , personalBest : Duration
+    { time : Maybe Duration
+    , personalBest : Maybe Duration
     }
 
 
@@ -90,9 +92,9 @@ empty =
     , driver = Driver.unknown
     , lap = 0
     , position = Nothing
-    , time = 0
-    , sectors = Sector.initialize (always { time = 0, personalBest = 0 })
-    , best = 0
+    , time = Nothing
+    , sectors = Sector.initialize (always { time = Nothing, personalBest = Nothing })
+    , best = Nothing
     , elapsed = Instant.raceStart
     , pitTime = Nothing
     , miniSectors = Nothing
@@ -102,10 +104,10 @@ empty =
 {-| A time as the source data spells it, where a zero stands for a time that was
 not recorded rather than a very quick one.
 
-`time`, `best` and the sector times all carry that convention, and this is the
-only place that knows it. Everything that rates or ranks one of those times
-comes through here, so nothing downstream has to guard against a zero it did not
-expect. Mini-sector times arrive as `Maybe` already and need no lifting.
+For the loader to call on the way in, so that the zero stops at the boundary and
+a `Lap` never carries one. Sector times arrive spelled as a blank cell and are
+`Nothing` before they get here; a lap time is the one the CLI writes out as
+`0.000` whether it was recorded or not.
 
     recorded 95365
     --> Just 95365
@@ -240,23 +242,41 @@ type alias Segment =
     }
 
 
+{-| When the lap began.
+
+Read off the lap's own end and duration, never the previous lap's, which may be
+missing or not adjacent. A lap the source data has no time for has no length, so
+it begins where it ends -- which is what the geometry below wants for a lap it
+cannot place.
+
+-}
+lapStart : Lap -> Instant
+lapStart lap =
+    Instant.subtract (Maybe.withDefault 0 lap.time) lap.elapsed
+
+
 {-| Cut a lap into its three sectors.
 
 The lap stores only how long each sector took, so where one begins has to be
-added up; this is the only place that happens. It adds up from the lap's own
-end and duration, never the previous lap's, which may be missing or not
-adjacent.
+added up; this is the only place that happens. A sector with no recorded time is
+empty rather than absent, so the two after it still start where they should.
 
 -}
 segments : Lap -> BySector Segment
 segments lap =
     let
         start =
-            Instant.subtract lap.time lap.elapsed
+            lapStart lap
+
+        took sector =
+            Maybe.withDefault 0 sector.time
+
+        ( s1, s2, s3 ) =
+            ( took lap.sectors.s1, took lap.sectors.s2, took lap.sectors.s3 )
     in
-    { s1 = { start = start, time = lap.sectors.s1.time }
-    , s2 = { start = Instant.add lap.sectors.s1.time start, time = lap.sectors.s2.time }
-    , s3 = { start = Instant.add (lap.sectors.s1.time + lap.sectors.s2.time) start, time = lap.sectors.s3.time }
+    { s1 = { start = start, time = s1 }
+    , s2 = { start = Instant.add s1 start, time = s2 }
+    , s3 = { start = Instant.add (s1 + s2) start, time = s3 }
     }
 
 
@@ -334,14 +354,14 @@ currentMiniSector clock lap =
         |> Maybe.andThen
             (\ms ->
                 let
-                    lapStart =
-                        Instant.subtract lap.time lap.elapsed
+                    start_of_lap =
+                        lapStart lap
 
                     inRange start end =
                         case ( start, end ) of
                             ( Just start_, Just end_ ) ->
                                 contains clock.elapsed
-                                    { start = Instant.add start_ lapStart, time = end_ - start_ }
+                                    { start = Instant.add start_ start_of_lap, time = end_ - start_ }
 
                             _ ->
                                 False
@@ -432,15 +452,12 @@ miniSectorToIndex miniSector =
 miniSectorToElapsed : Lap -> LeMans2025MiniSector -> Instant
 miniSectorToElapsed lap miniSector =
     let
-        lapStart =
-            Instant.subtract lap.time lap.elapsed
-
         intoTheLap =
             lap.miniSectors
                 |> Maybe.andThen (\miniSectors -> miniSectorStartElapsed miniSectors miniSector)
                 |> Maybe.withDefault 0
     in
-    Instant.add intoTheLap lapStart
+    Instant.add intoTheLap (lapStart lap)
 
 
 miniSectorElapsed : MiniSectors -> LeMans2025MiniSector -> Maybe Duration

--- a/package/src/Motorsport/Lap.elm
+++ b/package/src/Motorsport/Lap.elm
@@ -2,6 +2,7 @@ module Motorsport.Lap exposing
     ( Lap, empty
     , SectorTime, SectorTimes
     , MiniSectors, MiniSectorData
+    , recorded
     , compareAt
     , completedLapsAt, findLastLapAt, findCurrentLap
     , Segment, segments, sectorStart
@@ -14,6 +15,7 @@ module Motorsport.Lap exposing
 @docs Lap, empty
 @docs SectorTime, SectorTimes
 @docs MiniSectors, MiniSectorData
+@docs recorded
 @docs compareAt
 @docs completedLapsAt, findLastLapAt, findCurrentLap
 
@@ -95,6 +97,30 @@ empty =
     , pitTime = Nothing
     , miniSectors = Nothing
     }
+
+
+{-| A time as the source data spells it, where a zero stands for a time that was
+not recorded rather than a very quick one.
+
+`time`, `best` and the sector times all carry that convention, and this is the
+only place that knows it. Everything that rates or ranks one of those times
+comes through here, so nothing downstream has to guard against a zero it did not
+expect. Mini-sector times arrive as `Maybe` already and need no lifting.
+
+    recorded 95365
+    --> Just 95365
+
+    recorded 0
+    --> Nothing
+
+-}
+recorded : Duration -> Maybe Duration
+recorded time =
+    if time == 0 then
+        Nothing
+
+    else
+        Just time
 
 
 type alias Clock =

--- a/package/src/Motorsport/Lap/Performance.elm
+++ b/package/src/Motorsport/Lap/Performance.elm
@@ -41,9 +41,9 @@ type PerformanceLevel
 
 Both baselines are `Nothing` until some lap sets them, and nothing has beaten a
 record that has not been set -- so an unset baseline matches no time, and the
-comparison needs no guard of its own. There is only a time to rate here because
-[`Lap.recorded`](Motorsport-Lap#recorded) has already dropped the ones the
-source data did not record.
+comparison needs no guard of its own. There is only a time to rate here at all
+because the loader dropped the ones the source data did not record, on the way
+in -- see [`Lap.recorded`](Motorsport-Lap#recorded).
 
 -}
 performanceLevel : { a | time : Duration, personalBest : Maybe Duration, fastest : Maybe Duration } -> PerformanceLevel

--- a/package/src/Motorsport/Lap/Performance.elm
+++ b/package/src/Motorsport/Lap/Performance.elm
@@ -37,25 +37,21 @@ type PerformanceLevel
     | Standard
 
 
-{-| A zero is a time the source data did not record, not a very quick one, so it
-takes no colour.
+{-| How a time reads against the two baselines it is rated on.
 
-Without that first branch it would take both. Nothing has beaten a record that
-has not been set, so an unset baseline reads as zero -- and a zero time matches
-it exactly, which would light up every unrecorded time as the fastest of the
-race until the first real one is set. A car that has yet to set a personal best
-carries a zero for the same reason, and would rate its own missing time as one.
+Both baselines are `Nothing` until some lap sets them, and nothing has beaten a
+record that has not been set -- so an unset baseline matches no time, and the
+comparison needs no guard of its own. There is only a time to rate here because
+[`Lap.recorded`](Motorsport-Lap#recorded) has already dropped the ones the
+source data did not record.
 
 -}
-performanceLevel : { a | time : Duration, personalBest : Duration, fastest : Duration } -> PerformanceLevel
+performanceLevel : { a | time : Duration, personalBest : Maybe Duration, fastest : Maybe Duration } -> PerformanceLevel
 performanceLevel { time, personalBest, fastest } =
-    if time == 0 then
-        Standard
-
-    else if time == fastest then
+    if fastest == Just time then
         Fastest
 
-    else if time == personalBest then
+    else if personalBest == Just time then
         PersonalBest
 
     else

--- a/package/src/Motorsport/Ordering.elm
+++ b/package/src/Motorsport/Ordering.elm
@@ -23,7 +23,7 @@ the two cannot be mixed up downstream.
 -}
 
 import Compare
-import Motorsport.Duration exposing (Duration)
+import Motorsport.Instant exposing (Instant)
 import Motorsport.Lap as Lap exposing (Lap)
 import SortedList exposing (SortedList)
 
@@ -38,17 +38,17 @@ current sector.
 The result is a plain list, not a `SortedList`: the caller's next move is to
 number the cars off, and it is that number `byPosition` guards.
 
-    Ordering.runningOrder { elapsed = 3600000 } cars
+    Ordering.runningOrder { elapsed = Instant.fromDuration 3600000 } cars
     -- The leader first, then the rest in the order they are running
 
 -}
-runningOrder : { elapsed : Duration } -> List { a | currentLap : Maybe Lap } -> List { a | currentLap : Maybe Lap }
+runningOrder : { elapsed : Instant } -> List { a | currentLap : Maybe Lap } -> List { a | currentLap : Maybe Lap }
 runningOrder clock =
     List.sortWith (compareOnTrack clock)
 
 
 compareOnTrack :
-    { elapsed : Duration }
+    { elapsed : Instant }
     -> { a | currentLap : Maybe Lap }
     -> { a | currentLap : Maybe Lap }
     -> Order

--- a/package/src/Motorsport/Race.elm
+++ b/package/src/Motorsport/Race.elm
@@ -23,7 +23,7 @@ moment is derived from the two, in
 import Dict
 import List.Extra
 import Motorsport.BestTimes as BestTimes
-import Motorsport.Duration exposing (Duration)
+import Motorsport.Instant as Instant exposing (Instant)
 import Motorsport.Internal.ChangePoints as ChangePoints exposing (ChangePoints)
 import Motorsport.Race.Car exposing (Car, CarNumber)
 import Motorsport.Race.StatusChanges as StatusChanges exposing (StatusChanges)
@@ -45,7 +45,7 @@ counter's ceiling and `lapCountAt` can never disagree about how long the race wa
 type alias Race =
     { cars : List Car
     , lapTotal : Int
-    , timeLimit : Duration
+    , timeLimit : Instant
     , timelineEvents : List TimelineEvent
     , statusChanges : StatusChanges
     , lapCompletions : ChangePoints Int
@@ -59,7 +59,7 @@ empty : Race
 empty =
     { cars = []
     , lapTotal = 0
-    , timeLimit = 0
+    , timeLimit = Instant.raceStart
     , timelineEvents = []
     , statusChanges = StatusChanges.empty
     , lapCompletions = ChangePoints.empty
@@ -93,13 +93,21 @@ fromCars cars =
     }
 
 
-calcTimeLimit : List Car -> Duration
-calcTimeLimit =
-    List.map (.laps >> List.Extra.last >> Maybe.map .elapsed)
-        >> List.filterMap identity
-        >> List.maximum
-        >> Maybe.map (\timeLimit -> (timeLimit // (60 * 60 * 1000)) * 60 * 60 * 1000)
-        >> Maybe.withDefault 0
+{-| When the chequered flag falls: the last lap anyone completed, rounded down
+to the whole hour.
+-}
+calcTimeLimit : List Car -> Instant
+calcTimeLimit cars =
+    let
+        hour =
+            60 * 60 * 1000
+
+        lastLap =
+            cars
+                |> List.filterMap (.laps >> List.Extra.last >> Maybe.map .elapsed)
+                |> List.foldl Instant.later Instant.raceStart
+    in
+    Instant.fromDuration ((Instant.toDuration lastLap // hour) * hour)
 
 
 {-| When the lap counter goes up, and to what.
@@ -116,7 +124,7 @@ calcLapCompletions cars =
         |> List.foldl
             (\lap earliest ->
                 Dict.update lap.lap
-                    (Maybe.map (min lap.elapsed)
+                    (Maybe.map (Instant.earlier lap.elapsed)
                         >> Maybe.withDefault lap.elapsed
                         >> Just
                     )
@@ -130,7 +138,7 @@ calcLapCompletions cars =
 
 {-| How many laps the leading car has completed at a moment of the race.
 -}
-lapCountAt : { elapsed : Duration } -> Race -> Int
+lapCountAt : { elapsed : Instant } -> Race -> Int
 lapCountAt clock race =
     ChangePoints.valueAt clock.elapsed race.lapCompletions
         |> Maybe.withDefault 0
@@ -146,23 +154,23 @@ it gives the start.
 Total on its own, so a caller does not have to have checked the range first.
 
 -}
-elapsedAtLapCount : Int -> Race -> Duration
+elapsedAtLapCount : Int -> Race -> Instant
 elapsedAtLapCount lapCount race =
     if lapCount < 0 then
-        0
+        Instant.raceStart
 
     else
         case ChangePoints.timeOfNth lapCount race.lapCompletions of
             Just nextCompletion ->
-                nextCompletion - 1
+                Instant.subtract 1 nextCompletion
 
             Nothing ->
                 ChangePoints.timeOfNth (ChangePoints.length race.lapCompletions - 1) race.lapCompletions
-                    |> Maybe.withDefault 0
+                    |> Maybe.withDefault Instant.raceStart
 
 
 {-| The status a car holds at a moment of the race.
 -}
-statusAt : { elapsed : Duration } -> CarNumber -> Race -> Status
+statusAt : { elapsed : Instant } -> CarNumber -> Race -> Status
 statusAt clock carNumber race =
     StatusChanges.statusAt clock carNumber race.statusChanges

--- a/package/src/Motorsport/Race/StatusChanges.elm
+++ b/package/src/Motorsport/Race/StatusChanges.elm
@@ -7,7 +7,7 @@ module Motorsport.Race.StatusChanges exposing
 {-| Every moment a car's status changes, collected once from the race timeline.
 
 A status is not something playback accumulates as the clock runs -- it is
-a function of the race and the elapsed time. This index makes that function cheap:
+a function of the race and the moment it is read at. This index makes that cheap:
 see [`ChangePoints`](Motorsport-Internal-ChangePoints), one set of them per car.
 
 @docs StatusChanges
@@ -17,7 +17,7 @@ see [`ChangePoints`](Motorsport-Internal-ChangePoints), one set of them per car.
 -}
 
 import Dict exposing (Dict)
-import Motorsport.Duration exposing (Duration)
+import Motorsport.Instant exposing (Instant)
 import Motorsport.Internal.ChangePoints as ChangePoints exposing (ChangePoints)
 import Motorsport.Race.Car exposing (CarNumber)
 import Motorsport.Race.TimelineEvent as TimelineEvent exposing (TimelineEvent)
@@ -57,8 +57,8 @@ fromTimelineEvents events =
 
 collect :
     TimelineEvent
-    -> Dict CarNumber (List ( Duration, Status ))
-    -> Dict CarNumber (List ( Duration, Status ))
+    -> Dict CarNumber (List ( Instant, Status ))
+    -> Dict CarNumber (List ( Instant, Status ))
 collect { eventTime, eventType } acc =
     case statusChange eventType of
         Just ( carNumber, status ) ->
@@ -103,11 +103,11 @@ Where a pit exit and the chequered flag land on the same instant the flag wins,
 because the timeline lists it later -- see
 [`ChangePoints.fromList`](Motorsport-Internal-ChangePoints#fromList).
 
-    StatusChanges.statusAt { elapsed = 3600000 } "7" index
+    StatusChanges.statusAt { elapsed = Instant.fromDuration 3600000 } "7" index
     -- Racing, InPit, Retired, ...
 
 -}
-statusAt : { elapsed : Duration } -> CarNumber -> StatusChanges -> Status
+statusAt : { elapsed : Instant } -> CarNumber -> StatusChanges -> Status
 statusAt clock carNumber (StatusChanges index) =
     Dict.get carNumber index
         |> Maybe.andThen (ChangePoints.valueAt clock.elapsed)

--- a/package/src/Motorsport/Race/TimelineEvent.elm
+++ b/package/src/Motorsport/Race/TimelineEvent.elm
@@ -277,6 +277,14 @@ durationDecoder =
     string |> Decode.andThen (Duration.fromString >> Json.Decode.Extra.fromMaybe "Expected a Duration")
 
 
+{-| A lap or sector time the source data may not have recorded; see
+[`Lap.recorded`](Motorsport-Lap#recorded).
+-}
+recordedDurationDecoder : Decoder (Maybe Duration)
+recordedDurationDecoder =
+    Decode.map Lap.recorded durationDecoder
+
+
 lapDecoder : Decoder Lap
 lapDecoder =
     Decode.succeed Lap
@@ -284,8 +292,8 @@ lapDecoder =
         |> required "driver" (Decode.map Driver.fromName string)
         |> required "lap" int
         |> required "position" (Decode.maybe int)
-        |> required "time" durationDecoder
-        |> required "best" durationDecoder
+        |> required "time" recordedDurationDecoder
+        |> required "best" recordedDurationDecoder
         |> custom sectorsDecoder
         |> required "elapsed" Instant.decoder
         |> optional "pit_time" (Decode.maybe durationDecoder) Nothing
@@ -300,8 +308,8 @@ sectorsDecoder =
     let
         sectorTime timeKey bestKey =
             Decode.map2 (\time personalBest -> { time = time, personalBest = personalBest })
-                (field timeKey durationDecoder)
-                (field bestKey durationDecoder)
+                (field timeKey recordedDurationDecoder)
+                (field bestKey recordedDurationDecoder)
     in
     Decode.map3 (\s1 s2 s3 -> { s1 = s1, s2 = s2, s3 = s3 })
         (sectorTime "sector_1" "s1_best")

--- a/package/src/Motorsport/Race/TimelineEvent.elm
+++ b/package/src/Motorsport/Race/TimelineEvent.elm
@@ -18,12 +18,13 @@ import Json.Decode.Pipeline exposing (custom, optional, required)
 import List.Extra
 import Motorsport.Driver as Driver
 import Motorsport.Duration as Duration exposing (Duration)
+import Motorsport.Instant as Instant exposing (Instant)
 import Motorsport.Lap as Lap exposing (Lap)
 import Motorsport.Race.Car exposing (Car, CarNumber)
 
 
 type alias TimelineEvent =
-    { eventTime : Duration, eventType : EventType }
+    { eventTime : Instant, eventType : EventType }
 
 
 type EventType
@@ -77,21 +78,26 @@ fromCars cars =
                 ++ pitEvents cars
                 ++ terminalEvents timeLimit cars
     in
-    List.sortBy .eventTime events
+    List.sortBy (.eventTime >> Instant.toDuration) events
 
 
-calcTimeLimit : List Car -> Duration
+calcTimeLimit : List Car -> Instant
 calcTimeLimit cars =
-    cars
-        |> List.filterMap (\car -> List.Extra.last car.laps |> Maybe.map .elapsed)
-        |> List.maximum
-        |> Maybe.map (\t -> (t // (60 * 60 * 1000)) * 60 * 60 * 1000)
-        |> Maybe.withDefault 0
+    let
+        hour =
+            60 * 60 * 1000
+
+        lastLap =
+            cars
+                |> List.filterMap (\car -> List.Extra.last car.laps |> Maybe.map .elapsed)
+                |> List.foldl Instant.later Instant.raceStart
+    in
+    Instant.fromDuration ((Instant.toDuration lastLap // hour) * hour)
 
 
 raceStartEvent : TimelineEvent
 raceStartEvent =
-    { eventTime = 0, eventType = RaceStart }
+    { eventTime = Instant.raceStart, eventType = RaceStart }
 
 
 startEvents : List Car -> List TimelineEvent
@@ -102,7 +108,7 @@ startEvents cars =
                 List.head car.laps
                     |> Maybe.map
                         (\firstLap ->
-                            { eventTime = 0
+                            { eventTime = Instant.raceStart
                             , eventType =
                                 CarEvent car.metadata.carNumber
                                     (Start { currentLap = stripPitTime firstLap })
@@ -114,7 +120,7 @@ startEvents cars =
 {-| Who is leading at the end of each lap, in lap order.
 -}
 type alias Leader =
-    { lapNumber : Int, eventTime : Duration, carNumber : CarNumber }
+    { lapNumber : Int, eventTime : Instant, carNumber : CarNumber }
 
 
 {-| A `TookLead` each time the car at the front of the field changes hands.
@@ -182,7 +188,7 @@ pitEvents cars =
                                 Just pitDuration ->
                                     let
                                         pitInTime =
-                                            Basics.max 0 (lap.elapsed - pitDuration)
+                                            Instant.subtract pitDuration lap.elapsed
                                     in
                                     [ { eventTime = pitInTime
                                       , eventType =
@@ -202,7 +208,7 @@ pitEvents cars =
             )
 
 
-terminalEvents : Duration -> List Car -> List TimelineEvent
+terminalEvents : Instant -> List Car -> List TimelineEvent
 terminalEvents timeLimit cars =
     cars
         |> List.filterMap
@@ -212,7 +218,7 @@ terminalEvents timeLimit cars =
                         (\finalLap ->
                             let
                                 carEventType =
-                                    if finalLap.elapsed < timeLimit then
+                                    if Instant.compare finalLap.elapsed timeLimit == LT then
                                         Retirement
 
                                     else
@@ -241,18 +247,9 @@ decoder =
         (field "event_type" eventTypeDecoder)
 
 
-eventTimeDecoder : Decoder Duration
+eventTimeDecoder : Decoder Instant
 eventTimeDecoder =
-    string
-        |> Decode.andThen
-            (\str ->
-                case Duration.fromString str of
-                    Just duration ->
-                        Decode.succeed duration
-
-                    Nothing ->
-                        Decode.fail ("Invalid duration format: " ++ str)
-            )
+    Instant.decoder
 
 
 eventTypeDecoder : Decoder EventType
@@ -290,7 +287,7 @@ lapDecoder =
         |> required "time" durationDecoder
         |> required "best" durationDecoder
         |> custom sectorsDecoder
-        |> required "elapsed" durationDecoder
+        |> required "elapsed" Instant.decoder
         |> optional "pit_time" (Decode.maybe durationDecoder) Nothing
         |> optional "miniSectors" (Decode.maybe miniSectorsDecoder) Nothing
 

--- a/package/src/Motorsport/Replay.elm
+++ b/package/src/Motorsport/Replay.elm
@@ -19,6 +19,7 @@ worked out where it is needed.
 
 import Motorsport.Clock as Clock
 import Motorsport.Duration exposing (Duration)
+import Motorsport.Instant as Instant exposing (Instant)
 import Motorsport.Race as Race exposing (Race)
 import Motorsport.Race.Car exposing (Car)
 import Time exposing (Posix)
@@ -86,7 +87,7 @@ update msg m =
         Tick now ->
             case m.playback.state of
                 Clock.Started splitTime { startedAt } ->
-                    if Clock.calcElapsed startedAt now splitTime m.playback.playbackSpeed < m.race.timeLimit then
+                    if Instant.compare (Clock.calcElapsed startedAt now splitTime m.playback.playbackSpeed) m.race.timeLimit == LT then
                         { m | playback = Clock.update now Clock.Tick m.playback }
 
                     else
@@ -110,8 +111,8 @@ update msg m =
                     Clock.getElapsed m.playback
             in
             -- Skipping is offered forwards, and stops once the race is over.
-            if elapsed < m.race.timeLimit then
-                moveTo (elapsed + duration) m
+            if Instant.compare elapsed m.race.timeLimit == LT then
+                moveTo (Instant.add duration elapsed) m
 
             else
                 m
@@ -146,7 +147,7 @@ update msg m =
                 m
 
 
-moveTo : Duration -> Model -> Model
+moveTo : Instant -> Model -> Model
 moveTo elapsed m =
     { m | playback = Clock.setElapsed elapsed m.playback }
 

--- a/package/src/Motorsport/ViewModel/Entry.elm
+++ b/package/src/Motorsport/ViewModel/Entry.elm
@@ -65,13 +65,17 @@ type alias Entry =
 
 {-| Per-sector "progress + performance rating" for the current lap.
 Rated at compute time so donut displays can render without being supplied BestTimes separately.
+
+`rated` is `Nothing` for a sector the source data has no time for, the same way
+a mini-sector's is; there is nothing to colour it by.
+
 -}
 type alias CurrentSectorStates =
-    BySector { progress : Float, rated : RatedTime }
+    BySector { progress : Float, rated : Maybe RatedTime }
 
 
 type alias SectorPerformance =
-    BySector RatedTime
+    BySector (Maybe RatedTime)
 
 
 type alias MiniSectorPerformance =

--- a/package/src/Motorsport/ViewModel/LapHistory.elm
+++ b/package/src/Motorsport/ViewModel/LapHistory.elm
@@ -16,7 +16,7 @@ it is already sliced by time. Only chart modules that scan lap history over time
 -}
 
 import Dict exposing (Dict)
-import Motorsport.Duration exposing (Duration)
+import Motorsport.Instant exposing (Instant)
 import Motorsport.Lap exposing (Lap, completedLapsAt)
 import Motorsport.Race.Car exposing (Car)
 
@@ -25,7 +25,7 @@ type LapHistory
     = LapHistory (Dict String (List Lap))
 
 
-compute : { elapsed : Duration } -> List Car -> LapHistory
+compute : { elapsed : Instant } -> List Car -> LapHistory
 compute clock cars =
     cars
         |> List.map (\car -> ( car.metadata.carNumber, completedLapsAt clock car.laps ))

--- a/package/src/Motorsport/ViewModel/Standings.elm
+++ b/package/src/Motorsport/ViewModel/Standings.elm
@@ -110,8 +110,8 @@ compute bestTimes clock race =
                         , metadata = metadata
                         , classColor = (Class.toColor metadata.class).value
                         , lapsCompleted = lastLap.lap
-                        , currentLapTime = currentLap |> Maybe.map .time
-                        , currentLapBest = currentLap |> Maybe.map .best
+                        , currentLapTime = currentLap |> Maybe.andThen .time
+                        , currentLapBest = currentLap |> Maybe.andThen .best
                         , currentLapSectors = currentLap |> Maybe.map .sectors
                         , currentLapSectorStates = currentLap |> Maybe.map (extractCurrentSectorStates bestTimes timing.sector)
                         , currentLapMiniSectors = currentLap |> Maybe.andThen .miniSectors
@@ -122,7 +122,7 @@ compute bestTimes clock race =
                                     (\lap ->
                                         rateTime fastestLapTime
                                             { time = Just timing.currentLapElapsed
-                                            , personalBest = Lap.recorded lap.best
+                                            , personalBest = lap.best
                                             }
                                     )
                         , sector = timing.sector
@@ -131,25 +131,22 @@ compute bestTimes clock race =
                         , intervalToAhead = timing.intervalToAhead
                         , currentLapProgress =
                             currentLap
-                                |> Maybe.map (\lap -> min 1.0 (toFloat timing.currentLapElapsed / toFloat lap.time))
+                                |> Maybe.andThen .time
+                                |> Maybe.map (\lapTime -> min 1.0 (toFloat timing.currentLapElapsed / toFloat lapTime))
                                 |> Maybe.withDefault 0
                         , lastLapRated =
                             car.lastLap
                                 |> Maybe.andThen
                                     (\lap ->
                                         rateTime fastestLapTime
-                                            { time = Lap.recorded lap.time
-                                            , personalBest = Lap.recorded lap.best
-                                            }
+                                            { time = lap.time, personalBest = lap.best }
                                     )
                         , bestLapRated =
                             car.lastLap
                                 |> Maybe.andThen
                                     (\lap ->
                                         rateTime fastestLapTime
-                                            { time = Lap.recorded lap.best
-                                            , personalBest = Lap.recorded lap.best
-                                            }
+                                            { time = lap.best, personalBest = lap.best }
                                     )
                         , lastLapSectors = car.lastLap |> Maybe.map (extractSectorPerformance bestTimes)
                         , lastLapMiniSectors = car.lastLap |> Maybe.andThen (extractMiniSectorPerformance bestTimes)
@@ -192,8 +189,8 @@ fromLaps baseMetadata laps =
                         , metadata = { baseMetadata | carNumber = String.fromInt lap.lap }
                         , classColor = (Class.toColor baseMetadata.class).value
                         , lapsCompleted = lap.lap
-                        , currentLapTime = Just lap.time
-                        , currentLapBest = Just lap.best
+                        , currentLapTime = lap.time
+                        , currentLapBest = lap.best
                         , currentLapSectors = Just lap.sectors
                         , currentLapSectorStates = Just (extractCurrentSectorStates bestTimes Nothing lap)
                         , currentLapMiniSectors = lap.miniSectors
@@ -205,11 +202,9 @@ fromLaps baseMetadata laps =
                         , intervalToAhead = Gap.none
                         , currentLapProgress = 0
                         , lastLapRated =
-                            rateTime fastestLapTime
-                                { time = Lap.recorded lap.time, personalBest = Lap.recorded lap.best }
+                            rateTime fastestLapTime { time = lap.time, personalBest = lap.best }
                         , bestLapRated =
-                            rateTime fastestLapTime
-                                { time = Lap.recorded lap.best, personalBest = Lap.recorded lap.best }
+                            rateTime fastestLapTime { time = lap.best, personalBest = lap.best }
                         , lastLapSectors = Just (extractSectorPerformance bestTimes lap)
                         , lastLapMiniSectors = extractMiniSectorPerformance bestTimes lap
                         , currentDriver = Just lap.driver
@@ -334,17 +329,12 @@ extractCurrentSectorStates bestTimes sectorProgress lap =
         (extractSectorPerformance bestTimes lap)
 
 
+{-| A `SectorTime` is already the shape `rateTime` reads: a time that may not
+have been recorded, and the driver's best to rate it against.
+-}
 extractSectorPerformance : BestTimes.Snapshot -> Lap -> SectorPerformance
 extractSectorPerformance bestTimes lap =
-    Sector.map2
-        (\fastest sectorTime ->
-            rateTime (BestTimes.timeOf fastest)
-                { time = Lap.recorded sectorTime.time
-                , personalBest = Lap.recorded sectorTime.personalBest
-                }
-        )
-        bestTimes.fastestSectors
-        lap.sectors
+    Sector.map2 (BestTimes.timeOf >> rateTime) bestTimes.fastestSectors lap.sectors
 
 
 extractMiniSectorPerformance :

--- a/package/src/Motorsport/ViewModel/Standings.elm
+++ b/package/src/Motorsport/ViewModel/Standings.elm
@@ -27,6 +27,7 @@ import Motorsport.Class as Class
 import Motorsport.Driver exposing (Driver)
 import Motorsport.Duration exposing (Duration)
 import Motorsport.Gap as Gap exposing (Gap)
+import Motorsport.Instant as Instant exposing (Instant)
 import Motorsport.Lap as Lap exposing (Lap)
 import Motorsport.Lap.Performance exposing (RatedTime, performanceLevel)
 import Motorsport.Ordering as Ordering exposing (ByPosition)
@@ -40,7 +41,7 @@ import SortedList exposing (SortedList)
 
 type Standings
     = Standings
-        { elapsed : Duration
+        { elapsed : Instant
         , lapCount : Int
         , entries : SortedList ByPosition Entry
 
@@ -52,7 +53,7 @@ type Standings
         }
 
 
-compute : BestTimes.Snapshot -> { elapsed : Duration } -> Race -> Standings
+compute : BestTimes.Snapshot -> { elapsed : Instant } -> Race -> Standings
 compute bestTimes clock race =
     let
         fastestLapTime =
@@ -199,7 +200,7 @@ fromLaps baseMetadata laps =
             Ordering.byPosition entries
     in
     Standings
-        { elapsed = 0
+        { elapsed = Instant.raceStart
         , lapCount = laps |> List.map .lap |> List.maximum |> Maybe.withDefault 0
         , entries = sortedEntries
         , entriesByClass = groupEntriesByClass sortedEntries
@@ -215,7 +216,7 @@ fromList entries =
             Ordering.byPosition entries
     in
     Standings
-        { elapsed = 0
+        { elapsed = Instant.raceStart
         , lapCount = entries |> List.map .lapsCompleted |> List.maximum |> Maybe.withDefault 0
         , entries = sortedEntries
         , entriesByClass = groupEntriesByClass sortedEntries
@@ -243,7 +244,7 @@ type alias CarState =
 {-| Read a car at a moment of the race. The status is looked up rather than
 worked out here; see [`Race.statusAt`](Motorsport-Race#statusAt).
 -}
-carStateAt : { elapsed : Duration } -> Race -> Car -> CarState
+carStateAt : { elapsed : Instant } -> Race -> Car -> CarState
 carStateAt clock race car =
     let
         currentLap =
@@ -332,7 +333,7 @@ type alias TimingState =
     }
 
 
-init_timing : Duration -> { leader : Maybe CarState, rival : Maybe CarState } -> CarState -> TimingState
+init_timing : Instant -> { leader : Maybe CarState, rival : Maybe CarState } -> CarState -> TimingState
 init_timing raceElapsed rivals car =
     let
         raceClock =
@@ -354,7 +355,7 @@ init_timing raceElapsed rivals car =
         currentMiniSector =
             Lap.miniSectorProgressAt raceClock { current = currentLap, previous = lastLap }
     in
-    { currentLapElapsed = raceClock.elapsed - lastLap.elapsed
+    { currentLapElapsed = Instant.since { from = lastLap.elapsed, to = raceClock.elapsed }
     , sector = currentSector
     , miniSector = currentMiniSector
     , gapToLeader = gapTo raceClock car rivals.leader
@@ -364,7 +365,7 @@ init_timing raceElapsed rivals car =
 
 {-| The gap from `car` to the car ahead of it, or none where there is no such car.
 -}
-gapTo : { elapsed : Duration } -> CarState -> Maybe CarState -> Gap
+gapTo : { elapsed : Instant } -> CarState -> Maybe CarState -> Gap
 gapTo raceClock car ahead =
     ahead
         |> Maybe.map (\aheadCar -> Gap.at raceClock { ahead = aheadCar, behind = car })
@@ -406,9 +407,9 @@ lapCount (Standings s) =
     s.lapCount
 
 
-{-| The race elapsed time this Standings represents; the elapsed passed to compute is baked in.
+{-| The moment of the race this Standings represents; the clock passed to compute is baked in.
 -}
-elapsed : Standings -> Duration
+elapsed : Standings -> Instant
 elapsed (Standings s) =
     s.elapsed
 

--- a/package/src/Motorsport/ViewModel/Standings.elm
+++ b/package/src/Motorsport/ViewModel/Standings.elm
@@ -118,7 +118,13 @@ compute bestTimes clock race =
                         , currentLapElapsed = timing.currentLapElapsed
                         , currentLapRated =
                             currentLap
-                                |> Maybe.map (\lap -> rateTime fastestLapTime { time = timing.currentLapElapsed, personalBest = lap.best })
+                                |> Maybe.andThen
+                                    (\lap ->
+                                        rateTime fastestLapTime
+                                            { time = Just timing.currentLapElapsed
+                                            , personalBest = Lap.recorded lap.best
+                                            }
+                                    )
                         , sector = timing.sector
                         , miniSector = timing.miniSector
                         , gapToLeader = timing.gapToLeader
@@ -129,10 +135,22 @@ compute bestTimes clock race =
                                 |> Maybe.withDefault 0
                         , lastLapRated =
                             car.lastLap
-                                |> Maybe.map (\lap -> rateTime fastestLapTime { time = lap.time, personalBest = lap.best })
+                                |> Maybe.andThen
+                                    (\lap ->
+                                        rateTime fastestLapTime
+                                            { time = Lap.recorded lap.time
+                                            , personalBest = Lap.recorded lap.best
+                                            }
+                                    )
                         , bestLapRated =
                             car.lastLap
-                                |> Maybe.map (\lap -> rateTime fastestLapTime { time = lap.best, personalBest = lap.best })
+                                |> Maybe.andThen
+                                    (\lap ->
+                                        rateTime fastestLapTime
+                                            { time = Lap.recorded lap.best
+                                            , personalBest = Lap.recorded lap.best
+                                            }
+                                    )
                         , lastLapSectors = car.lastLap |> Maybe.map (extractSectorPerformance bestTimes)
                         , lastLapMiniSectors = car.lastLap |> Maybe.andThen (extractMiniSectorPerformance bestTimes)
                         , currentDriver = car.currentDriver
@@ -187,9 +205,11 @@ fromLaps baseMetadata laps =
                         , intervalToAhead = Gap.none
                         , currentLapProgress = 0
                         , lastLapRated =
-                            Just (rateTime fastestLapTime { time = lap.time, personalBest = lap.best })
+                            rateTime fastestLapTime
+                                { time = Lap.recorded lap.time, personalBest = Lap.recorded lap.best }
                         , bestLapRated =
-                            Just (rateTime fastestLapTime { time = lap.best, personalBest = lap.best })
+                            rateTime fastestLapTime
+                                { time = Lap.recorded lap.best, personalBest = Lap.recorded lap.best }
                         , lastLapSectors = Just (extractSectorPerformance bestTimes lap)
                         , lastLapMiniSectors = extractMiniSectorPerformance bestTimes lap
                         , currentDriver = Just lap.driver
@@ -266,11 +286,22 @@ groupEntriesByClass sortedEntries =
         |> List.map (\( first, rest ) -> ( Entry.classInfoOf first, first :: SortedList.toList rest ))
 
 
-rateTime : Duration -> { time : Duration, personalBest : Duration } -> RatedTime
+{-| Rate a time against the race's record and the car's own, where there is a
+time to rate. A time the source data did not record produces no rating rather
+than an uncoloured one, so a caller renders the same "-" it renders for a car
+with no lap at all.
+-}
+rateTime : Maybe Duration -> { time : Maybe Duration, personalBest : Maybe Duration } -> Maybe RatedTime
 rateTime fastest { time, personalBest } =
-    { time = time
-    , performance = performanceLevel { time = time, personalBest = personalBest, fastest = fastest }
-    }
+    time
+        |> Maybe.map
+            (\recordedTime ->
+                { time = recordedTime
+                , performance =
+                    performanceLevel
+                        { time = recordedTime, personalBest = personalBest, fastest = fastest }
+                }
+            )
 
 
 extractCurrentSectorStates :
@@ -305,7 +336,15 @@ extractCurrentSectorStates bestTimes sectorProgress lap =
 
 extractSectorPerformance : BestTimes.Snapshot -> Lap -> SectorPerformance
 extractSectorPerformance bestTimes lap =
-    Sector.map2 (BestTimes.timeOf >> rateTime) bestTimes.fastestSectors lap.sectors
+    Sector.map2
+        (\fastest sectorTime ->
+            rateTime (BestTimes.timeOf fastest)
+                { time = Lap.recorded sectorTime.time
+                , personalBest = Lap.recorded sectorTime.personalBest
+                }
+        )
+        bestTimes.fastestSectors
+        lap.sectors
 
 
 extractMiniSectorPerformance :
@@ -314,11 +353,9 @@ extractMiniSectorPerformance :
     -> Maybe MiniSectorPerformance
 extractMiniSectorPerformance bestTimes lap =
     let
-        rate recorded fastest =
-            Maybe.map2
-                (\time personalBest -> rateTime (BestTimes.timeOf fastest) { time = time, personalBest = personalBest })
-                recorded.time
-                recorded.best
+        rate miniSector fastest =
+            rateTime (BestTimes.timeOf fastest)
+                { time = miniSector.time, personalBest = miniSector.best }
     in
     lap.miniSectors
         |> Maybe.map (\ms -> LeMans.map2 rate ms bestTimes.fastestMiniSectors)

--- a/package/src/Motorsport/Widget/Compare/Distribution.elm
+++ b/package/src/Motorsport/Widget/Compare/Distribution.elm
@@ -57,9 +57,11 @@ seriesOf lapHistory range entry =
 racingTimes : LapHistory -> ( Int, Int ) -> Entry -> List Int
 racingTimes lapHistory ( minLap, maxLap ) entry =
     let
+        -- filterMap, not map: a lap the source data has no time for is not a
+        -- lap run in no time, and has no place in the distribution.
         times =
             LapHistory.get entry.metadata.carNumber lapHistory
                 |> List.filter (\lap -> minLap <= lap.lap && lap.lap <= maxLap && lap.pitTime == Nothing)
-                |> List.map .time
+                |> List.filterMap .time
     in
     times |> List.filter (\t -> t <= upperFence times)

--- a/package/src/Motorsport/Widget/Compare/PositionProgression.elm
+++ b/package/src/Motorsport/Widget/Compare/PositionProgression.elm
@@ -6,6 +6,7 @@ import Html.Styled exposing (Html)
 import List.Extra
 import Motorsport.Chart.Common exposing (Dimensions, Emphasis(..), Scales, axisPadding, lapAxis, lapGridLines, renderLine, sortForDrawing, svg, xContinuousScale, yAxis)
 import Motorsport.Class exposing (Class)
+import Motorsport.Instant as Instant
 import Motorsport.Lap exposing (Lap)
 import Motorsport.Manufacturer as Manufacturer
 import Motorsport.ViewModel exposing (ViewModel)
@@ -130,11 +131,11 @@ calculateLapThreshold { standings, lapHistory } =
             Standings.elapsed standings
 
         timeThreshold =
-            max 0 (currentRaceTime - positionHistoryWindowMillis)
+            Instant.subtract positionHistoryWindowMillis currentRaceTime
     in
     Standings.leader standings
         |> Maybe.map (\l -> LapHistory.get l.metadata.carNumber lapHistory)
-        |> Maybe.andThen (List.Extra.find (\lap -> lap.elapsed >= timeThreshold))
+        |> Maybe.andThen (List.Extra.find (\lap -> Instant.compare lap.elapsed timeThreshold /= LT))
         |> Maybe.map .lap
         |> Maybe.withDefault 1
 

--- a/package/src/Motorsport/Widget/Leaderboard.elm
+++ b/package/src/Motorsport/Widget/Leaderboard.elm
@@ -65,7 +65,7 @@ import Motorsport.Circuit.LeMans as LeMans exposing (ByMiniSector)
 import Motorsport.Class as Class exposing (Class)
 import Motorsport.Driver as Driver exposing (Driver)
 import Motorsport.Duration as Duration exposing (Duration)
-import Motorsport.Lap as Lap exposing (Lap, MiniSectorProgress, MiniSectors, SectorProgress)
+import Motorsport.Lap exposing (Lap, MiniSectorProgress, MiniSectors, SectorProgress)
 import Motorsport.Lap.Performance as Performance exposing (RatedTime, performanceLevel)
 import Motorsport.Manufacturer as Manufacturer exposing (Manufacturer)
 import Motorsport.Sector as Sector
@@ -498,7 +498,7 @@ viewCurrentLapColumn_LeMans24h bestTimes { status, currentLapElapsed, currentLap
                         status_ =
                             performanceLevel
                                 { time = time
-                                , personalBest = Lap.recorded personalBest
+                                , personalBest = personalBest
                                 , fastest = BestTimes.timeOf bestTimes.fastestLapTime
                                 }
                       in
@@ -550,7 +550,7 @@ viewCurrentLapColumn_LeMans24h bestTimes { status, currentLapElapsed, currentLap
             |> Maybe.map
                 (\best ->
                     div [ css [ displayFlex, flexDirection column, property "row-gap" "5px" ] ]
-                        [ lapTime { time = currentLapElapsed, personalBest = best }
+                        [ lapTime { time = currentLapElapsed, personalBest = Just best }
                         , let
                             progressMap =
                                 LeMans.calculateMiniSectorProgress miniSector
@@ -747,12 +747,12 @@ performanceHistory_ bestTimes laps =
             BestTimes.timeOf bestTimes.fastestLapTime
 
         toCssColor lap =
-            Lap.recorded lap.time
+            lap.time
                 |> Maybe.map
                     (\time ->
                         performanceLevel
                             { time = time
-                            , personalBest = Lap.recorded lap.best
+                            , personalBest = lap.best
                             , fastest = fastestLapTime
                             }
                     )

--- a/package/src/Motorsport/Widget/Leaderboard.elm
+++ b/package/src/Motorsport/Widget/Leaderboard.elm
@@ -65,7 +65,7 @@ import Motorsport.Circuit.LeMans as LeMans exposing (ByMiniSector)
 import Motorsport.Class as Class exposing (Class)
 import Motorsport.Driver as Driver exposing (Driver)
 import Motorsport.Duration as Duration exposing (Duration)
-import Motorsport.Lap exposing (Lap, MiniSectorProgress, MiniSectors, SectorProgress)
+import Motorsport.Lap as Lap exposing (Lap, MiniSectorProgress, MiniSectors, SectorProgress)
 import Motorsport.Lap.Performance as Performance exposing (RatedTime, performanceLevel)
 import Motorsport.Manufacturer as Manufacturer exposing (Manufacturer)
 import Motorsport.Sector as Sector
@@ -113,6 +113,28 @@ update =
 
 type alias Config data msg =
     DataView.Config data msg
+
+
+
+-- RATING COLOURS
+
+
+{-| The colour of a rating that may not exist.
+
+A sector, mini-sector or lap the source data has no time for has no rating
+either, and takes the standard colour: there is nothing to rate it against.
+Every cell that paints a rating goes through one of these two, so the fallback
+is decided in one place rather than at each of them.
+
+-}
+colorOfRated : Maybe RatedTime -> String
+colorOfRated =
+    Maybe.map .performance >> colorOfPerformance
+
+
+colorOfPerformance : Maybe Performance.PerformanceLevel -> String
+colorOfPerformance =
+    Maybe.withDefault Performance.Standard >> Performance.toColorVariable
 
 
 
@@ -165,7 +187,7 @@ veryCustomColumn =
 
 sectorTimeColumn :
     { label : String
-    , getter : data -> Maybe { time : Duration, personalBest : Duration, fastest : Duration, progress : Float }
+    , getter : data -> Maybe { time : Duration, personalBest : Maybe Duration, fastest : Maybe Duration, progress : Float }
     }
     -> Column data msg
 sectorTimeColumn { label, getter } =
@@ -401,7 +423,7 @@ viewCurrentLapColumn_Wec { status, currentLapRated, currentLapSectorStates } =
 
                         else
                             [ width (pct 100)
-                            , property "background-color" (Performance.toColorVariable rated.performance)
+                            , property "background-color" (colorOfRated rated)
                             ]
                     ]
                 ]
@@ -474,7 +496,11 @@ viewCurrentLapColumn_LeMans24h bestTimes { status, currentLapElapsed, currentLap
                     [ textAlign center
                     , let
                         status_ =
-                            performanceLevel { time = time, personalBest = personalBest, fastest = BestTimes.timeOf bestTimes.fastestLapTime }
+                            performanceLevel
+                                { time = time
+                                , personalBest = Lap.recorded personalBest
+                                , fastest = BestTimes.timeOf bestTimes.fastestLapTime
+                                }
                       in
                       if Performance.isStandard status_ then
                         batch []
@@ -500,8 +526,16 @@ viewCurrentLapColumn_LeMans24h bestTimes { status, currentLapElapsed, currentLap
                         else
                             [ width (pct 100)
                             , property "background-color"
-                                (performanceLevel { time = Maybe.withDefault 1000000 sector_.time, personalBest = Maybe.withDefault 1000000 sector_.personalBest, fastest = sector_.fastest }
-                                    |> Performance.toColorVariable
+                                (sector_.time
+                                    |> Maybe.map
+                                        (\time ->
+                                            performanceLevel
+                                                { time = time
+                                                , personalBest = sector_.personalBest
+                                                , fastest = sector_.fastest
+                                                }
+                                        )
+                                    |> colorOfPerformance
                                 )
                             ]
                     ]
@@ -575,12 +609,12 @@ viewLastLapColumn_Wec { lastLapRated, lastLapSectors } =
                 ]
                 [ text (Duration.toString time) ]
 
-        sectorCell { performance } =
+        sectorCell rated =
             div
                 [ css
                     [ height (px 3)
                     , borderRadius (px 1)
-                    , property "background-color" (Performance.toColorVariable performance)
+                    , property "background-color" (colorOfRated rated)
                     ]
                 ]
                 []
@@ -638,17 +672,12 @@ viewLastLapColumn_LeMans24h { lastLapRated, lastLapMiniSectors } =
                 ]
                 [ text (Duration.toString time) ]
 
-        sectorCell maybeRatedTime =
+        sectorCell rated =
             div
                 [ css
                     [ height (px 3)
                     , borderRadius (px 1)
-                    , property "background-color"
-                        (maybeRatedTime
-                            |> Maybe.map .performance
-                            |> Maybe.withDefault Performance.Standard
-                            |> Performance.toColorVariable
-                        )
+                    , property "background-color" (colorOfRated rated)
                     ]
                 ]
                 []
@@ -717,9 +746,17 @@ performanceHistory_ bestTimes laps =
         fastestLapTime =
             BestTimes.timeOf bestTimes.fastestLapTime
 
-        toCssColor { time, best } =
-            performanceLevel { time = time, personalBest = best, fastest = fastestLapTime }
-                |> Performance.toColorVariable
+        toCssColor lap =
+            Lap.recorded lap.time
+                |> Maybe.map
+                    (\time ->
+                        performanceLevel
+                            { time = time
+                            , personalBest = Lap.recorded lap.best
+                            , fastest = fastestLapTime
+                            }
+                    )
+                |> colorOfPerformance
     in
     div
         [ css

--- a/package/src/Motorsport/Widget/SectorAndLaps.elm
+++ b/package/src/Motorsport/Widget/SectorAndLaps.elm
@@ -148,13 +148,19 @@ currentSectorPie item =
 {-| Convert one sector into `(fill color, fill fraction 0..1)`:
 white partial fill while in progress, full performance color once completed.
 -}
-currentSectorSlot : { progress : Float, rated : RatedTime } -> ( String, Float )
+currentSectorSlot : { progress : Float, rated : Maybe RatedTime } -> ( String, Float )
 currentSectorSlot { progress, rated } =
     if progress < 1 then
         ( "oklch(1 0 0)", progress )
 
     else
-        ( Performance.toColorVariable rated.performance, 1 )
+        -- A sector the source data has no time for has no rating to colour it by.
+        ( rated
+            |> Maybe.map .performance
+            |> Maybe.withDefault Performance.Standard
+            |> Performance.toColorVariable
+        , 1
+        )
 
 
 {-| Draw three slots as 120° donut arcs. Each element is

--- a/package/tests/Data/Wec/LapsTest.elm
+++ b/package/tests/Data/Wec/LapsTest.elm
@@ -5,6 +5,7 @@ import Expect
 import Json.Decode as Decode
 import Motorsport.Class as Class
 import Motorsport.Driver as Driver
+import Motorsport.Instant as Instant
 import Motorsport.Manufacturer exposing (Manufacturer(..))
 import Motorsport.Race.Car exposing (Car)
 import Test exposing (Test, describe, test)
@@ -98,7 +99,7 @@ suite =
                               , s1 = Nothing
                               , s2 = Nothing
                               , s3 = Nothing
-                              , elapsed = 200000
+                              , elapsed = Instant.fromDuration 200000
                               , pitTime = Just 50000
                               }
                             ]
@@ -126,7 +127,7 @@ rawLap carNumber lapNumber lapTime elapsed =
     , s1 = Nothing
     , s2 = Nothing
     , s3 = Nothing
-    , elapsed = elapsed
+    , elapsed = Instant.fromDuration elapsed
     , pitTime = Nothing
     }
 

--- a/package/tests/Data/Wec/LapsTest.elm
+++ b/package/tests/Data/Wec/LapsTest.elm
@@ -53,7 +53,7 @@ suite =
                                 |> List.concatMap .laps
                                 |> List.map .best
                     in
-                    Expect.equal [ 100000, 95000, 95000 ] bests
+                    Expect.equal [ Just 100000, Just 95000, Just 95000 ] bests
             , test "assigns 0-based position by elapsed within each lap number" <|
                 \_ ->
                     let

--- a/package/tests/Motorsport/BestTimesTest.elm
+++ b/package/tests/Motorsport/BestTimesTest.elm
@@ -6,6 +6,7 @@ import Motorsport.Circuit.LeMans as LeMans
 import Motorsport.Class as Class
 import Motorsport.Driver as Driver
 import Motorsport.Duration exposing (Duration)
+import Motorsport.Instant as Instant
 import Motorsport.Lap as Lap exposing (Lap)
 import Motorsport.Manufacturer as Manufacturer
 import Motorsport.Race as Race
@@ -123,7 +124,7 @@ tests =
                     [ 0, 6000, 10000 ]
                         |> List.map
                             (\elapsed ->
-                                BestTimes.at { elapsed = elapsed } (changesOf cars)
+                                BestTimes.at { elapsed = Instant.fromDuration elapsed } (changesOf cars)
                                     |> .fastestLapTime
                                     |> Maybe.map .carNumber
                             )
@@ -152,7 +153,7 @@ finalTime pick cars =
 -}
 timeAt : Duration -> (Snapshot -> Maybe Holder) -> List Car -> Duration
 timeAt elapsed pick cars =
-    BestTimes.timeOf (pick (BestTimes.at { elapsed = elapsed } (changesOf cars)))
+    BestTimes.timeOf (pick (BestTimes.at { elapsed = Instant.fromDuration elapsed } (changesOf cars)))
 
 
 {-| Built the way the app builds them -- through `Race.fromCars`, rather than
@@ -189,7 +190,7 @@ finalSectors cars =
 -}
 sectorsAt : Duration -> List Car -> List Duration
 sectorsAt elapsed cars =
-    BestTimes.at { elapsed = elapsed } (changesOf cars)
+    BestTimes.at { elapsed = Instant.fromDuration elapsed } (changesOf cars)
         |> .fastestSectors
         |> Sector.values
         |> List.map BestTimes.timeOf
@@ -213,7 +214,7 @@ lap lapNumber time ( s1, s2, s3 ) =
     { empty
         | lap = lapNumber
         , time = time
-        , elapsed = lapNumber * time
+        , elapsed = Instant.fromDuration (lapNumber * time)
         , sectors =
             { s1 = { time = s1, personalBest = s1 }
             , s2 = { time = s2, personalBest = s2 }

--- a/package/tests/Motorsport/BestTimesTest.elm
+++ b/package/tests/Motorsport/BestTimesTest.elm
@@ -209,17 +209,22 @@ finalMiniSectors cars =
 
 {-| A lap of `time`, split into the three given sector times, running from the
 end of the previous lap of the same length.
+
+Written in plain milliseconds and lifted through
+[`Lap.recorded`](Motorsport-Lap#recorded), the way the loader does it, so that a
+zero here still means the time the source data did not record.
+
 -}
 lap : Int -> Duration -> ( Duration, Duration, Duration ) -> Lap
 lap lapNumber time ( s1, s2, s3 ) =
     { empty
         | lap = lapNumber
-        , time = time
+        , time = Lap.recorded time
         , elapsed = Instant.fromDuration (lapNumber * time)
         , sectors =
-            { s1 = { time = s1, personalBest = s1 }
-            , s2 = { time = s2, personalBest = s2 }
-            , s3 = { time = s3, personalBest = s3 }
+            { s1 = { time = Lap.recorded s1, personalBest = Lap.recorded s1 }
+            , s2 = { time = Lap.recorded s2, personalBest = Lap.recorded s2 }
+            , s3 = { time = Lap.recorded s3, personalBest = Lap.recorded s3 }
             }
     }
 

--- a/package/tests/Motorsport/BestTimesTest.elm
+++ b/package/tests/Motorsport/BestTimesTest.elm
@@ -26,14 +26,14 @@ tests =
                     , car "2" [ lap 1 6000 ( 1100, 1900, 2900 ) ]
                     ]
                         |> finalSectors
-                        |> Expect.equal [ 1000, 1900, 2900 ]
+                        |> Expect.equal [ Just 1000, Just 1900, Just 2900 ]
             , test "ignores a sector with no recorded time rather than calling it the quickest" <|
                 \_ ->
                     [ car "1" [ lap 1 6000 ( 1000, 2000, 3000 ) ]
                     , car "2" [ lap 1 6000 ( 0, 0, 0 ) ]
                     ]
                         |> finalSectors
-                        |> Expect.equal [ 1000, 2000, 3000 ]
+                        |> Expect.equal [ Just 1000, Just 2000, Just 3000 ]
             ]
         , describe "fastestLapTime"
             [ test "stands at the quickest lap run so far, and moves when it is beaten" <|
@@ -46,19 +46,19 @@ tests =
                     in
                     [ 0, 5999, 6000, 9999, 10000 ]
                         |> List.map (\elapsed -> timeAt elapsed .fastestLapTime cars)
-                        |> Expect.equal [ 0, 0, 6000, 6000, 5000 ]
+                        |> Expect.equal [ Nothing, Nothing, Just 6000, Just 6000, Just 5000 ]
             , test "a lap with no recorded time is not the quickest" <|
                 \_ ->
                     [ car "1" [ lap 1 0 anySectors, lap 2 6000 anySectors ] ]
                         |> finalTime .fastestLapTime
-                        |> Expect.equal 6000
+                        |> Expect.equal (Just 6000)
             ]
         , describe "slowestLapTime"
             [ test "stands at the slowest lap run so far" <|
                 \_ ->
                     [ car "1" [ lap 1 6000 anySectors, lap 2 5000 anySectors ] ]
                         |> finalTime .slowestLapTime
-                        |> Expect.equal 6000
+                        |> Expect.equal (Just 6000)
             ]
         , describe "fastestMiniSectors"
             [ test "ignores the mini-sectors of a lap that has no lap time" <|
@@ -71,7 +71,7 @@ tests =
                         ]
                     ]
                         |> finalMiniSectors
-                        |> Expect.equal (List.repeat 15 2000)
+                        |> Expect.equal (List.repeat 15 (Just 2000))
             ]
         , describe "where the records are read"
             [ test "`at` ignores laps the clock has not reached yet" <|
@@ -83,7 +83,7 @@ tests =
                         ]
                     ]
                         |> sectorsAt 6000
-                        |> Expect.equal [ 1000, 2000, 3000 ]
+                        |> Expect.equal [ Just 1000, Just 2000, Just 3000 ]
             , test "`final` counts every lap, whatever the clock says" <|
                 \_ ->
                     [ car "1"
@@ -92,7 +92,7 @@ tests =
                         ]
                     ]
                         |> finalSectors
-                        |> Expect.equal [ 900, 1900, 2900 ]
+                        |> Expect.equal [ Just 900, Just 1900, Just 2900 ]
             ]
         , describe "who holds each record"
             [ test "is the car and lap that set it" <|
@@ -142,16 +142,17 @@ tests =
 -- HELPERS
 
 
-{-| One record as a plain time, at the end of the race.
+{-| One record as a plain time, at the end of the race. `Nothing` is a record
+no lap has taken.
 -}
-finalTime : (Snapshot -> Maybe Holder) -> List Car -> Duration
+finalTime : (Snapshot -> Maybe Holder) -> List Car -> Maybe Duration
 finalTime pick cars =
     BestTimes.timeOf (pick (BestTimes.final (changesOf cars)))
 
 
 {-| The same, as it stood at `elapsed`.
 -}
-timeAt : Duration -> (Snapshot -> Maybe Holder) -> List Car -> Duration
+timeAt : Duration -> (Snapshot -> Maybe Holder) -> List Car -> Maybe Duration
 timeAt elapsed pick cars =
     BestTimes.timeOf (pick (BestTimes.at { elapsed = Instant.fromDuration elapsed } (changesOf cars)))
 
@@ -178,7 +179,7 @@ finalHolderOf pick cars =
 
 {-| The three fastest sector times in sector order, over the whole race.
 -}
-finalSectors : List Car -> List Duration
+finalSectors : List Car -> List (Maybe Duration)
 finalSectors cars =
     BestTimes.final (changesOf cars)
         |> .fastestSectors
@@ -188,7 +189,7 @@ finalSectors cars =
 
 {-| The same three, as they stood at `elapsed`.
 -}
-sectorsAt : Duration -> List Car -> List Duration
+sectorsAt : Duration -> List Car -> List (Maybe Duration)
 sectorsAt elapsed cars =
     BestTimes.at { elapsed = Instant.fromDuration elapsed } (changesOf cars)
         |> .fastestSectors
@@ -198,7 +199,7 @@ sectorsAt elapsed cars =
 
 {-| Every mini-sector record in track order, over the whole race.
 -}
-finalMiniSectors : List Car -> List Duration
+finalMiniSectors : List Car -> List (Maybe Duration)
 finalMiniSectors cars =
     BestTimes.final (changesOf cars)
         |> .fastestMiniSectors

--- a/package/tests/Motorsport/ClockTest.elm
+++ b/package/tests/Motorsport/ClockTest.elm
@@ -2,6 +2,7 @@ module Motorsport.ClockTest exposing (tests)
 
 import Expect
 import Motorsport.Clock as Clock
+import Motorsport.Instant as Instant exposing (Instant)
 import Test exposing (..)
 import Time exposing (millisToPosix)
 
@@ -14,6 +15,11 @@ epoch =
     millisToPosix 0
 
 
+instant : Int -> Instant
+instant =
+    Instant.fromDuration
+
+
 tests : Test
 tests =
     describe "Motorsport.Clock"
@@ -21,58 +27,58 @@ tests =
             [ test "moves a clock that has never been started" <|
                 \_ ->
                     Clock.init
-                        |> Clock.setElapsed 39742950
+                        |> Clock.setElapsed (instant 39742950)
                         |> Clock.getElapsed
-                        |> Expect.equal 39742950
+                        |> Expect.equal (instant 39742950)
             , test "leaves the clock stopped, so it does not run on from where it was put" <|
                 \_ ->
                     Clock.init
-                        |> Clock.setElapsed 39742950
+                        |> Clock.setElapsed (instant 39742950)
                         |> Clock.update (millisToPosix 5000) Clock.Tick
                         |> Clock.getElapsed
-                        |> Expect.equal 39742950
+                        |> Expect.equal (instant 39742950)
             , test "carries the moment it was moved to into playback" <|
                 \_ ->
                     Clock.init
-                        |> Clock.setElapsed 39742950
+                        |> Clock.setElapsed (instant 39742950)
                         |> Clock.update epoch Clock.Start
                         |> Clock.update (millisToPosix 5000) Clock.Tick
                         |> Clock.getElapsed
-                        |> Expect.equal (39742950 + 5000)
+                        |> Expect.equal (instant (39742950 + 5000))
             , test "moves a paused clock" <|
                 \_ ->
                     Clock.init
                         |> Clock.update epoch Clock.Start
                         |> Clock.update epoch Clock.Pause
-                        |> Clock.setElapsed 1000
+                        |> Clock.setElapsed (instant 1000)
                         |> Clock.getElapsed
-                        |> Expect.equal 1000
+                        |> Expect.equal (instant 1000)
             , test "moves a running clock to the moment asked for, not past it" <|
                 \_ ->
                     -- Five minutes into playback, asked to go back to 1.000.
                     Clock.init
                         |> Clock.update epoch Clock.Start
                         |> Clock.update (millisToPosix 300000) Clock.Tick
-                        |> Clock.setElapsed 1000
+                        |> Clock.setElapsed (instant 1000)
                         |> Clock.getElapsed
-                        |> Expect.equal 1000
+                        |> Expect.equal (instant 1000)
             , test "the moment asked for is not scaled by the playback speed" <|
                 \_ ->
                     Clock.init
                         |> Clock.setPlaybackSpeed Clock.Speed60x
                         |> Clock.update epoch Clock.Start
                         |> Clock.update (millisToPosix 60000) Clock.Tick
-                        |> Clock.setElapsed 1000
+                        |> Clock.setElapsed (instant 1000)
                         |> Clock.getElapsed
-                        |> Expect.equal 1000
+                        |> Expect.equal (instant 1000)
             , test "a running clock carries on from where it was moved to" <|
                 \_ ->
                     Clock.init
                         |> Clock.update epoch Clock.Start
                         |> Clock.update (millisToPosix 300000) Clock.Tick
-                        |> Clock.setElapsed 1000
+                        |> Clock.setElapsed (instant 1000)
                         |> Clock.update (millisToPosix 305000) Clock.Tick
                         |> Clock.getElapsed
-                        |> Expect.equal (1000 + 5000)
+                        |> Expect.equal (instant (1000 + 5000))
             ]
         ]

--- a/package/tests/Motorsport/DurationTest.elm
+++ b/package/tests/Motorsport/DurationTest.elm
@@ -28,4 +28,17 @@ tests =
                         Duration.fromString "1.001" |> Maybe.map Duration.toString
                 in
                 Expect.equal (Just "1.001") result
+        , test "an exact half-millisecond rounds up" <|
+            -- 0.5005 s is exactly 500.5 ms, but the nearest Double to it is
+            -- 500.49999999999994, so reading the seconds through a Float and
+            -- rounding back out of it answered 500. Reading the digits as
+            -- integers answers what they say.
+            \_ ->
+                Duration.fromString "0.5005"
+                    |> Expect.equal (Just 501)
+        , test "a part that is not a run of digits is not a duration" <|
+            \_ ->
+                [ "1:ab.000", "1:-30.000", "--4.321", "1e3", "" ]
+                    |> List.map Duration.fromString
+                    |> Expect.equal (List.repeat 5 Nothing)
         ]

--- a/package/tests/Motorsport/DurationTest.elm
+++ b/package/tests/Motorsport/DurationTest.elm
@@ -28,17 +28,4 @@ tests =
                         Duration.fromString "1.001" |> Maybe.map Duration.toString
                 in
                 Expect.equal (Just "1.001") result
-        , test "an exact half-millisecond rounds up" <|
-            -- 0.5005 s is exactly 500.5 ms, but the nearest Double to it is
-            -- 500.49999999999994, so reading the seconds through a Float and
-            -- rounding back out of it answered 500. Reading the digits as
-            -- integers answers what they say.
-            \_ ->
-                Duration.fromString "0.5005"
-                    |> Expect.equal (Just 501)
-        , test "a part that is not a run of digits is not a duration" <|
-            \_ ->
-                [ "1:ab.000", "1:-30.000", "--4.321", "1e3", "" ]
-                    |> List.map Duration.fromString
-                    |> Expect.equal (List.repeat 5 Nothing)
         ]

--- a/package/tests/Motorsport/GapTest.elm
+++ b/package/tests/Motorsport/GapTest.elm
@@ -3,6 +3,7 @@ module Motorsport.GapTest exposing (tests)
 import Expect
 import Motorsport.Duration exposing (Duration)
 import Motorsport.Gap as Gap
+import Motorsport.Instant as Instant
 import Motorsport.Lap as Lap exposing (Lap)
 import Test exposing (..)
 
@@ -54,7 +55,7 @@ lap lapNumber =
     { empty
         | lap = lapNumber
         , time = 10000
-        , elapsed = lapNumber * 10000
+        , elapsed = Instant.fromDuration (lapNumber * 10000)
         , sectors =
             { s1 = { time = 2000, personalBest = 0 }
             , s2 = { time = 3000, personalBest = 0 }
@@ -65,7 +66,7 @@ lap lapNumber =
 
 delayBy : Duration -> Lap -> Lap
 delayBy delay l =
-    { l | elapsed = l.elapsed + delay }
+    { l | elapsed = Instant.add delay l.elapsed }
 
 
 empty : Lap
@@ -79,38 +80,38 @@ tests =
         [ describe "at"
             [ test "reports how long ago the car ahead was where the car behind is now" <|
                 \_ ->
-                    Gap.at { elapsed = 25000 }
+                    Gap.at { elapsed = Instant.fromDuration 25000 }
                         { ahead = leader, behind = following 3 1500 }
                         |> Expect.equal (Gap.seconds 1500)
             , test "reports no gap for a car that has not started a lap" <|
                 \_ ->
-                    Gap.at { elapsed = 25000 }
+                    Gap.at { elapsed = Instant.fromDuration 25000 }
                         { ahead = leader, behind = { currentLap = Nothing, laps = [] } }
                         |> Expect.equal Gap.none
             , test "reports no gap where the car ahead has no record of the lap being compared" <|
                 \_ ->
-                    Gap.at { elapsed = 25000 }
+                    Gap.at { elapsed = Instant.fromDuration 25000 }
                         { ahead = { leader | laps = List.filter (\l -> l.lap /= 3) leader.laps }
                         , behind = following 3 1500
                         }
                         |> Expect.equal Gap.none
             , test "reports no gap rather than a negative one when the two cars are given the wrong way round" <|
                 \_ ->
-                    Gap.at { elapsed = 25000 }
+                    Gap.at { elapsed = Instant.fromDuration 25000 }
                         { ahead = following 3 1500, behind = leader }
                         |> Expect.equal Gap.none
             , test "stays a gap in seconds while the car ahead is only a lap up on the counter" <|
                 \_ ->
                     -- The leader has crossed the line onto lap 3; the car 1.500
                     -- behind is still finishing lap 2.
-                    Gap.at { elapsed = 20500 }
+                    Gap.at { elapsed = Instant.fromDuration 20500 }
                         { ahead = leader, behind = following 2 1500 }
                         |> Expect.equal (Gap.seconds 1500)
             , test "becomes a gap in laps once the car ahead has come back round" <|
                 \_ ->
                     -- A lap takes 10.000, so a car 12.000 back on lap 2 is a
                     -- whole lap down on a leader driving lap 3.
-                    Gap.at { elapsed = 25000 }
+                    Gap.at { elapsed = Instant.fromDuration 25000 }
                         { ahead = leader, behind = following 2 12000 }
                         |> Expect.equal (Gap.laps 1)
             ]

--- a/package/tests/Motorsport/GapTest.elm
+++ b/package/tests/Motorsport/GapTest.elm
@@ -54,12 +54,12 @@ lap : Int -> Lap
 lap lapNumber =
     { empty
         | lap = lapNumber
-        , time = 10000
+        , time = Just 10000
         , elapsed = Instant.fromDuration (lapNumber * 10000)
         , sectors =
-            { s1 = { time = 2000, personalBest = 0 }
-            , s2 = { time = 3000, personalBest = 0 }
-            , s3 = { time = 5000, personalBest = 0 }
+            { s1 = { time = Just 2000, personalBest = Nothing }
+            , s2 = { time = Just 3000, personalBest = Nothing }
+            , s3 = { time = Just 5000, personalBest = Nothing }
             }
     }
 

--- a/package/tests/Motorsport/Internal/ChangePointsTest.elm
+++ b/package/tests/Motorsport/Internal/ChangePointsTest.elm
@@ -2,6 +2,7 @@ module Motorsport.Internal.ChangePointsTest exposing (suite)
 
 import Expect
 import Motorsport.Duration exposing (Duration)
+import Motorsport.Instant as Instant exposing (Instant)
 import Motorsport.Internal.ChangePoints as ChangePoints exposing (ChangePoints)
 import Test exposing (Test, describe, test)
 
@@ -12,39 +13,39 @@ suite =
         [ describe "valueAt"
             [ test "reads nothing back before the first change" <|
                 \_ ->
-                    ChangePoints.valueAt 999 index
+                    ChangePoints.valueAt (instant 999) index
                         |> Expect.equal Nothing
             , test "an empty index has nothing at any time" <|
                 \_ ->
-                    ChangePoints.valueAt 500000 ChangePoints.empty
+                    ChangePoints.valueAt (instant 500000) ChangePoints.empty
                         |> Expect.equal Nothing
             , test "a change takes effect on the instant it happens, not the one after" <|
                 \_ ->
                     Expect.equal
                         ( Just "a", Just "b" )
-                        ( ChangePoints.valueAt 2999 index
-                        , ChangePoints.valueAt 3000 index
+                        ( ChangePoints.valueAt (instant 2999) index
+                        , ChangePoints.valueAt (instant 3000) index
                         )
             , test "holds the last value once the changes run out" <|
                 \_ ->
-                    ChangePoints.valueAt 9999999 index
+                    ChangePoints.valueAt (instant 9999999) index
                         |> Expect.equal (Just "d")
             , test "the last of two changes sharing an instant wins" <|
                 \_ ->
-                    ChangePoints.fromList [ ( 500, "first" ), ( 500, "second" ) ]
-                        |> ChangePoints.valueAt 500
+                    ChangePoints.fromList [ ( instant 500, "first" ), ( instant 500, "second" ) ]
+                        |> ChangePoints.valueAt (instant 500)
                         |> Expect.equal (Just "second")
             , test "an unsorted list is indexed as if it had been sorted" <|
                 \_ ->
-                    ChangePoints.fromList [ ( 3000, "b" ), ( 1000, "a" ) ]
-                        |> ChangePoints.valueAt 2000
+                    ChangePoints.fromList [ ( instant 3000, "b" ), ( instant 1000, "a" ) ]
+                        |> ChangePoints.valueAt (instant 2000)
                         |> Expect.equal (Just "a")
             ]
         , describe "last"
             [ test "gives the value in force once every change has happened" <|
                 \_ ->
                     ChangePoints.last index
-                        |> Expect.equal (ChangePoints.valueAt 9999999 index)
+                        |> Expect.equal (ChangePoints.valueAt (instant 9999999) index)
             , test "an empty index has no last value" <|
                 \_ ->
                     ChangePoints.last ChangePoints.empty
@@ -54,7 +55,7 @@ suite =
             [ test "counts the changes at or before the clock" <|
                 \_ ->
                     [ -1, 0, 1000, 2999, 3000, 6000, 6001, 9999999 ]
-                        |> List.map (\elapsed -> ChangePoints.countUpTo elapsed index)
+                        |> List.map (\elapsed -> ChangePoints.countUpTo (instant elapsed) index)
                         |> Expect.equal [ 0, 0, 1, 1, 2, 4, 4, 4 ]
             ]
         , describe "timeOfNth"
@@ -64,7 +65,7 @@ suite =
                     , ChangePoints.timeOfNth 3 index
                     , ChangePoints.timeOfNth 4 index
                     ]
-                        |> Expect.equal [ Just 1000, Just 6000, Nothing ]
+                        |> Expect.equal [ Just (instant 1000), Just (instant 6000), Nothing ]
             ]
         , describe "length"
             [ test "counts every change" <|
@@ -78,12 +79,12 @@ suite =
             [ test "reads the same values a linear scan would" <|
                 \_ ->
                     samples
-                        |> List.map (\elapsed -> ChangePoints.valueAt elapsed longIndex)
+                        |> List.map (\elapsed -> ChangePoints.valueAt (instant elapsed) longIndex)
                         |> Expect.equal (List.map scanValue samples)
             , test "counts the same changes a linear scan would" <|
                 \_ ->
                     samples
-                        |> List.map (\elapsed -> ChangePoints.countUpTo elapsed longIndex)
+                        |> List.map (\elapsed -> ChangePoints.countUpTo (instant elapsed) longIndex)
                         |> Expect.equal (List.map scanCount samples)
             ]
         ]
@@ -93,13 +94,21 @@ suite =
 -- FIXTURE
 
 
+{-| The fixtures below are written in plain milliseconds and lifted to
+[`Instant`](Motorsport-Instant) here, so the numbers stay readable.
+-}
+instant : Duration -> Instant
+instant =
+    Instant.fromDuration
+
+
 index : ChangePoints String
 index =
     ChangePoints.fromList
-        [ ( 1000, "a" )
-        , ( 3000, "b" )
-        , ( 5000, "c" )
-        , ( 6000, "d" )
+        [ ( instant 1000, "a" )
+        , ( instant 3000, "b" )
+        , ( instant 5000, "c" )
+        , ( instant 6000, "d" )
         ]
 
 
@@ -110,7 +119,7 @@ longChanges =
 
 longIndex : ChangePoints Int
 longIndex =
-    ChangePoints.fromList longChanges
+    ChangePoints.fromList (List.map (Tuple.mapFirst instant) longChanges)
 
 
 samples : List Duration
@@ -124,7 +133,7 @@ samples =
 
 upTo : Duration -> List ( Duration, Int )
 upTo elapsed =
-    List.filter (\( at, _ ) -> at <= elapsed) longChanges
+    List.filter (\( time, _ ) -> time <= elapsed) longChanges
 
 
 scanValue : Duration -> Maybe Int

--- a/package/tests/Motorsport/Lap/PerformanceTest.elm
+++ b/package/tests/Motorsport/Lap/PerformanceTest.elm
@@ -12,29 +12,28 @@ suite =
         [ describe "performanceLevel"
             [ test "matching the race's fastest is the fastest" <|
                 \_ ->
-                    rate { time = 5000, personalBest = 5000, fastest = 5000 }
+                    rate { time = 5000, personalBest = Just 5000, fastest = Just 5000 }
                         |> Expect.equal Fastest
             , test "matching the car's own best, but not the race's, is a personal best" <|
                 \_ ->
-                    rate { time = 6000, personalBest = 6000, fastest = 5000 }
+                    rate { time = 6000, personalBest = Just 6000, fastest = Just 5000 }
                         |> Expect.equal PersonalBest
             , test "beating neither is standard" <|
                 \_ ->
-                    rate { time = 7000, personalBest = 6000, fastest = 5000 }
+                    rate { time = 7000, personalBest = Just 6000, fastest = Just 5000 }
                         |> Expect.equal Standard
-            , test "a time the data did not record takes no colour" <|
-                -- Zero is how an unrecorded time arrives, and how a record no
-                -- lap has set yet reads back (whether that's the race's
-                -- baseline or the car's own personal best). Left to match, it
-                -- would rate as the fastest of the race, or as the car's own
-                -- best.
+            , test "a baseline no lap has set yet matches nothing" <|
+                -- Nothing has beaten a record that has not been set. This used
+                -- to need a guard of its own: an unset baseline read back as a
+                -- zero, and so rated every unrecorded time as the fastest of
+                -- the race until the first real one was set.
                 \_ ->
-                    rate { time = 0, personalBest = 0, fastest = 0 }
+                    rate { time = 5000, personalBest = Nothing, fastest = Nothing }
                         |> Expect.equal Standard
             ]
         ]
 
 
-rate : { time : Duration, personalBest : Duration, fastest : Duration } -> PerformanceLevel
+rate : { time : Duration, personalBest : Maybe Duration, fastest : Maybe Duration } -> PerformanceLevel
 rate =
     Performance.performanceLevel

--- a/package/tests/Motorsport/LapTest.elm
+++ b/package/tests/Motorsport/LapTest.elm
@@ -1,6 +1,7 @@
 module Motorsport.LapTest exposing (tests)
 
 import Expect
+import Motorsport.Instant as Instant exposing (Instant)
 import Motorsport.Lap as Lap exposing (Lap)
 import Motorsport.Sector as Sector exposing (Sector(..))
 import Test exposing (..)
@@ -12,7 +13,7 @@ lap : Lap
 lap =
     { empty
         | time = 6000
-        , elapsed = 10000
+        , elapsed = instant 10000
         , sectors =
             { s1 = { time = 1000, personalBest = 0 }
             , s2 = { time = 2000, personalBest = 0 }
@@ -26,6 +27,14 @@ empty =
     Lap.empty
 
 
+{-| The fixtures are written in plain milliseconds and lifted to
+[`Instant`](Motorsport-Instant) here, so the numbers stay readable.
+-}
+instant : Int -> Instant
+instant =
+    Instant.fromDuration
+
+
 tests : Test
 tests =
     describe "Motorsport.Lap"
@@ -35,22 +44,22 @@ tests =
                     Lap.segments lap
                         |> Sector.values
                         |> List.map .start
-                        |> Expect.equal [ 4000, 5000, 7000 ]
+                        |> Expect.equal [ instant 4000, instant 5000, instant 7000 ]
             , test "measures the first sector from the start of the lap, not the previous lap record" <|
                 \_ ->
                     (Lap.segments lap).s1.start
-                        |> Expect.equal (lap.elapsed - lap.time)
+                        |> Expect.equal (Instant.subtract lap.time lap.elapsed)
             , test "ends the last sector where the lap ended" <|
                 \_ ->
                     (Lap.segments lap).s3
-                        |> (\segment -> segment.start + segment.time)
+                        |> (\segment -> Instant.add segment.time segment.start)
                         |> Expect.equal lap.elapsed
             ]
         , describe "progressAt"
             [ test "measures how far through the current sector the moment is" <|
                 \_ ->
                     [ 4000, 4500, 5000, 8500 ]
-                        |> List.map (\elapsed -> Lap.progressAt { elapsed = elapsed } lap)
+                        |> List.map (\elapsed -> Lap.progressAt { elapsed = instant elapsed } lap)
                         |> Expect.equal
                             [ { sector = S1, progress = 0 }
                             , { sector = S1, progress = 0.5 }
@@ -59,22 +68,22 @@ tests =
                             ]
             , test "reports past the end of a lap that is already over, rather than capping" <|
                 \_ ->
-                    (Lap.progressAt { elapsed = 11500 } lap).progress
+                    (Lap.progressAt { elapsed = instant 11500 } lap).progress
                         |> Expect.greaterThan 1
             ]
         , describe "currentSector"
             [ test "picks the sector holding the moment, and hands over on the boundary" <|
                 \_ ->
                     [ 4000, 4999, 5000, 6999, 7000, 9999 ]
-                        |> List.map (\elapsed -> Lap.currentSector { elapsed = elapsed } lap)
+                        |> List.map (\elapsed -> Lap.currentSector { elapsed = instant elapsed } lap)
                         |> Expect.equal [ S1, S1, S2, S2, S3, S3 ]
             , test "falls through to the last sector once the lap is over" <|
                 \_ ->
-                    Lap.currentSector { elapsed = 10000 } lap
+                    Lap.currentSector { elapsed = instant 10000 } lap
                         |> Expect.equal S3
             , test "falls through to the last sector before the lap has begun" <|
                 \_ ->
-                    Lap.currentSector { elapsed = 3999 } lap
+                    Lap.currentSector { elapsed = instant 3999 } lap
                         |> Expect.equal S3
             , test "agrees with sectorStart, where progress is zero" <|
                 \_ ->
@@ -93,7 +102,7 @@ tests =
                 \_ ->
                     -- The car a lap up is the further back of the two around
                     -- the lap at this moment, and still ahead.
-                    Lap.compareAt { elapsed = 6500 }
+                    Lap.compareAt { elapsed = instant 6500 }
                         { lapStartingLate | lap = 5 }
                         { lap | lap = 4 }
                         |> Expect.equal LT
@@ -101,17 +110,17 @@ tests =
                 \_ ->
                     -- At 6.500 `lap` is in S2 (5.000-7.000) and
                     -- `lapStartingLate` is still in S1 (6.000-7.000).
-                    Lap.compareAt { elapsed = 6500 } lap lapStartingLate
+                    Lap.compareAt { elapsed = instant 6500 } lap lapStartingLate
                         |> Expect.equal LT
             , test "in the same sector, the car that entered it first is ahead" <|
                 \_ ->
                     -- At 4.800 both are in S1: `lap` entered at 4.000,
                     -- `lapStartingHalfLate` at 4.500.
-                    Lap.compareAt { elapsed = 4800 } lap lapStartingHalfLate
+                    Lap.compareAt { elapsed = instant 4800 } lap lapStartingHalfLate
                         |> Expect.equal LT
             , test "two cars running the same lap identically are level" <|
                 \_ ->
-                    Lap.compareAt { elapsed = 6500 } lap lap
+                    Lap.compareAt { elapsed = instant 6500 } lap lap
                         |> Expect.equal EQ
             ]
         ]
@@ -121,11 +130,11 @@ tests =
 -}
 lapStartingLate : Lap
 lapStartingLate =
-    { lap | elapsed = 12000 }
+    { lap | elapsed = instant 12000 }
 
 
 {-| The same lap, run half a second later: S1 runs 4.500 to 5.500.
 -}
 lapStartingHalfLate : Lap
 lapStartingHalfLate =
-    { lap | elapsed = 10500 }
+    { lap | elapsed = instant 10500 }

--- a/package/tests/Motorsport/LapTest.elm
+++ b/package/tests/Motorsport/LapTest.elm
@@ -12,12 +12,12 @@ import Test exposing (..)
 lap : Lap
 lap =
     { empty
-        | time = 6000
+        | time = Just 6000
         , elapsed = instant 10000
         , sectors =
-            { s1 = { time = 1000, personalBest = 0 }
-            , s2 = { time = 2000, personalBest = 0 }
-            , s3 = { time = 3000, personalBest = 0 }
+            { s1 = { time = Just 1000, personalBest = Nothing }
+            , s2 = { time = Just 2000, personalBest = Nothing }
+            , s3 = { time = Just 3000, personalBest = Nothing }
             }
     }
 
@@ -48,7 +48,7 @@ tests =
             , test "measures the first sector from the start of the lap, not the previous lap record" <|
                 \_ ->
                     (Lap.segments lap).s1.start
-                        |> Expect.equal (Instant.subtract lap.time lap.elapsed)
+                        |> Expect.equal (Instant.subtract 6000 lap.elapsed)
             , test "ends the last sector where the lap ended" <|
                 \_ ->
                     (Lap.segments lap).s3

--- a/package/tests/Motorsport/Race/StatusChangesTest.elm
+++ b/package/tests/Motorsport/Race/StatusChangesTest.elm
@@ -2,6 +2,7 @@ module Motorsport.Race.StatusChangesTest exposing (suite)
 
 import Expect
 import Motorsport.Duration exposing (Duration)
+import Motorsport.Instant as Instant
 import Motorsport.Lap as Lap
 import Motorsport.Race.StatusChanges as StatusChanges exposing (StatusChanges)
 import Motorsport.Race.TimelineEvent as TimelineEvent exposing (TimelineEvent)
@@ -17,19 +18,19 @@ suite =
                 \_ ->
                     Expect.equal
                         ( Status.PreRace, Status.PreRace )
-                        ( StatusChanges.statusAt { elapsed = 500000 } "99" index
-                        , StatusChanges.statusAt { elapsed = 500000 } "1" StatusChanges.empty
+                        ( StatusChanges.statusAt { elapsed = Instant.fromDuration 500000 } "99" index
+                        , StatusChanges.statusAt { elapsed = Instant.fromDuration 500000 } "1" StatusChanges.empty
                         )
             , test "a change takes effect on the instant it happens, not the one after" <|
                 \_ ->
                     Expect.equal
                         ( Status.Racing, Status.InPit )
-                        ( StatusChanges.statusAt { elapsed = 169999 } "1" index
-                        , StatusChanges.statusAt { elapsed = 170000 } "1" index
+                        ( StatusChanges.statusAt { elapsed = Instant.fromDuration 169999 } "1" index
+                        , StatusChanges.statusAt { elapsed = Instant.fromDuration 170000 } "1" index
                         )
             , test "taking the lead is not a status change" <|
                 \_ ->
-                    StatusChanges.statusAt { elapsed = 210000 } "1" index
+                    StatusChanges.statusAt { elapsed = Instant.fromDuration 210000 } "1" index
                         |> Expect.equal Status.Racing
             , test "the last of two changes sharing an instant wins" <|
                 \_ ->
@@ -40,7 +41,7 @@ suite =
                                 , carEvent 300000 TimelineEvent.Checkered
                                 ]
                     in
-                    StatusChanges.statusAt { elapsed = 300000 } "1" pitOutThenFlag
+                    StatusChanges.statusAt { elapsed = Instant.fromDuration 300000 } "1" pitOutThenFlag
                         |> Expect.equal Status.Checkered
             ]
         , describe "fromTimelineEvents"
@@ -49,15 +50,15 @@ suite =
                     let
                         twoCars =
                             StatusChanges.fromTimelineEvents
-                                [ { eventTime = 0, eventType = TimelineEvent.CarEvent "1" (TimelineEvent.Start { currentLap = Lap.empty }) }
-                                , { eventTime = 0, eventType = TimelineEvent.CarEvent "2" (TimelineEvent.Start { currentLap = Lap.empty }) }
-                                , { eventTime = 100000, eventType = TimelineEvent.CarEvent "2" TimelineEvent.Retirement }
+                                [ { eventTime = Instant.raceStart, eventType = TimelineEvent.CarEvent "1" (TimelineEvent.Start { currentLap = Lap.empty }) }
+                                , { eventTime = Instant.raceStart, eventType = TimelineEvent.CarEvent "2" (TimelineEvent.Start { currentLap = Lap.empty }) }
+                                , { eventTime = Instant.fromDuration 100000, eventType = TimelineEvent.CarEvent "2" TimelineEvent.Retirement }
                                 ]
                     in
                     Expect.equal
                         ( Status.Racing, Status.Retired )
-                        ( StatusChanges.statusAt { elapsed = 200000 } "1" twoCars
-                        , StatusChanges.statusAt { elapsed = 200000 } "2" twoCars
+                        ( StatusChanges.statusAt { elapsed = Instant.fromDuration 200000 } "1" twoCars
+                        , StatusChanges.statusAt { elapsed = Instant.fromDuration 200000 } "2" twoCars
                         )
             ]
         ]
@@ -89,4 +90,6 @@ index =
 
 carEvent : Duration -> TimelineEvent.CarEventType -> TimelineEvent
 carEvent eventTime carEventType =
-    { eventTime = eventTime, eventType = TimelineEvent.CarEvent "1" carEventType }
+    { eventTime = Instant.fromDuration eventTime
+    , eventType = TimelineEvent.CarEvent "1" carEventType
+    }

--- a/package/tests/Motorsport/Race/TimelineEventTest.elm
+++ b/package/tests/Motorsport/Race/TimelineEventTest.elm
@@ -3,6 +3,7 @@ module Motorsport.Race.TimelineEventTest exposing (suite)
 import Expect
 import Motorsport.Class as Class
 import Motorsport.Driver as Driver
+import Motorsport.Instant as Instant
 import Motorsport.Lap as Lap exposing (Lap)
 import Motorsport.Manufacturer exposing (Manufacturer(..))
 import Motorsport.Race.Car exposing (Car)
@@ -25,7 +26,7 @@ suite =
                         case List.head events of
                             Just event ->
                                 Expect.all
-                                    [ \_ -> Expect.equal 0 event.eventTime
+                                    [ \_ -> Expect.equal Instant.raceStart event.eventTime
                                     , \_ -> Expect.equal RaceStart event.eventType
                                     ]
                                     ()
@@ -100,7 +101,7 @@ suite =
 
                             Nothing ->
                                 Expect.fail "Expected at least one event"
-                    , \() -> Expect.equal True (isSortedAscending (List.map .eventTime events))
+                    , \() -> Expect.equal True (isSortedAscending (List.map (.eventTime >> Instant.toDuration) events))
                     ]
                     ()
         , test "PitIn / PitOut events: timing, lap_number, duration, integrity" <|
@@ -149,11 +150,11 @@ suite =
                         Expect.all
                             [ \_ -> Expect.equal 2 pitIn.lapNumber
                             , \_ -> Expect.equal pitDuration pitIn.duration
-                            , \_ -> Expect.equal (189575 - pitDuration) pitInTime
+                            , \_ -> Expect.equal (Instant.fromDuration (189575 - pitDuration)) pitInTime
                             , \_ -> Expect.equal 2 pitOut.lapNumber
                             , \_ -> Expect.equal pitDuration pitOut.duration
-                            , \_ -> Expect.equal 189575 pitOutTime
-                            , \_ -> Expect.equal pitOutTime (pitInTime + pitDuration)
+                            , \_ -> Expect.equal (Instant.fromDuration 189575) pitOutTime
+                            , \_ -> Expect.equal pitOutTime (Instant.add pitDuration pitInTime)
                             ]
                             ()
 
@@ -251,7 +252,7 @@ lapAt lapNumber elapsed =
         , driver = Driver.fromName "Test Driver"
         , lap = lapNumber
         , position = Just 1
-        , elapsed = elapsed
+        , elapsed = Instant.fromDuration elapsed
     }
 
 
@@ -300,7 +301,7 @@ tookLeadEvents cars =
             (\event ->
                 case event.eventType of
                     CarEvent carNumber TookLead ->
-                        Just ( event.eventTime, carNumber )
+                        Just ( Instant.toDuration event.eventTime, carNumber )
 
                     _ ->
                         Nothing

--- a/package/tests/Motorsport/RaceTest.elm
+++ b/package/tests/Motorsport/RaceTest.elm
@@ -3,6 +3,7 @@ module Motorsport.RaceTest exposing (suite)
 import Expect
 import Motorsport.Class as Class
 import Motorsport.Driver as Driver
+import Motorsport.Instant as Instant exposing (Instant)
 import Motorsport.Lap as Lap exposing (Lap)
 import Motorsport.Manufacturer exposing (Manufacturer(..))
 import Motorsport.Race as Race exposing (Race)
@@ -17,7 +18,7 @@ suite =
             [ test "reads zero before the race has begun" <|
                 \_ ->
                     [ -1, 0 ]
-                        |> List.map (\elapsed -> Race.lapCountAt { elapsed = elapsed } race)
+                        |> List.map (\elapsed -> Race.lapCountAt { elapsed = instant elapsed } race)
                         |> Expect.equal [ 0, 0 ]
             , test "goes up the moment the first car of the field crosses the line" <|
                 \_ ->
@@ -25,16 +26,16 @@ suite =
                     -- counter reads 1 from 90.000, not 100.000.
                     Expect.equal
                         ( 0, 1 )
-                        ( Race.lapCountAt { elapsed = 89999 } race
-                        , Race.lapCountAt { elapsed = 90000 } race
+                        ( Race.lapCountAt { elapsed = instant 89999 } race
+                        , Race.lapCountAt { elapsed = instant 90000 } race
                         )
             , test "holds the final count once the laps run out" <|
                 \_ ->
-                    Race.lapCountAt { elapsed = 99999999 } race
+                    Race.lapCountAt { elapsed = instant 99999999 } race
                         |> Expect.equal 3
             , test "a race with no cars is always on lap zero" <|
                 \_ ->
-                    Race.lapCountAt { elapsed = 500000 } Race.empty
+                    Race.lapCountAt { elapsed = instant 500000 } Race.empty
                         |> Expect.equal 0
             ]
         , describe "elapsedAtLapCount"
@@ -42,7 +43,7 @@ suite =
                 \_ ->
                     [ 0, 1, 2 ]
                         |> List.map (\lapCount -> Race.elapsedAtLapCount lapCount race)
-                        |> Expect.equal [ 89999, 199999, 299999 ]
+                        |> Expect.equal [ instant 89999, instant 199999, instant 299999 ]
             , test "round-trips through lapCountAt" <|
                 \_ ->
                     [ 0, 1, 2, 3 ]
@@ -52,20 +53,20 @@ suite =
                 \_ ->
                     -- Car 1 completes lap 3 at 300.000, and nobody goes further.
                     Race.elapsedAtLapCount 3 race
-                        |> Expect.equal 300000
+                        |> Expect.equal (instant 300000)
             , test "a count the race never reached lands at the start" <|
                 \_ ->
                     -- Total on its own: no caller has to have range-checked first.
                     [ Race.elapsedAtLapCount (-1) race
                     , Race.elapsedAtLapCount 0 Race.empty
                     ]
-                        |> Expect.equal [ 0, 0 ]
+                        |> Expect.equal [ Instant.raceStart, Instant.raceStart ]
             ]
         , describe "lapTotal"
             [ test "is the ceiling lapCountAt can actually reach" <|
                 \_ ->
                     -- Both come off lapCompletions, so they cannot disagree.
-                    Race.lapCountAt { elapsed = 99999999 } race
+                    Race.lapCountAt { elapsed = instant 99999999 } race
                         |> Expect.equal race.lapTotal
             ]
         ]
@@ -107,6 +108,14 @@ carWith carNumber laps =
     }
 
 
+{-| The fixtures are written in plain milliseconds and lifted to
+[`Instant`](Motorsport-Instant) here, so the numbers stay readable.
+-}
+instant : Int -> Instant
+instant =
+    Instant.fromDuration
+
+
 lapAt : CarNumber -> Int -> Int -> Lap
 lapAt carNumber lapNumber elapsed =
     let
@@ -118,5 +127,5 @@ lapAt carNumber lapNumber elapsed =
         , driver = Driver.fromName "Test Driver"
         , lap = lapNumber
         , position = Just 1
-        , elapsed = elapsed
+        , elapsed = instant elapsed
     }

--- a/package/tests/Motorsport/ReplayTest.elm
+++ b/package/tests/Motorsport/ReplayTest.elm
@@ -4,6 +4,7 @@ import Expect
 import Motorsport.Class as Class
 import Motorsport.Clock as Clock
 import Motorsport.Driver as Driver
+import Motorsport.Instant as Instant
 import Motorsport.Lap as Lap exposing (Lap)
 import Motorsport.Manufacturer exposing (Manufacturer(..))
 import Motorsport.Race.Car as Car exposing (Car, CarNumber)
@@ -135,14 +136,16 @@ playingAt elapsed =
         |> Replay.update (Replay.Tick (millisToPosix elapsed))
 
 
+{-| As plain milliseconds, which is what the expectations below are written in.
+-}
 elapsedOf : Replay.Model -> Int
 elapsedOf m =
-    Clock.getElapsed m.playback
+    Instant.toDuration (Clock.getElapsed m.playback)
 
 
 skipTo : Int -> Replay.Model -> Replay.Model
 skipTo elapsed m =
-    skipBy (elapsed - Clock.getElapsed m.playback) m
+    skipBy (elapsed - elapsedOf m) m
 
 
 skipBy : Int -> Replay.Model -> Replay.Model
@@ -189,7 +192,7 @@ lapAt carNumber lapNumber elapsed =
         , driver = Driver.fromName "Test Driver"
         , lap = lapNumber
         , position = Just 1
-        , elapsed = elapsed
+        , elapsed = Instant.fromDuration elapsed
     }
 
 

--- a/package/tests/Motorsport/ViewModel/StandingsTest.elm
+++ b/package/tests/Motorsport/ViewModel/StandingsTest.elm
@@ -5,6 +5,7 @@ import Motorsport.Class as Class
 import Motorsport.Driver as Driver
 import Motorsport.Duration exposing (Duration)
 import Motorsport.Gap as Gap exposing (Gap)
+import Motorsport.Instant as Instant
 import Motorsport.Lap as Lap exposing (Lap)
 import Motorsport.Lap.Performance exposing (PerformanceLevel(..))
 import Motorsport.Manufacturer as Manufacturer
@@ -147,7 +148,7 @@ sectorFixtureLap =
     { empty
         | lap = 1
         , time = 6000
-        , elapsed = 6000
+        , elapsed = Instant.fromDuration 6000
         , sectors =
             { s1 = { time = 1000, personalBest = 900 }
             , s2 = { time = 2000, personalBest = 1900 }
@@ -164,7 +165,7 @@ quickerLap =
     { empty
         | lap = 2
         , time = 5000
-        , elapsed = 11000
+        , elapsed = Instant.fromDuration 11000
     }
 
 

--- a/package/tests/Motorsport/ViewModel/StandingsTest.elm
+++ b/package/tests/Motorsport/ViewModel/StandingsTest.elm
@@ -30,9 +30,9 @@ suite =
                         |> Maybe.map Sector.toList
                         |> Expect.equal
                             (Just
-                                [ ( S1, { time = 1000, personalBest = 900 } )
-                                , ( S2, { time = 2000, personalBest = 1900 } )
-                                , ( S3, { time = 3000, personalBest = 2900 } )
+                                [ ( S1, { time = Just 1000, personalBest = Just 900 } )
+                                , ( S2, { time = Just 2000, personalBest = Just 1900 } )
+                                , ( S3, { time = Just 3000, personalBest = Just 2900 } )
                                 ]
                             )
             ]
@@ -147,12 +147,12 @@ sectorFixtureLap : Lap
 sectorFixtureLap =
     { empty
         | lap = 1
-        , time = 6000
+        , time = Just 6000
         , elapsed = Instant.fromDuration 6000
         , sectors =
-            { s1 = { time = 1000, personalBest = 900 }
-            , s2 = { time = 2000, personalBest = 1900 }
-            , s3 = { time = 3000, personalBest = 2900 }
+            { s1 = { time = Just 1000, personalBest = Just 900 }
+            , s2 = { time = Just 2000, personalBest = Just 1900 }
+            , s3 = { time = Just 3000, personalBest = Just 2900 }
             }
     }
 
@@ -164,7 +164,7 @@ quickerLap : Lap
 quickerLap =
     { empty
         | lap = 2
-        , time = 5000
+        , time = Just 5000
         , elapsed = Instant.fromDuration 11000
     }
 

--- a/package/tests/Motorsport/ViewModelTest.elm
+++ b/package/tests/Motorsport/ViewModelTest.elm
@@ -89,6 +89,6 @@ lapOf lapNumber time elapsed =
         , driver = Driver.fromName "Test Driver"
         , lap = lapNumber
         , position = Just 1
-        , time = time
+        , time = Just time
         , elapsed = Instant.fromDuration elapsed
     }

--- a/package/tests/Motorsport/ViewModelTest.elm
+++ b/package/tests/Motorsport/ViewModelTest.elm
@@ -24,11 +24,11 @@ suite =
             [ test "UpToElapsed draws it from the laps run so far" <|
                 \_ ->
                     fastestLapTimeAt 6000 UpToElapsed
-                        |> Expect.equal 6000
+                        |> Expect.equal (Just 6000)
             , test "WholeRace draws it from every lap, the ones ahead of the clock included" <|
                 \_ ->
                     fastestLapTimeAt 6000 WholeRace
-                        |> Expect.equal 5000
+                        |> Expect.equal (Just 5000)
             ]
         ]
 
@@ -38,7 +38,7 @@ suite =
 -- One car improving on itself: a 6.000 lap, then a 5.000 one.
 
 
-fastestLapTimeAt : Duration -> Scope -> Duration
+fastestLapTimeAt : Duration -> Scope -> Maybe Duration
 fastestLapTimeAt elapsed scope =
     replayAt elapsed
         |> ViewModel.compute scope

--- a/package/tests/Motorsport/ViewModelTest.elm
+++ b/package/tests/Motorsport/ViewModelTest.elm
@@ -6,6 +6,7 @@ import Motorsport.Class as Class
 import Motorsport.Clock as Clock
 import Motorsport.Driver as Driver
 import Motorsport.Duration exposing (Duration)
+import Motorsport.Instant as Instant
 import Motorsport.Lap as Lap exposing (Lap)
 import Motorsport.Manufacturer exposing (Manufacturer(..))
 import Motorsport.Race.Car exposing (Car)
@@ -56,7 +57,7 @@ replayAt elapsed =
         m =
             Replay.fromCars [ improvingCar ]
     in
-    { m | playback = Clock.setElapsed elapsed m.playback }
+    { m | playback = Clock.setElapsed (Instant.fromDuration elapsed) m.playback }
 
 
 improvingCar : Car
@@ -89,5 +90,5 @@ lapOf lapNumber time elapsed =
         , lap = lapNumber
         , position = Just 1
         , time = time
-        , elapsed = elapsed
+        , elapsed = Instant.fromDuration elapsed
     }

--- a/package/tests/elm-verify-examples.json
+++ b/package/tests/elm-verify-examples.json
@@ -6,6 +6,7 @@
     "Motorsport.Duration",
     "Motorsport.Gap",
     "Motorsport.Instant",
+    "Motorsport.Lap",
     "Motorsport.Sector"
   ]
 }

--- a/package/tests/elm-verify-examples.json
+++ b/package/tests/elm-verify-examples.json
@@ -1,3 +1,11 @@
 {
-  "tests": ["Motorsport.Class", "Motorsport.Class.Era", "Motorsport.Driver", "Motorsport.Duration", "Motorsport.Gap", "Motorsport.Sector"]
+  "tests": [
+    "Motorsport.Class",
+    "Motorsport.Class.Era",
+    "Motorsport.Driver",
+    "Motorsport.Duration",
+    "Motorsport.Gap",
+    "Motorsport.Instant",
+    "Motorsport.Sector"
+  ]
 }


### PR DESCRIPTION
## Summary

Introduces a new `Motorsport.Instant` module that creates a distinct type for moments in a race (measured from race start) versus `Duration` which represents lengths of time. This prevents type-unsafe operations like comparing lap times against lap completion times or adding two moments together.

## Key Changes

- **New `Instant` type** (`package/src/Motorsport/Instant.elm`): An opaque wrapper around milliseconds representing a moment in the race, with algebra that only allows meaningful operations:
  - `add`/`subtract` a duration to/from an instant → instant
  - `since` two instants → duration
  - Comparison and ordering operations (`compare`, `earlier`, `later`)
  - Conversion to/from `Duration` via `toDuration` and `fromDuration`

- **Updated `Lap` model**: 
  - `elapsed` field changed from `Duration` to `Instant` (when the lap was completed)
  - `time` and `best` fields changed from `Duration` to `Maybe Duration` (unrecorded times are `Nothing`, not `0`)
  - Sector times similarly use `Maybe Duration` for missing data

- **Updated `Race` and related modules**:
  - `timeLimit` changed from `Duration` to `Instant`
  - `Clock` state now uses `Instant` for elapsed time
  - `TimelineEvent.eventTime` changed to `Instant`
  - `BestTimes.Snapshot` and `ChangePoints` now work with `Instant` for temporal indexing

- **Updated `ViewModel` modules**:
  - `Standings` and related view models now use `Instant` for race moments
  - Proper handling of `Maybe Duration` for optional times throughout

- **Test updates**: All test fixtures updated to use `Instant.fromDuration` and `Maybe Duration` where appropriate

- **Rust CLI**: Improved duration parsing to read milliseconds as digits rather than through floating-point conversion, avoiding rounding errors

## Implementation Details

- The `Instant` type is opaque; the only way to construct one is via `raceStart`, `fromDuration`, or the JSON decoder
- Negative durations passed to `fromDuration` clamp to `raceStart` (no racing before the race starts)
- The `recorded` helper function converts zero-valued times from source data to `Nothing`, establishing the boundary where zeros stop being used as sentinels
- All temporal comparisons now use `Instant.compare` instead of `Basics.compare`, making the intent explicit
- `Maybe Duration` is used throughout for optional times, eliminating the ambiguity of whether a zero means "not recorded" or "very fast"