### PR TITLE
refactor(package): read the field at a moment in one pass, and let it be read back

### DIFF
--- a/app/src/Page/Debug.elm
+++ b/app/src/Page/Debug.elm
@@ -154,7 +154,7 @@ field `lastLapColumn` reads, not everything a
 type alias LapRow =
     { position : Int
     , metadata : Car.Metadata
-    , currentDriver : Maybe Driver
+    , currentDriver : Driver
     , lapsCompleted : Int
     , currentLapSectors : Maybe Lap.SectorTimes
     , lastLap : { rated : Maybe RatedTime }
@@ -180,7 +180,7 @@ lapRow bestTimes index lap =
         , team = ""
         , manufacturer = Motorsport.Manufacturer.Other
         }
-    , currentDriver = Just lap.driver
+    , currentDriver = lap.driver
     , lapsCompleted = lap.lap
     , currentLapSectors = Just lap.sectors
     , lastLap = { rated = Performance.rateTime fastestLapTime { time = lap.time, personalBest = lap.best } }

--- a/app/src/Page/Debug.elm
+++ b/app/src/Page/Debug.elm
@@ -146,7 +146,10 @@ view { replay } { leaderboardState } =
 
 
 {-| One row of this page is one lap of one car, not one car of the race. The
-leaderboard columns only ask for the fields they print, so a row is just those.
+leaderboard columns only ask for the fields they print, so a row is just those
+-- including the shape they ask for them in: `lastLap` here holds only the one
+field `lastLapColumn` reads, not everything a
+[`Snapshot.LastLap`](Motorsport-Race-Snapshot#LastLap) carries.
 -}
 type alias LapRow =
     { position : Int
@@ -154,7 +157,7 @@ type alias LapRow =
     , currentDriver : Maybe Driver
     , lapsCompleted : Int
     , currentLapSectors : Maybe Lap.SectorTimes
-    , lastLapRated : Maybe RatedTime
+    , lastLap : { rated : Maybe RatedTime }
     , bestLapRated : Maybe RatedTime
     }
 
@@ -180,7 +183,7 @@ lapRow bestTimes index lap =
     , currentDriver = Just lap.driver
     , lapsCompleted = lap.lap
     , currentLapSectors = Just lap.sectors
-    , lastLapRated = Performance.rateTime fastestLapTime { time = lap.time, personalBest = lap.best }
+    , lastLap = { rated = Performance.rateTime fastestLapTime { time = lap.time, personalBest = lap.best } }
     , bestLapRated = Performance.rateTime fastestLapTime { time = lap.best, personalBest = lap.best }
     }
 
@@ -198,7 +201,7 @@ config bestTimes =
             ++ sectorColumns bestTimes
             ++ [ lastLapColumn
                     { getter = identity
-                    , sorter = Compare.by (.lastLapRated >> Maybe.map .time >> Maybe.withDefault 0)
+                    , sorter = Compare.by (.lastLap >> .rated >> Maybe.map .time >> Maybe.withDefault 0)
                     }
                , bestTimeColumn { getter = .bestLapRated }
                ]

--- a/package/src/Motorsport/Chart/Tracker.elm
+++ b/package/src/Motorsport/Chart/Tracker.elm
@@ -351,8 +351,8 @@ renderCar direction car { angle, x, y } =
         [ g [ Attributes.transform [ Translate x y ] ]
             -- Lazy compares its arguments by reference equality (===). A Css.Color record is
             -- recreated on every compute, so pass a String, which compares by value.
-            [ Lazy.lazy2 carMarker car.positionInClass (Class.toColor car.metadata.class).value ]
-        , carLabel car.positionInClass { x = labelX, y = labelY } { carNumber = car.metadata.carNumber }
+            [ Lazy.lazy2 carMarker car.standing.positionInClass (Class.toColor car.metadata.class).value ]
+        , carLabel car.standing.positionInClass { x = labelX, y = labelY } { carNumber = car.metadata.carNumber }
         ]
 
 

--- a/package/src/Motorsport/Chart/Tracker/Config.elm
+++ b/package/src/Motorsport/Chart/Tracker/Config.elm
@@ -169,11 +169,11 @@ buildMiniSectors miniSectors sectorStart miniRatio =
 
 computeProgress : TrackConfig -> CarAt -> Float
 computeProgress config car =
-    if car.currentLapProgress > 0 then
-        car.currentLapProgress
+    if car.currentLap.progress > 0 then
+        car.currentLap.progress
 
     else
-        case ( car.sector, car.miniSector ) of
+        case ( car.currentLap.sector, car.currentLap.miniSector ) of
             ( _, Just miniSectorProgress ) ->
                 progressFromMiniSector config miniSectorProgress
 

--- a/package/src/Motorsport/Chart/Tracker/Config.elm
+++ b/package/src/Motorsport/Chart/Tracker/Config.elm
@@ -169,22 +169,16 @@ buildMiniSectors miniSectors sectorStart miniRatio =
 
 computeProgress : TrackConfig -> CarAt -> Float
 computeProgress config car =
-    case car.currentLap of
-        Nothing ->
-            -- Nowhere on the track, so the start line is as good as anywhere.
-            0
+    if car.currentLap.progress > 0 then
+        car.currentLap.progress
 
-        Just currentLap ->
-            if currentLap.progress > 0 then
-                currentLap.progress
+    else
+        case car.currentLap.miniSector of
+            Just miniSectorProgress ->
+                progressFromMiniSector config miniSectorProgress
 
-            else
-                case currentLap.miniSector of
-                    Just miniSectorProgress ->
-                        progressFromMiniSector config miniSectorProgress
-
-                    Nothing ->
-                        progressFromSector config currentLap.sector
+            Nothing ->
+                progressFromSector config car.currentLap.sector
 
 
 progressFromSector : List SectorConfig -> SectorProgress -> Float

--- a/package/src/Motorsport/Chart/Tracker/Config.elm
+++ b/package/src/Motorsport/Chart/Tracker/Config.elm
@@ -169,19 +169,22 @@ buildMiniSectors miniSectors sectorStart miniRatio =
 
 computeProgress : TrackConfig -> CarAt -> Float
 computeProgress config car =
-    if car.currentLap.progress > 0 then
-        car.currentLap.progress
+    case car.currentLap of
+        Nothing ->
+            -- Nowhere on the track, so the start line is as good as anywhere.
+            0
 
-    else
-        case ( car.currentLap.sector, car.currentLap.miniSector ) of
-            ( _, Just miniSectorProgress ) ->
-                progressFromMiniSector config miniSectorProgress
+        Just currentLap ->
+            if currentLap.progress > 0 then
+                currentLap.progress
 
-            ( Just sectorProgress, Nothing ) ->
-                progressFromSector config sectorProgress
+            else
+                case currentLap.miniSector of
+                    Just miniSectorProgress ->
+                        progressFromMiniSector config miniSectorProgress
 
-            ( Nothing, Nothing ) ->
-                0
+                    Nothing ->
+                        progressFromSector config currentLap.sector
 
 
 progressFromSector : List SectorConfig -> SectorProgress -> Float

--- a/package/src/Motorsport/Circuit/LeMans.elm
+++ b/package/src/Motorsport/Circuit/LeMans.elm
@@ -276,12 +276,9 @@ miniSectorDefaultRatio miniSector =
         |> Maybe.map .ratio
 
 
-{-| Order two mini-sectors by where they fall on the lap.
-
-The counterpart of [`Sector.compare`](Motorsport-Sector#compare), and there for
-the same reason: it is how a reading of one mini-sector is placed against the
-one the car is in -- behind it, in it, or still ahead of it.
-
+{-| Order two mini-sectors by where they fall on the lap. The counterpart of
+[`Sector.compare`](Motorsport-Sector#compare), and there for the same reason:
+placing a mini-sector against the one the car is in.
 -}
 compare : LeMans2025MiniSector -> LeMans2025MiniSector -> Order
 compare a b =

--- a/package/src/Motorsport/Circuit/LeMans.elm
+++ b/package/src/Motorsport/Circuit/LeMans.elm
@@ -1,7 +1,7 @@
 module Motorsport.Circuit.LeMans exposing
     ( LeMans2025MiniSector(..)
     , ByMiniSector, initialize, get, map2, values
-    , calculateMiniSectorProgress
+    , compare
     , layout, miniSectorDefaultRatio, miniSectorOrder, miniSectorToString
     )
 
@@ -14,7 +14,7 @@ module Motorsport.Circuit.LeMans exposing
 
 @docs ByMiniSector, initialize, get, map2, values
 
-@docs calculateMiniSectorProgress
+@docs compare
 
 -}
 
@@ -276,73 +276,20 @@ miniSectorDefaultRatio miniSector =
         |> Maybe.map .ratio
 
 
-calculateMiniSectorProgress :
-    Maybe { miniSector : LeMans2025MiniSector, progress : Float }
-    ->
-        { scl2 : Float
-        , z4 : Float
-        , ip1 : Float
-        , z12 : Float
-        , sclc : Float
-        , a7_1 : Float
-        , ip2 : Float
-        , a8_1 : Float
-        , sclb : Float
-        , porin : Float
-        , porout : Float
-        , pitref : Float
-        , scl1 : Float
-        , fordout : Float
-        , fl : Float
-        }
-calculateMiniSectorProgress maybeCurrentMiniSector =
-    case maybeCurrentMiniSector of
-        Nothing ->
-            { scl2 = 0, z4 = 0, ip1 = 0, z12 = 0, sclc = 0, a7_1 = 0, ip2 = 0, a8_1 = 0, sclb = 0, porin = 0, porout = 0, pitref = 0, scl1 = 0, fordout = 0, fl = 0 }
+{-| Order two mini-sectors by where they fall on the lap.
 
-        Just { miniSector, progress } ->
-            case miniSector of
-                SCL2 ->
-                    { scl2 = progress, z4 = 0, ip1 = 0, z12 = 0, sclc = 0, a7_1 = 0, ip2 = 0, a8_1 = 0, sclb = 0, porin = 0, porout = 0, pitref = 0, scl1 = 0, fordout = 0, fl = 0 }
+The counterpart of [`Sector.compare`](Motorsport-Sector#compare), and there for
+the same reason: it is how a reading of one mini-sector is placed against the
+one the car is in -- behind it, in it, or still ahead of it.
 
-                Z4 ->
-                    { scl2 = 1, z4 = progress, ip1 = 0, z12 = 0, sclc = 0, a7_1 = 0, ip2 = 0, a8_1 = 0, sclb = 0, porin = 0, porout = 0, pitref = 0, scl1 = 0, fordout = 0, fl = 0 }
+-}
+compare : LeMans2025MiniSector -> LeMans2025MiniSector -> Order
+compare a b =
+    Basics.compare (toIndex a) (toIndex b)
 
-                IP1 ->
-                    { scl2 = 1, z4 = 1, ip1 = progress, z12 = 0, sclc = 0, a7_1 = 0, ip2 = 0, a8_1 = 0, sclb = 0, porin = 0, porout = 0, pitref = 0, scl1 = 0, fordout = 0, fl = 0 }
 
-                Z12 ->
-                    { scl2 = 1, z4 = 1, ip1 = 1, z12 = progress, sclc = 0, a7_1 = 0, ip2 = 0, a8_1 = 0, sclb = 0, porin = 0, porout = 0, pitref = 0, scl1 = 0, fordout = 0, fl = 0 }
-
-                SCLC ->
-                    { scl2 = 1, z4 = 1, ip1 = 1, z12 = 1, sclc = progress, a7_1 = 0, ip2 = 0, a8_1 = 0, sclb = 0, porin = 0, porout = 0, pitref = 0, scl1 = 0, fordout = 0, fl = 0 }
-
-                A7_1 ->
-                    { scl2 = 1, z4 = 1, ip1 = 1, z12 = 1, sclc = 1, a7_1 = progress, ip2 = 0, a8_1 = 0, sclb = 0, porin = 0, porout = 0, pitref = 0, scl1 = 0, fordout = 0, fl = 0 }
-
-                IP2 ->
-                    { scl2 = 1, z4 = 1, ip1 = 1, z12 = 1, sclc = 1, a7_1 = 1, ip2 = progress, a8_1 = 0, sclb = 0, porin = 0, porout = 0, pitref = 0, scl1 = 0, fordout = 0, fl = 0 }
-
-                A8_1 ->
-                    { scl2 = 1, z4 = 1, ip1 = 1, z12 = 1, sclc = 1, a7_1 = 1, ip2 = 1, a8_1 = progress, sclb = 0, porin = 0, porout = 0, pitref = 0, scl1 = 0, fordout = 0, fl = 0 }
-
-                SCLB ->
-                    { scl2 = 1, z4 = 1, ip1 = 1, z12 = 1, sclc = 1, a7_1 = 1, ip2 = 1, a8_1 = 1, sclb = progress, porin = 0, porout = 0, pitref = 0, scl1 = 0, fordout = 0, fl = 0 }
-
-                PORIN ->
-                    { scl2 = 1, z4 = 1, ip1 = 1, z12 = 1, sclc = 1, a7_1 = 1, ip2 = 1, a8_1 = 1, sclb = 1, porin = progress, porout = 0, pitref = 0, scl1 = 0, fordout = 0, fl = 0 }
-
-                POROUT ->
-                    { scl2 = 1, z4 = 1, ip1 = 1, z12 = 1, sclc = 1, a7_1 = 1, ip2 = 1, a8_1 = 1, sclb = 1, porin = 1, porout = progress, pitref = 0, scl1 = 0, fordout = 0, fl = 0 }
-
-                PITREF ->
-                    { scl2 = 1, z4 = 1, ip1 = 1, z12 = 1, sclc = 1, a7_1 = 1, ip2 = 1, a8_1 = 1, sclb = 1, porin = 1, porout = 1, pitref = progress, scl1 = 0, fordout = 0, fl = 0 }
-
-                SCL1 ->
-                    { scl2 = 1, z4 = 1, ip1 = 1, z12 = 1, sclc = 1, a7_1 = 1, ip2 = 1, a8_1 = 1, sclb = 1, porin = 1, porout = 1, pitref = 1, scl1 = progress, fordout = 0, fl = 0 }
-
-                FORDOUT ->
-                    { scl2 = 1, z4 = 1, ip1 = 1, z12 = 1, sclc = 1, a7_1 = 1, ip2 = 1, a8_1 = 1, sclb = 1, porin = 1, porout = 1, pitref = 1, scl1 = 1, fordout = progress, fl = 0 }
-
-                FL ->
-                    { scl2 = 1, z4 = 1, ip1 = 1, z12 = 1, sclc = 1, a7_1 = 1, ip2 = 1, a8_1 = 1, sclb = 1, porin = 1, porout = 1, pitref = 1, scl1 = 1, fordout = 1, fl = progress }
+toIndex : LeMans2025MiniSector -> Int
+toIndex mini =
+    miniSectorOrder
+        |> List.Extra.elemIndex mini
+        |> Maybe.withDefault 0

--- a/package/src/Motorsport/Gap.elm
+++ b/package/src/Motorsport/Gap.elm
@@ -104,9 +104,9 @@ type alias Clock =
 car state is the only one in the app; measuring a gap needs nothing else from
 it.
 
-The lap in progress is a lap, not a `Maybe` of one: a car that is not driving
-one is not racing anybody, and [`Race.Snapshot`](Motorsport-Race-Snapshot) keeps
-such a car out of the field it measures.
+The lap in progress is a lap, not a `Maybe` of one: a car not driving one is
+racing nobody, and [`Race.Snapshot`](Motorsport-Race-Snapshot) keeps it out of
+the field.
 
 -}
 type alias Competitor a =

--- a/package/src/Motorsport/Gap.elm
+++ b/package/src/Motorsport/Gap.elm
@@ -100,12 +100,17 @@ type alias Clock =
 -- MEASURING A GAP
 
 
-{-| Whatever carries a lap history and a lap in progress. The standings' own
+{-| Whatever carries a lap history and a lap it is driving. The standings' own
 car state is the only one in the app; measuring a gap needs nothing else from
 it.
+
+The lap in progress is a lap, not a `Maybe` of one: a car that is not driving
+one is not racing anybody, and [`Race.Snapshot`](Motorsport-Race-Snapshot) keeps
+such a car out of the field it measures.
+
 -}
 type alias Competitor a =
-    { a | currentLap : Maybe Lap, laps : List Lap }
+    { a | currentLap : Lap, laps : List Lap }
 
 
 {-| The gap between two cars at a moment of the race, seen from the car behind.
@@ -140,26 +145,19 @@ lapsBetween : Clock -> { ahead : Competitor a, behind : Competitor b } -> Int
 lapsBetween clock { ahead, behind } =
     let
         currentSector =
-            Maybe.map (Lap.currentSector clock) behind.currentLap
+            Lap.currentSector clock behind.currentLap
 
         hasComeBackRound =
-            Maybe.map3
-                (\sector aheadLap behindLap ->
-                    Instant.compare (Lap.sectorStart sector aheadLap) (Lap.sectorStart sector behindLap) == LT
-                )
-                currentSector
-                ahead.currentLap
-                behind.currentLap
-                |> Maybe.withDefault False
+            Instant.compare
+                (Lap.sectorStart currentSector ahead.currentLap)
+                (Lap.sectorStart currentSector behind.currentLap)
+                == LT
     in
-    case Maybe.map2 (\aheadLap behindLap -> aheadLap.lap - behindLap.lap) ahead.currentLap behind.currentLap of
-        Nothing ->
+    case ahead.currentLap.lap - behind.currentLap.lap of
+        0 ->
             0
 
-        Just 0 ->
-            0
-
-        Just lapDiff ->
+        lapDiff ->
             if hasComeBackRound then
                 lapDiff
 
@@ -180,27 +178,25 @@ between the cars.
 -}
 secondsBetween : Clock -> { ahead : Competitor a, behind : Competitor b } -> Gap
 secondsBetween clock { ahead, behind } =
-    case behind.currentLap of
-        Just behindLap ->
-            let
-                currentSector =
-                    Lap.currentSector clock behindLap
-            in
-            ahead.laps
-                |> List.Extra.find (\lap -> lap.lap == behindLap.lap)
-                |> Maybe.map
-                    (\aheadLap ->
-                        seconds
-                            (Instant.since
-                                { from = Lap.sectorStart currentSector aheadLap
-                                , to = Lap.sectorStart currentSector behindLap
-                                }
-                            )
-                    )
-                |> Maybe.withDefault none
+    let
+        behindLap =
+            behind.currentLap
 
-        Nothing ->
-            none
+        currentSector =
+            Lap.currentSector clock behindLap
+    in
+    ahead.laps
+        |> List.Extra.find (\lap -> lap.lap == behindLap.lap)
+        |> Maybe.map
+            (\aheadLap ->
+                seconds
+                    (Instant.since
+                        { from = Lap.sectorStart currentSector aheadLap
+                        , to = Lap.sectorStart currentSector behindLap
+                        }
+                    )
+            )
+        |> Maybe.withDefault none
 
 
 

--- a/package/src/Motorsport/Lap/Performance.elm
+++ b/package/src/Motorsport/Lap/Performance.elm
@@ -95,12 +95,12 @@ type alias MiniSectorPerformance =
 ofMiniSectors : BestTimes.Snapshot -> Lap -> Maybe MiniSectorPerformance
 ofMiniSectors bestTimes lap =
     let
-        rate miniSector fastest =
+        rateOne miniSector fastest =
             rateTime (BestTimes.timeOf fastest)
                 { time = miniSector.time, personalBest = miniSector.best }
     in
     lap.miniSectors
-        |> Maybe.map (\ms -> LeMans.map2 rate ms bestTimes.fastestMiniSectors)
+        |> Maybe.map (\ms -> LeMans.map2 rateOne ms bestTimes.fastestMiniSectors)
 
 
 

--- a/package/src/Motorsport/Lap/Performance.elm
+++ b/package/src/Motorsport/Lap/Performance.elm
@@ -1,5 +1,5 @@
 module Motorsport.Lap.Performance exposing
-    ( RatedTime, rate, rateTime
+    ( RatedTime, rateTime
     , SectorPerformance, ofSectors
     , MiniSectorPerformance, ofMiniSectors
     , PerformanceLevel(..), performanceLevel
@@ -17,7 +17,7 @@ lap and the record alone, so [`Race.Snapshot`](Motorsport-Race-Snapshot) reads i
 as part of the race; but nothing in the race changes when it is read, so the view
 is free to rate a lap of its own.
 
-@docs RatedTime, rate, rateTime
+@docs RatedTime, rateTime
 @docs SectorPerformance, ofSectors
 @docs MiniSectorPerformance, ofMiniSectors
 
@@ -40,30 +40,27 @@ type alias RatedTime =
     }
 
 
-{-| Rate a time against the race's record and the car's own.
+{-| Rate a time against the race's record and the car's own, where there is a
+time to rate. A time the source data did not record produces no rating rather
+than an uncoloured one, so a caller renders the same "-" it renders for a car
+with no lap at all.
 
-For a time that is certainly there -- a running lap's elapsed time is read off
-the clock, so there is always one. A time out of the source data may not have
-been recorded, and takes [`rateTime`](#rateTime) instead.
+A time that is certainly there -- a running lap's, read off the clock -- wants
+[`performanceLevel`](#performanceLevel) instead, and keeps the time under
+whatever name it already has.
 
--}
-rate : Maybe Duration -> { time : Duration, personalBest : Maybe Duration } -> RatedTime
-rate fastest { time, personalBest } =
-    { time = time
-    , performance =
-        performanceLevel { time = time, personalBest = personalBest, fastest = fastest }
-    }
-
-
-{-| Rate a time where there is a time to rate. A time the source data did not
-record produces no rating rather than an uncoloured one, so a caller renders the
-same "-" it renders for a car with no lap at all.
 -}
 rateTime : Maybe Duration -> { time : Maybe Duration, personalBest : Maybe Duration } -> Maybe RatedTime
 rateTime fastest { time, personalBest } =
     time
         |> Maybe.map
-            (\recordedTime -> rate fastest { time = recordedTime, personalBest = personalBest })
+            (\recordedTime ->
+                { time = recordedTime
+                , performance =
+                    performanceLevel
+                        { time = recordedTime, personalBest = personalBest, fastest = fastest }
+                }
+            )
 
 
 {-| A lap's sector times, each rated.

--- a/package/src/Motorsport/Lap/Performance.elm
+++ b/package/src/Motorsport/Lap/Performance.elm
@@ -1,5 +1,5 @@
 module Motorsport.Lap.Performance exposing
-    ( RatedTime, rateTime
+    ( RatedTime, rate, rateTime
     , SectorPerformance, ofSectors
     , MiniSectorPerformance, ofMiniSectors
     , PerformanceLevel(..), performanceLevel
@@ -17,7 +17,7 @@ lap and the record alone, so [`Race.Snapshot`](Motorsport-Race-Snapshot) reads i
 as part of the race; but nothing in the race changes when it is read, so the view
 is free to rate a lap of its own.
 
-@docs RatedTime, rateTime
+@docs RatedTime, rate, rateTime
 @docs SectorPerformance, ofSectors
 @docs MiniSectorPerformance, ofMiniSectors
 
@@ -40,22 +40,30 @@ type alias RatedTime =
     }
 
 
-{-| Rate a time against the race's record and the car's own, where there is a
-time to rate. A time the source data did not record produces no rating rather
-than an uncoloured one, so a caller renders the same "-" it renders for a car
-with no lap at all.
+{-| Rate a time against the race's record and the car's own.
+
+For a time that is certainly there -- a running lap's elapsed time is read off
+the clock, so there is always one. A time out of the source data may not have
+been recorded, and takes [`rateTime`](#rateTime) instead.
+
+-}
+rate : Maybe Duration -> { time : Duration, personalBest : Maybe Duration } -> RatedTime
+rate fastest { time, personalBest } =
+    { time = time
+    , performance =
+        performanceLevel { time = time, personalBest = personalBest, fastest = fastest }
+    }
+
+
+{-| Rate a time where there is a time to rate. A time the source data did not
+record produces no rating rather than an uncoloured one, so a caller renders the
+same "-" it renders for a car with no lap at all.
 -}
 rateTime : Maybe Duration -> { time : Maybe Duration, personalBest : Maybe Duration } -> Maybe RatedTime
 rateTime fastest { time, personalBest } =
     time
         |> Maybe.map
-            (\recordedTime ->
-                { time = recordedTime
-                , performance =
-                    performanceLevel
-                        { time = recordedTime, personalBest = personalBest, fastest = fastest }
-                }
-            )
+            (\recordedTime -> rate fastest { time = recordedTime, personalBest = personalBest })
 
 
 {-| A lap's sector times, each rated.

--- a/package/src/Motorsport/Ordering.elm
+++ b/package/src/Motorsport/Ordering.elm
@@ -30,10 +30,13 @@ import SortedList exposing (SortedList)
 
 {-| Sort cars into the order they are running in at a moment of the race.
 
-This carries the domain rule: a car with a lap in progress is ahead of one
-without, and between two cars that are both running, `Lap.compareAt` decides --
-by lap number, then sector, then mini-sector, then elapsed time within the
-current sector.
+This carries the domain rule, which is `Lap.compareAt`'s: by lap number, then
+sector, then mini-sector, then elapsed time within the current sector.
+
+Every car handed here is driving a lap. A car that is not is not in a running
+order at all -- there is no answer to where it stands -- so it is
+[`Race.Snapshot`](Motorsport-Race-Snapshot)'s to leave out before it gets
+here.
 
 The result is a plain list, not a `SortedList`: the caller's next move is to
 number the cars off, and it is that number `byPosition` guards.
@@ -42,31 +45,9 @@ number the cars off, and it is that number `byPosition` guards.
     -- The leader first, then the rest in the order they are running
 
 -}
-runningOrder : { elapsed : Instant } -> List { a | currentLap : Maybe Lap } -> List { a | currentLap : Maybe Lap }
+runningOrder : { elapsed : Instant } -> List { a | currentLap : Lap } -> List { a | currentLap : Lap }
 runningOrder clock =
-    List.sortWith (compareOnTrack clock)
-
-
-compareOnTrack :
-    { elapsed : Instant }
-    -> { a | currentLap : Maybe Lap }
-    -> { a | currentLap : Maybe Lap }
-    -> Order
-compareOnTrack clock a b =
-    case ( a.currentLap, b.currentLap ) of
-        ( Just lapA, Just lapB ) ->
-            Lap.compareAt clock lapA lapB
-
-        ( Just _, Nothing ) ->
-            LT
-
-        ( Nothing, Just _ ) ->
-            GT
-
-        ( Nothing, Nothing ) ->
-            -- Ordering between two cars without lap data is undefined.
-            -- List.sortWith is stable, so their relative order from the input list is preserved.
-            EQ
+    List.sortWith (\a b -> Lap.compareAt clock a.currentLap b.currentLap)
 
 
 {-| Phantom type marking a list as ordered by racing position.

--- a/package/src/Motorsport/Ordering.elm
+++ b/package/src/Motorsport/Ordering.elm
@@ -76,7 +76,11 @@ type ByPosition
 
 
 {-| Sort by the position each item has already been given.
+
+Takes the position rather than reading a field off the item, so that where the
+caller keeps that number is the caller's business.
+
 -}
-byPosition : List { a | position : Int } -> SortedList ByPosition { a | position : Int }
-byPosition items =
-    SortedList.sortBy (Compare.by .position) items
+byPosition : (a -> Int) -> List a -> SortedList ByPosition a
+byPosition toPosition items =
+    SortedList.sortBy (Compare.by toPosition) items

--- a/package/src/Motorsport/Ordering.elm
+++ b/package/src/Motorsport/Ordering.elm
@@ -33,10 +33,9 @@ import SortedList exposing (SortedList)
 This carries the domain rule, which is `Lap.compareAt`'s: by lap number, then
 sector, then mini-sector, then elapsed time within the current sector.
 
-Every car handed here is driving a lap. A car that is not is not in a running
-order at all -- there is no answer to where it stands -- so it is
-[`Race.Snapshot`](Motorsport-Race-Snapshot)'s to leave out before it gets
-here.
+Every car handed here is driving a lap; a car that is not holds no place in a
+running order, and [`Race.Snapshot`](Motorsport-Race-Snapshot) leaves it out
+before it gets here.
 
 The result is a plain list, not a `SortedList`: the caller's next move is to
 number the cars off, and it is that number `byPosition` guards.

--- a/package/src/Motorsport/Race/Snapshot.elm
+++ b/package/src/Motorsport/Race/Snapshot.elm
@@ -47,7 +47,7 @@ import Motorsport.Duration exposing (Duration)
 import Motorsport.Gap as Gap exposing (Gap)
 import Motorsport.Instant as Instant exposing (Instant)
 import Motorsport.Lap as Lap exposing (Lap)
-import Motorsport.Lap.Performance as Performance exposing (MiniSectorPerformance, RatedTime, SectorPerformance)
+import Motorsport.Lap.Performance as Performance exposing (MiniSectorPerformance, PerformanceLevel, RatedTime, SectorPerformance)
 import Motorsport.Ordering as Ordering exposing (ByPosition)
 import Motorsport.Race as Race exposing (Race)
 import Motorsport.Race.Car as Car exposing (Car, CarNumber)
@@ -102,7 +102,7 @@ car is stays at the top, and so does `bestLap`, for the reason below.
 
 Grouping the two laps apart is by which lap the reading came off, which cuts
 across the other question one can ask of these fields: whether the reading is a
-position or a rating. Every rating here -- `currentLap.rated`,
+position or a rating. Every rating here -- `currentLap.performance`,
 `currentLap.sectorStates`, `currentLap.miniSectorStates`, `lastLap.rated`,
 `lastLap.sectors`, `lastLap.miniSectors` and `bestLap` -- is measured against
 the records held at this moment rather than the ones the race ends on, and the
@@ -162,21 +162,16 @@ has retired or taken the flag still reads the last lap it ran.
 
 `elapsed` is how long the car has been on it, counted from the last time it
 crossed the line -- or from the race start, for a car still on its opening lap.
+`performance` is how that reads against the records, and `progress` is how far
+through the lap it puts the car. Nothing here is the lap's eventual time, which
+is the one figure of a lap in progress that the clock has not reached: what a
+caller wants of it is `progress`, so `progress` is what it is kept for.
 
-`time` is the source data's, and the source data runs to the end of the race: it
-is what the lap will have taken once it is over, not anything the clock has
-reached. Nothing here cuts it -- `progress` is `elapsed` measured against it,
-which is a use of the future figure rather than a guard on it -- so a view that
-shows `time` has to do the cutting itself. It is the only field here that runs
-ahead of the clock.
-
-`progress`, `sector` and `miniSector` say how far around the car has got, read
-off the clock and the lap's own times, so they say where the car is rather than
-how anything is drawn. `sectorStates` and `miniSectorStates` say as much of
-every sector and every mini-sector at once -- how much of each is behind the car
-and how it rates -- which is what a strip of cells is drawn from. They are cut
-at the clock already, so a view draws them without asking what the car has
-reached.
+`sector` and `miniSector` say where on the lap the car has got to.
+`sectorStates` and `miniSectorStates` say as much of every sector and every
+mini-sector at once -- how much of each is behind the car and how it rates --
+which is what a strip of cells is drawn from. All of it is cut at the clock, so
+a view draws it without asking what the car has reached.
 
 The two mini-sector readings are what remains `Maybe` here, and for a reason of
 their own: a lap with no mini-sector times has none to be in or to rate, and
@@ -184,15 +179,14 @@ away from Le Mans no lap has any. `miniSector` is also `Nothing` for a clock
 past the last mini-sector of the lap, which is in none of them -- the same
 lap-is-over reading that fills `miniSectorStates` in.
 
-What `rated`, `sectorStates` and `miniSectorStates` are rated against is
+What `performance`, `sectorStates` and `miniSectorStates` are rated against is
 [`CarAt`](#CarAt)'s to say, along with every other rating on a car.
 
 -}
 type alias CurrentLap =
-    { time : Maybe Duration
-    , elapsed : Duration
+    { elapsed : Duration
     , progress : Float
-    , rated : RatedTime
+    , performance : PerformanceLevel
     , sector : Lap.SectorProgress
     , sectorStates : CurrentSectorStates
     , miniSector : Maybe Lap.MiniSectorProgress
@@ -527,15 +521,21 @@ readCurrentLap frame lap =
         miniSector =
             Lap.miniSectorProgressAt frame.clock { current = lap, previous = frame.previousLap }
     in
-    { time = lap.time
-    , elapsed = frame.elapsed
+    { elapsed = frame.elapsed
     , progress =
+        -- Against the lap's eventual time, which is the one figure of this lap
+        -- the clock has not reached. It stays inside: what a caller wants of
+        -- it is how far round the car has got, not the answer it is measured
+        -- against.
         lap.time
             |> Maybe.map (\lapTime -> min 1.0 (toFloat frame.elapsed / toFloat lapTime))
             |> Maybe.withDefault 0
-    , rated =
-        Performance.rate frame.fastestLapTime
-            { time = frame.elapsed, personalBest = frame.personalBest }
+    , performance =
+        Performance.performanceLevel
+            { time = frame.elapsed
+            , personalBest = frame.personalBest
+            , fastest = frame.fastestLapTime
+            }
     , sector = sector
     , sectorStates = currentSectorStates sector (Performance.ofSectors frame.records lap)
     , miniSector = miniSector
@@ -648,8 +648,8 @@ readCarAt frame placed =
         -- itself. A car on its opening lap has no record yet, which is what
         -- `Nothing` says here.
         --
-        -- Read once: both the baseline `currentLap.rated` is rated against and
-        -- `bestLap` come off this, so the two cannot come apart.
+        -- Read once: both the baseline `currentLap.performance` is read against
+        -- and `bestLap` come off this, so the two cannot come apart.
         personalBest =
             car.lastLap |> Maybe.andThen .best
     in

--- a/package/src/Motorsport/Race/Snapshot.elm
+++ b/package/src/Motorsport/Race/Snapshot.elm
@@ -122,7 +122,7 @@ type alias CarAt =
     , status : Status
     , currentDriver : Maybe Driver
     , standing : Standing
-    , currentLap : Maybe CurrentLap
+    , currentLap : CurrentLap
     , lastLap : LastLap
     , bestLap : Maybe RatedTime
     }
@@ -154,11 +154,10 @@ type alias Standing =
 
 {-| The lap the car is on, as it reads at this moment.
 
-Held as a `Maybe` on [`CarAt`](#CarAt) rather than field by field, because
-whether the car is on a lap at all is one question and it is asked there once. A
-car that has turned no lap has none of this; a car that has finished one keeps
-it, since a lap stays the car's current one until the next begins, so a car that
-has retired or taken the flag still reads the last lap it ran.
+Every car of a [`Snapshot`](#Snapshot) has one, because a car that has turned no
+lap is not in the field at all -- see [`at`](#at). A car that has finished a lap
+keeps it, since a lap stays the car's current one until the next begins, so a
+car that has retired or taken the flag still reads the last lap it ran.
 
 `elapsed` is how long the car has been on it, counted from the last time it
 crossed the line -- or from the race start, for a car still on its opening lap.
@@ -249,10 +248,11 @@ at clock race =
 
         -- A car carries only its laps, so what it is doing at this moment is
         -- read off the clock here. Who is ahead of whom follows from that, and
-        -- every position below is read off the resulting order.
+        -- every position below is read off the resulting order. A car with no
+        -- lap in progress drops out; see `sampleCar`.
         sampled =
             race.cars
-                |> List.map (sampleCar clock race)
+                |> List.filterMap (sampleCar clock race)
                 |> Ordering.runningOrder clock
 
         cars =
@@ -445,25 +445,46 @@ The status is looked up rather than worked out here; see
 type alias SampledCar =
     Gap.Competitor
         { metadata : Car.Metadata
+        , lapInProgress : Lap
         , lastLap : Maybe Lap
         , status : Status
         , currentDriver : Maybe Driver
         }
 
 
-sampleCar : { elapsed : Instant } -> Race -> Car -> SampledCar
+{-| Read a car at the clock, where it is running.
+
+`Nothing` for a car with no lap in progress, which is a car that has turned no
+lap at all: a lap stays the car's current one until the next begins, so a car
+that has retired or taken the flag still has one. Such a car is not in the
+field. It holds no place in a running order --
+[`Ordering.runningOrder`](Motorsport-Ordering#runningOrder) says as much of two
+of them -- and there is nothing to report of it but its number.
+
+Nor can the data produce one. The loader builds the entry list out of the lap
+records themselves, so a car that completed no lap is in neither of the files
+the app reads; keeping it out here is what lets a [`CarAt`](#CarAt) carry its
+lap plainly rather than as a `Maybe` no race could fill.
+
+`lapInProgress` is that lap, and `currentLap` is the same lap in the shape
+[`Gap.Competitor`](Motorsport-Gap#Competitor) and the ordering read it in. The
+`Maybe` is theirs, not this module's.
+
+-}
+sampleCar : { elapsed : Instant } -> Race -> Car -> Maybe SampledCar
 sampleCar clock race car =
-    let
-        currentLap =
-            Lap.findCurrentLap clock car.laps
-    in
-    { metadata = car.metadata
-    , laps = car.laps
-    , currentLap = currentLap
-    , lastLap = Lap.findLastLapAt clock car.laps
-    , status = Race.statusAt clock car.metadata.carNumber race
-    , currentDriver = Maybe.map .driver currentLap
-    }
+    Lap.findCurrentLap clock car.laps
+        |> Maybe.map
+            (\lap ->
+                { metadata = car.metadata
+                , laps = car.laps
+                , currentLap = Just lap
+                , lapInProgress = lap
+                , lastLap = Lap.findLastLapAt clock car.laps
+                , status = Race.statusAt clock car.metadata.carNumber race
+                , currentDriver = Just lap.driver
+                }
+            )
 
 
 type alias Timing =
@@ -664,17 +685,15 @@ readCarAt frame placed =
         , intervalToAhead = timing.intervalToAhead
         }
     , currentLap =
-        car.currentLap
-            |> Maybe.map
-                (readCurrentLap
-                    { clock = { elapsed = frame.raceElapsed }
-                    , records = frame.records
-                    , fastestLapTime = frame.fastestLapTime
-                    , personalBest = personalBest
-                    , elapsed = timing.currentLapElapsed
-                    , previousLap = Maybe.withDefault Lap.empty car.lastLap
-                    }
-                )
+        readCurrentLap
+            { clock = { elapsed = frame.raceElapsed }
+            , records = frame.records
+            , fastestLapTime = frame.fastestLapTime
+            , personalBest = personalBest
+            , elapsed = timing.currentLapElapsed
+            , previousLap = Maybe.withDefault Lap.empty car.lastLap
+            }
+            car.lapInProgress
     , lastLap =
         { rated =
             car.lastLap

--- a/package/src/Motorsport/Race/Snapshot.elm
+++ b/package/src/Motorsport/Race/Snapshot.elm
@@ -155,11 +155,13 @@ crossed the line -- or from the race start, for a car still on its opening lap.
 It is the only lap time here the clock has actually reached.
 
 `time` and `miniSectors` are the source data's, and the source data runs to the
-end of the race: they are this lap's eventual time and its full set of
-mini-sector times, including the parts of the lap the car has not driven yet.
-Read either one against `progress` -- as the views that paint a mini-sector do,
-drawing only what is behind the car -- or it will answer a question about the
-future. Nothing else here runs ahead of the clock.
+end of the race: `time` is what the lap will have taken once it is over, and
+`miniSectors` carries every mini-sector time of it, the ones the car has not
+reached included. Neither is cut at the clock, and nothing here cuts them --
+`progress` is `elapsed` measured against `time`, which is a use of the future
+figure rather than a guard on it. A view that shows either has to do the cutting
+itself, as the mini-sector strip does by filling each cell only as far as
+`miniSector` says the car has got. Nothing else here runs ahead of the clock.
 
 `progress`, `sector` and `miniSector` say how far around the car has got. All
 three come off the clock and the lap's own times, so they say where the car is,
@@ -602,6 +604,9 @@ readCarAt frame placed =
         , sector = timing.sector
         , miniSector = timing.miniSector
         , rated =
+            -- On the lap for its presence alone, which is why the lap itself
+            -- goes unread: there is a running time to rate only while the car
+            -- is on a lap, and that time is the clock's, not the lap's.
             car.currentLap
                 |> Maybe.andThen
                     (\_ ->

--- a/package/src/Motorsport/Race/Snapshot.elm
+++ b/package/src/Motorsport/Race/Snapshot.elm
@@ -1,5 +1,5 @@
 module Motorsport.Race.Snapshot exposing
-    ( Snapshot, CarAt, CurrentSectorStates
+    ( Snapshot, CarAt, CurrentLap, LastLap, CurrentSectorStates
     , at
     , toList, toClassList, get, inClass, leader, lapCount, elapsed
     , bestTimes, lapHistory
@@ -29,7 +29,7 @@ Reading one car or one class out of the field is the snapshot's own business --
 `get` and `inClass` below -- so that a view narrowing the field does not have to
 scan `toList` for it.
 
-@docs Snapshot, CarAt, CurrentSectorStates
+@docs Snapshot, CarAt, CurrentLap, LastLap, CurrentSectorStates
 @docs at
 @docs toList, toClassList, get, inClass, leader, lapCount, elapsed
 @docs bestTimes, lapHistory
@@ -89,8 +89,13 @@ Readings only -- no laps of any kind. The whole list runs to the end of the
 race, and handing it out beside values that stop at the clock is how future data
 gets read by accident; the laps up to this moment are
 [`lapHistory`](#lapHistory)'s to give out, already cut. A lap the car has
-already turned is here as what was read off it -- `lapsCompleted`,
-`lastLapRated`, `lastLapSectors` -- rather than as the lap itself.
+already turned is here as what was read off it -- `lapsCompleted`, and
+[`lastLap`](#LastLap) -- rather than as the lap itself.
+
+What is read off the lap in progress and off the one just finished is grouped
+under [`currentLap`](#CurrentLap) and [`lastLap`](#LastLap), so that the two
+cannot be mistaken for one another at a call site; what stands apart from both
+-- who the car is, where it stands, the gaps it holds -- stays at the top.
 
 -}
 type alias CarAt =
@@ -100,35 +105,64 @@ type alias CarAt =
     , position : Int
     , positionInClass : Int
     , lapsCompleted : Int
-    , currentLapTime : Maybe Duration
-    , currentLapBest : Maybe Duration
-    , currentLapMiniSectors : Maybe MiniSectors
-
-    -- Since the car last crossed the line, or since the race start for a car
-    -- still on its opening lap.
-    , currentLapElapsed : Duration
-
-    -- How far through the lap and through the sector the car is. Both are
-    -- read off the clock and the lap's own times, so they say where the car
-    -- is, not how anything is drawn.
-    --
-    -- `sector` and `miniSector` are `Nothing` for a car with no lap in
-    -- progress, which is the same condition `currentLapSectorStates` is
-    -- absent under: a car that is not on a lap is nowhere on the track.
-    , currentLapProgress : Float
-    , sector : Maybe Lap.SectorProgress
-    , miniSector : Maybe Lap.MiniSectorProgress
     , gapToLeader : Gap
     , intervalToAhead : Gap
+    , currentLap : CurrentLap
+    , lastLap : LastLap
 
-    -- Rated against the record the race held at this moment; see
-    -- [`Lap.Performance`](Motorsport-Lap-Performance).
-    , currentLapRated : Maybe RatedTime
-    , currentLapSectorStates : Maybe CurrentSectorStates
-    , lastLapRated : Maybe RatedTime
+    -- The quickest lap the car has turned by this moment, rated. Neither the
+    -- lap it is on nor the one it just finished, so it belongs to neither
+    -- group.
     , bestLapRated : Maybe RatedTime
-    , lastLapSectors : Maybe SectorPerformance
-    , lastLapMiniSectors : Maybe MiniSectorPerformance
+    }
+
+
+{-| The lap the car is on, as it reads at this moment.
+
+`time` and `best` are the lap's own, as the source data has them; `elapsed` is
+how long the car has been on it, counted from the last time it crossed the line
+-- or from the race start, for a car still on its opening lap.
+
+`progress`, `sector` and `miniSector` say how far around the car has got. All
+three come off the clock and the lap's own times, so they say where the car is,
+not how anything is drawn. Singular `miniSector` is one of those three -- which
+mini-sector the car is in, and how far through it; plural `miniSectors` is the
+lap's recorded mini-sector times, which is data rather than a position.
+
+`sector`, `miniSector` and `sectorStates` are `Nothing` together, for a car with
+no lap in progress: a car that is not on a lap is nowhere on the track.
+
+`rated` and `sectorStates` are rated against the record the race held at this
+moment; see [`Lap.Performance`](Motorsport-Lap-Performance).
+
+-}
+type alias CurrentLap =
+    { time : Maybe Duration
+    , best : Maybe Duration
+    , miniSectors : Maybe MiniSectors
+    , elapsed : Duration
+    , progress : Float
+    , sector : Maybe Lap.SectorProgress
+    , miniSector : Maybe Lap.MiniSectorProgress
+    , rated : Maybe RatedTime
+    , sectorStates : Maybe CurrentSectorStates
+    }
+
+
+{-| The lap the car has just finished, as it was read off it.
+
+The lap itself is not here -- see [`CarAt`](#CarAt) -- only what was read: the
+time it took and how its sectors went, each rated against the record the race
+held at this moment.
+
+`miniSectors` is `Nothing` away from Le Mans, where the source data records no
+mini-sectors to rate.
+
+-}
+type alias LastLap =
+    { rated : Maybe RatedTime
+    , sectors : Maybe SectorPerformance
+    , miniSectors : Maybe MiniSectorPerformance
     }
 
 
@@ -494,41 +528,49 @@ readCarAt frame placed =
     , position = placed.position
     , positionInClass = placed.positionInClass
     , lapsCompleted = car.lastLap |> Maybe.map .lap |> Maybe.withDefault 0
-    , currentLapTime = car.currentLap |> Maybe.andThen .time
-    , currentLapBest = car.currentLap |> Maybe.andThen .best
-    , currentLapMiniSectors = car.currentLap |> Maybe.andThen .miniSectors
-    , currentLapElapsed = timing.currentLapElapsed
-    , currentLapProgress =
-        car.currentLap
-            |> Maybe.andThen .time
-            |> Maybe.map (\lapTime -> min 1.0 (toFloat timing.currentLapElapsed / toFloat lapTime))
-            |> Maybe.withDefault 0
-    , sector = timing.sector
-    , miniSector = timing.miniSector
     , gapToLeader = timing.gapToLeader
     , intervalToAhead = timing.intervalToAhead
-    , currentLapRated =
-        car.currentLap
-            |> Maybe.andThen
-                (\lap ->
-                    Performance.rateTime frame.fastestLapTime
-                        { time = Just timing.currentLapElapsed
-                        , personalBest = lap.best
-                        }
-                )
-    , currentLapSectorStates =
-        car.currentLap
-            |> Maybe.map
-                (Performance.ofSectors frame.records
-                    >> currentSectorStates timing.sector
-                )
-    , lastLapRated =
-        car.lastLap
-            |> Maybe.andThen
-                (\lap ->
-                    Performance.rateTime frame.fastestLapTime
-                        { time = lap.time, personalBest = lap.best }
-                )
+    , currentLap =
+        { time = car.currentLap |> Maybe.andThen .time
+        , best = car.currentLap |> Maybe.andThen .best
+        , miniSectors = car.currentLap |> Maybe.andThen .miniSectors
+        , elapsed = timing.currentLapElapsed
+        , progress =
+            car.currentLap
+                |> Maybe.andThen .time
+                |> Maybe.map (\lapTime -> min 1.0 (toFloat timing.currentLapElapsed / toFloat lapTime))
+                |> Maybe.withDefault 0
+        , sector = timing.sector
+        , miniSector = timing.miniSector
+        , rated =
+            car.currentLap
+                |> Maybe.andThen
+                    (\lap ->
+                        Performance.rateTime frame.fastestLapTime
+                            { time = Just timing.currentLapElapsed
+                            , personalBest = lap.best
+                            }
+                    )
+        , sectorStates =
+            car.currentLap
+                |> Maybe.map
+                    (Performance.ofSectors frame.records
+                        >> currentSectorStates timing.sector
+                    )
+        }
+    , lastLap =
+        { rated =
+            car.lastLap
+                |> Maybe.andThen
+                    (\lap ->
+                        Performance.rateTime frame.fastestLapTime
+                            { time = lap.time, personalBest = lap.best }
+                    )
+        , sectors =
+            car.lastLap |> Maybe.map (Performance.ofSectors frame.records)
+        , miniSectors =
+            car.lastLap |> Maybe.andThen (Performance.ofMiniSectors frame.records)
+        }
     , bestLapRated =
         car.lastLap
             |> Maybe.andThen
@@ -536,8 +578,4 @@ readCarAt frame placed =
                     Performance.rateTime frame.fastestLapTime
                         { time = lap.best, personalBest = lap.best }
                 )
-    , lastLapSectors =
-        car.lastLap |> Maybe.map (Performance.ofSectors frame.records)
-    , lastLapMiniSectors =
-        car.lastLap |> Maybe.andThen (Performance.ofMiniSectors frame.records)
     }

--- a/package/src/Motorsport/Race/Snapshot.elm
+++ b/package/src/Motorsport/Race/Snapshot.elm
@@ -1,7 +1,7 @@
 module Motorsport.Race.Snapshot exposing
     ( Snapshot, CarAt, CurrentSectorStates
     , at
-    , toList, toClassList, leader, lapCount, elapsed
+    , toList, toClassList, get, inClass, leader, lapCount, elapsed
     , bestTimes, lapHistory
     )
 
@@ -25,17 +25,20 @@ The records the times are rated against and the laps run so far are read at the
 same clock, so they are taken here too rather than by each caller: see
 [`bestTimes`](#bestTimes) and [`lapHistory`](#lapHistory).
 
+Reading one car or one class out of the field is the snapshot's own business --
+`get` and `inClass` below -- so that a view narrowing the field does not have to
+scan `toList` for it.
+
 @docs Snapshot, CarAt, CurrentSectorStates
 @docs at
-@docs toList, toClassList, leader, lapCount, elapsed
+@docs toList, toClassList, get, inClass, leader, lapCount, elapsed
 @docs bestTimes, lapHistory
 
 -}
 
 import Dict exposing (Dict)
-import List.Extra
 import Motorsport.BestTimes as BestTimes
-import Motorsport.Class exposing (Class)
+import Motorsport.Class as Class exposing (Class)
 import Motorsport.Driver exposing (Driver)
 import Motorsport.Duration exposing (Duration)
 import Motorsport.Gap as Gap exposing (Gap)
@@ -44,7 +47,7 @@ import Motorsport.Lap as Lap exposing (Lap, MiniSectors)
 import Motorsport.Lap.Performance as Performance exposing (MiniSectorPerformance, RatedTime, SectorPerformance)
 import Motorsport.Ordering as Ordering exposing (ByPosition)
 import Motorsport.Race as Race exposing (Race)
-import Motorsport.Race.Car as Car exposing (Car)
+import Motorsport.Race.Car as Car exposing (Car, CarNumber)
 import Motorsport.Race.LapHistory as LapHistory exposing (LapHistory)
 import Motorsport.Sector as Sector exposing (BySector)
 import Motorsport.Status exposing (Status)
@@ -71,6 +74,12 @@ type Snapshot
         -- never re-sort them, so the phantom-typed SortedList guarantee isn't
         -- worth the extra unwrapping at each call site.
         , carsByClass : List ( Class, List CarAt )
+
+        -- The same cars again, to look one up by number. Built with the rest of
+        -- the frame so that `get` costs a lookup rather than a scan of the
+        -- field; two cars sharing a number leave only the leading one here,
+        -- which is the one a caller asking by number wants.
+        , carsByNumber : Dict CarNumber CarAt
         }
 
 
@@ -94,11 +103,18 @@ type alias CarAt =
     , currentLapTime : Maybe Duration
     , currentLapBest : Maybe Duration
     , currentLapMiniSectors : Maybe MiniSectors
+
+    -- Since the car last crossed the line, or since the race start for a car
+    -- still on its opening lap.
     , currentLapElapsed : Duration
 
     -- How far through the lap and through the sector the car is. Both are
     -- read off the clock and the lap's own times, so they say where the car
     -- is, not how anything is drawn.
+    --
+    -- `sector` and `miniSector` are `Nothing` for a car with no lap in
+    -- progress, which is the same condition `currentLapSectorStates` is
+    -- absent under: a car that is not on a lap is nowhere on the track.
     , currentLapProgress : Float
     , sector : Maybe Lap.SectorProgress
     , miniSector : Maybe Lap.MiniSectorProgress
@@ -150,87 +166,14 @@ at clock race =
                 |> List.map (sampleCar clock race)
                 |> Ordering.runningOrder clock
 
-        leaderCar =
-            List.head sampled
-
-        positionsInClass =
-            positionsInClassByCarNumber sampled
-
-        fastestLapTime =
-            BestTimes.timeOf records.fastestLapTime
-
         cars =
-            sampled
-                |> List.indexedMap
-                    (\index car ->
-                        let
-                            timing =
-                                timingOf clock.elapsed
-                                    { leader =
-                                        -- The leader is not behind itself; it has no gap to report.
-                                        if index == 0 then
-                                            Nothing
-
-                                        else
-                                            leaderCar
-                                    , rival = List.Extra.getAt (index - 1) sampled
-                                    }
-                                    car
-                        in
-                        { metadata = car.metadata
-                        , status = car.status
-                        , currentDriver = car.currentDriver
-                        , position = index + 1
-                        , positionInClass =
-                            Dict.get car.metadata.carNumber positionsInClass
-                                |> Maybe.withDefault 1
-                        , lapsCompleted = (Maybe.withDefault Lap.empty car.lastLap).lap
-                        , currentLapTime = car.currentLap |> Maybe.andThen .time
-                        , currentLapBest = car.currentLap |> Maybe.andThen .best
-                        , currentLapMiniSectors = car.currentLap |> Maybe.andThen .miniSectors
-                        , currentLapElapsed = timing.currentLapElapsed
-                        , currentLapProgress =
-                            car.currentLap
-                                |> Maybe.andThen .time
-                                |> Maybe.map (\lapTime -> min 1.0 (toFloat timing.currentLapElapsed / toFloat lapTime))
-                                |> Maybe.withDefault 0
-                        , sector = timing.sector
-                        , miniSector = timing.miniSector
-                        , gapToLeader = timing.gapToLeader
-                        , intervalToAhead = timing.intervalToAhead
-                        , currentLapRated =
-                            car.currentLap
-                                |> Maybe.andThen
-                                    (\lap ->
-                                        Performance.rateTime fastestLapTime
-                                            { time = Just timing.currentLapElapsed
-                                            , personalBest = lap.best
-                                            }
-                                    )
-                        , currentLapSectorStates =
-                            car.currentLap
-                                |> Maybe.map
-                                    (Performance.ofSectors records
-                                        >> currentSectorStates timing.sector
-                                    )
-                        , lastLapRated =
-                            car.lastLap
-                                |> Maybe.andThen
-                                    (\lap ->
-                                        Performance.rateTime fastestLapTime
-                                            { time = lap.time, personalBest = lap.best }
-                                    )
-                        , bestLapRated =
-                            car.lastLap
-                                |> Maybe.andThen
-                                    (\lap ->
-                                        Performance.rateTime fastestLapTime
-                                            { time = lap.best, personalBest = lap.best }
-                                    )
-                        , lastLapSectors =
-                            car.lastLap |> Maybe.map (Performance.ofSectors records)
-                        , lastLapMiniSectors =
-                            car.lastLap |> Maybe.andThen (Performance.ofMiniSectors records)
+            placeInField sampled
+                |> List.map
+                    (readCarAt
+                        { raceElapsed = clock.elapsed
+                        , records = records
+                        , fastestLapTime = BestTimes.timeOf records.fastestLapTime
+                        , leaderCar = List.head sampled
                         }
                     )
 
@@ -242,6 +185,7 @@ at clock race =
         , lapCount = Race.lapCountAt clock race
         , cars = sortedCars
         , carsByClass = groupByClass sortedCars
+        , carsByNumber = indexByCarNumber cars
         , bestTimes = records
         , lapHistory = LapHistory.at clock race.cars
         }
@@ -273,6 +217,18 @@ currentSectorStates sectorProgress rated =
         rated
 
 
+{-| Index the field by car number.
+
+Folded from the right so that the leading car wins a number two cars share:
+`Dict.insert` keeps the last write, and folding backwards makes that the car
+earliest in the running order.
+
+-}
+indexByCarNumber : List CarAt -> Dict CarNumber CarAt
+indexByCarNumber =
+    List.foldr (\car -> Dict.insert car.metadata.carNumber car) Dict.empty
+
+
 groupByClass : SortedList ByPosition CarAt -> List ( Class, List CarAt )
 groupByClass sortedCars =
     sortedCars
@@ -292,6 +248,29 @@ toList (Snapshot s) =
 toClassList : Snapshot -> List ( Class, List CarAt )
 toClassList (Snapshot s) =
     s.carsByClass
+
+
+{-| One car of the field by its number, where the race has such a car.
+-}
+get : CarNumber -> Snapshot -> Maybe CarAt
+get carNumber (Snapshot s) =
+    Dict.get carNumber s.carsByNumber
+
+
+{-| The cars racing in one class, in running order.
+
+The same list [`toClassList`](#toClassList) holds that class under, for a caller
+that already knows which class it wants. A class no car races in is empty rather
+than absent: there is nothing to draw either way.
+
+-}
+inClass : Class -> Snapshot -> List CarAt
+inClass class (Snapshot s) =
+    s.carsByClass
+        |> List.filter (\( carClass, _ ) -> carClass == class)
+        |> List.head
+        |> Maybe.map Tuple.second
+        |> Maybe.withDefault []
 
 
 {-| The car leading the race, where there is one.
@@ -385,25 +364,32 @@ timingOf raceElapsed rivals car =
         raceClock =
             { elapsed = raceElapsed }
 
-        currentLap =
-            Maybe.withDefault Lap.empty car.currentLap
-
+        -- A car on its opening lap has no lap behind it, and that lap began at
+        -- the race start -- which is the instant `Lap.empty` carries. So the
+        -- empty lap stands in for the missing one here rather than papering
+        -- over it: both the elapsed time below and the mini-sector's own start
+        -- come out right for a first lap.
         lastLap =
             Maybe.withDefault Lap.empty car.lastLap
-
-        currentSector =
-            let
-                sectorProgress =
-                    Lap.progressAt raceClock currentLap
-            in
-            Just { sectorProgress | progress = min 1 sectorProgress.progress }
-
-        currentMiniSector =
-            Lap.miniSectorProgressAt raceClock { current = currentLap, previous = lastLap }
     in
     { currentLapElapsed = Instant.since { from = lastLap.elapsed, to = raceClock.elapsed }
-    , sector = currentSector
-    , miniSector = currentMiniSector
+    , sector =
+        -- Only a car with a lap in progress is anywhere on the lap. Reading a
+        -- sector off `Lap.empty` would place every car without lap data at the
+        -- start of the track, which is a position it does not hold.
+        car.currentLap
+            |> Maybe.map
+                (\lap ->
+                    let
+                        sectorProgress =
+                            Lap.progressAt raceClock lap
+                    in
+                    { sectorProgress | progress = min 1 sectorProgress.progress }
+                )
+    , miniSector =
+        car.currentLap
+            |> Maybe.andThen
+                (\lap -> Lap.miniSectorProgressAt raceClock { current = lap, previous = lastLap })
     , gapToLeader = gapTo raceClock car rivals.leader
     , intervalToAhead = gapTo raceClock car rivals.rival
     }
@@ -418,16 +404,140 @@ gapTo raceClock car ahead =
         |> Maybe.withDefault Gap.none
 
 
-{-| Position within class, keyed by car number. Expects the cars already in
-running order, so gathering by class preserves it.
+{-| A sampled car with its place in the field: what it stands overall, what it
+stands in its class, and which car it is running directly behind.
 -}
-positionsInClassByCarNumber : List SampledCar -> Dict String Int
-positionsInClassByCarNumber carsInRaceOrder =
-    carsInRaceOrder
-        |> List.Extra.gatherEqualsBy (.metadata >> .class)
-        |> List.concatMap
-            (\( firstCar, restCars ) ->
-                (firstCar :: restCars)
-                    |> List.indexedMap (\index car -> ( car.metadata.carNumber, index + 1 ))
+type alias Placed =
+    { car : SampledCar
+    , position : Int
+    , positionInClass : Int
+    , ahead : Maybe SampledCar
+    }
+
+
+{-| Number the field off in one pass over the running order.
+
+Class position is counted as the cars go past rather than looked up afterwards.
+A lookup has to be keyed by car number, and two cars sharing one -- which the
+source data occasionally has -- would collapse into a single entry, leaving the
+other car to fall back on a position it does not hold. Counting cannot miss a
+car that is in the list, so there is no fallback to get wrong.
+
+The car ahead comes off the same pass, which is also the car each interval is
+measured to; the first car has none, and reports no interval.
+
+-}
+placeInField : List SampledCar -> List Placed
+placeInField carsInRunningOrder =
+    carsInRunningOrder
+        |> List.foldl
+            (\car state ->
+                let
+                    classKey =
+                        Class.toString car.metadata.class
+
+                    positionInClass =
+                        Dict.get classKey state.positionsInClass
+                            |> Maybe.withDefault 0
+                            |> (+) 1
+                in
+                { position = state.position + 1
+                , positionsInClass = Dict.insert classKey positionInClass state.positionsInClass
+                , ahead = Just car
+                , placed =
+                    { car = car
+                    , position = state.position
+                    , positionInClass = positionInClass
+                    , ahead = state.ahead
+                    }
+                        :: state.placed
+                }
             )
-        |> Dict.fromList
+            { position = 1
+            , positionsInClass = Dict.empty
+            , ahead = Nothing
+            , placed = []
+            }
+        |> .placed
+        |> List.reverse
+
+
+readCarAt :
+    { raceElapsed : Instant
+    , records : BestTimes.Snapshot
+    , fastestLapTime : Maybe Duration
+    , leaderCar : Maybe SampledCar
+    }
+    -> Placed
+    -> CarAt
+readCarAt frame placed =
+    let
+        car =
+            placed.car
+
+        timing =
+            timingOf frame.raceElapsed
+                { leader =
+                    -- The leader is not behind itself; it has no gap to report.
+                    if placed.position == 1 then
+                        Nothing
+
+                    else
+                        frame.leaderCar
+                , rival = placed.ahead
+                }
+                car
+    in
+    { metadata = car.metadata
+    , status = car.status
+    , currentDriver = car.currentDriver
+    , position = placed.position
+    , positionInClass = placed.positionInClass
+    , lapsCompleted = car.lastLap |> Maybe.map .lap |> Maybe.withDefault 0
+    , currentLapTime = car.currentLap |> Maybe.andThen .time
+    , currentLapBest = car.currentLap |> Maybe.andThen .best
+    , currentLapMiniSectors = car.currentLap |> Maybe.andThen .miniSectors
+    , currentLapElapsed = timing.currentLapElapsed
+    , currentLapProgress =
+        car.currentLap
+            |> Maybe.andThen .time
+            |> Maybe.map (\lapTime -> min 1.0 (toFloat timing.currentLapElapsed / toFloat lapTime))
+            |> Maybe.withDefault 0
+    , sector = timing.sector
+    , miniSector = timing.miniSector
+    , gapToLeader = timing.gapToLeader
+    , intervalToAhead = timing.intervalToAhead
+    , currentLapRated =
+        car.currentLap
+            |> Maybe.andThen
+                (\lap ->
+                    Performance.rateTime frame.fastestLapTime
+                        { time = Just timing.currentLapElapsed
+                        , personalBest = lap.best
+                        }
+                )
+    , currentLapSectorStates =
+        car.currentLap
+            |> Maybe.map
+                (Performance.ofSectors frame.records
+                    >> currentSectorStates timing.sector
+                )
+    , lastLapRated =
+        car.lastLap
+            |> Maybe.andThen
+                (\lap ->
+                    Performance.rateTime frame.fastestLapTime
+                        { time = lap.time, personalBest = lap.best }
+                )
+    , bestLapRated =
+        car.lastLap
+            |> Maybe.andThen
+                (\lap ->
+                    Performance.rateTime frame.fastestLapTime
+                        { time = lap.best, personalBest = lap.best }
+                )
+    , lastLapSectors =
+        car.lastLap |> Maybe.map (Performance.ofSectors frame.records)
+    , lastLapMiniSectors =
+        car.lastLap |> Maybe.andThen (Performance.ofMiniSectors frame.records)
+    }

--- a/package/src/Motorsport/Race/Snapshot.elm
+++ b/package/src/Motorsport/Race/Snapshot.elm
@@ -148,9 +148,21 @@ type alias Standing =
 
 {-| The lap the car is on, as it reads at this moment.
 
-`time` and `best` are the lap's own, as the source data has them; `elapsed` is
-how long the car has been on it, counted from the last time it crossed the line
--- or from the race start, for a car still on its opening lap.
+`elapsed` is how long the car has been on it, counted from the last time it
+crossed the line -- or from the race start, for a car still on its opening lap.
+It is the only lap time here the clock has actually reached.
+
+`best` is not this lap's anything: it is the car's own record, the least time it
+had turned by this moment, and it is what a time of this car's is rated against.
+It is taken off the last lap the car finished, so a car on its opening lap has
+none.
+
+`time` and `miniSectors` are the source data's, and the source data runs to the
+end of the race: they are this lap's eventual time and its full set of
+mini-sector times, including the parts of the lap the car has not driven yet.
+Read either one against `progress` -- as the views that paint a mini-sector do,
+drawing only what is behind the car -- or it will answer a question about the
+future. Nothing else here runs ahead of the clock.
 
 `progress`, `sector` and `miniSector` say how far around the car has got. All
 three come off the clock and the lap's own times, so they say where the car is,
@@ -549,6 +561,18 @@ readCarAt frame placed =
                 , rival = placed.ahead
                 }
                 car
+
+        -- The car's own record as it stood at this moment, taken off the last
+        -- lap it finished rather than the one it is running.
+        --
+        -- A lap's `best` is the least time the car had turned up to and
+        -- including that lap, so the lap in progress carries a `best` that
+        -- already counts a time the clock has not reached -- its own. Reading
+        -- it off the finished lap is what stops the lap being rated against
+        -- itself. A car on its opening lap has no record yet, which is what
+        -- `Nothing` says here.
+        personalBest =
+            car.lastLap |> Maybe.andThen .best
     in
     { metadata = car.metadata
     , status = car.status
@@ -562,7 +586,7 @@ readCarAt frame placed =
         }
     , currentLap =
         { time = car.currentLap |> Maybe.andThen .time
-        , best = car.currentLap |> Maybe.andThen .best
+        , best = personalBest
         , miniSectors = car.currentLap |> Maybe.andThen .miniSectors
         , elapsed = timing.currentLapElapsed
         , progress =
@@ -575,10 +599,10 @@ readCarAt frame placed =
         , rated =
             car.currentLap
                 |> Maybe.andThen
-                    (\lap ->
+                    (\_ ->
                         Performance.rateTime frame.fastestLapTime
                             { time = Just timing.currentLapElapsed
-                            , personalBest = lap.best
+                            , personalBest = personalBest
                             }
                     )
         , sectorStates =

--- a/package/src/Motorsport/Race/Snapshot.elm
+++ b/package/src/Motorsport/Race/Snapshot.elm
@@ -95,22 +95,22 @@ already turned is here as what was read off it -- `standing.lapsCompleted`, and
 Three groups, by what the reading is of. Where the car stands in the field is
 [`standing`](#Standing); what was read off the lap it is on and off the one it
 just finished is [`currentLap`](#CurrentLap) and [`lastLap`](#LastLap). Who the
-car is stays at the top, and so does `bestLapRated`, for the reason below.
+car is stays at the top, and so does `bestLap`, for the reason below.
 
 Grouping the two laps apart is by which lap the reading came off, which cuts
 across the other question one can ask of these fields: whether the reading is a
 position or a rating. Every rating here -- `currentLap.rated`, `currentLap.sectorStates`,
-`lastLap.rated`, `lastLap.sectors`, `lastLap.miniSectors` and `bestLapRated` --
+`lastLap.rated`, `lastLap.sectors`, `lastLap.miniSectors` and `bestLap` --
 is measured against the records held at this moment rather than the ones the
 race ends on, and the grouping leaves them in three separate places. That is why
 it is said here, once, instead of at each of them; see
 [`Lap.Performance`](Motorsport-Lap-Performance).
 
 Two records, in fact: the race's, which is [`bestTimes`](#bestTimes)'s to hold,
-and the car's own, which is `bestLapRated`. That is what puts `bestLapRated` at
-the top rather than in a group -- it is the least time the car had turned by
-this moment, so it is neither the lap it is on nor the one it just finished, and
-it is the baseline every other rating of this car is read against.
+and the car's own, which is `bestLap`. That is what puts `bestLap` at the top
+rather than in a group -- it is the least time the car had turned by this
+moment, so it is neither the lap it is on nor the one it just finished, and it
+is the baseline every other rating of this car is read against.
 
 -}
 type alias CarAt =
@@ -120,7 +120,7 @@ type alias CarAt =
     , standing : Standing
     , currentLap : CurrentLap
     , lastLap : LastLap
-    , bestLapRated : Maybe RatedTime
+    , bestLap : Maybe RatedTime
     }
 
 
@@ -578,7 +578,7 @@ readCarAt frame placed =
         -- `Nothing` says here.
         --
         -- Read once: both the baseline `currentLap.rated` is rated against and
-        -- `bestLapRated` come off this, so the two cannot come apart.
+        -- `bestLap` come off this, so the two cannot come apart.
         personalBest =
             car.lastLap |> Maybe.andThen .best
     in
@@ -635,7 +635,7 @@ readCarAt frame placed =
         , miniSectors =
             car.lastLap |> Maybe.andThen (Performance.ofMiniSectors frame.records)
         }
-    , bestLapRated =
+    , bestLap =
         -- The record itself, rated: `rateTime` gives nothing back for a car
         -- that has not set one, which is the same `Nothing` `personalBest`
         -- already carries.

--- a/package/src/Motorsport/Race/Snapshot.elm
+++ b/package/src/Motorsport/Race/Snapshot.elm
@@ -88,33 +88,22 @@ type Snapshot
 
 {-| One [`Car`](Motorsport-Race-Car) as it stands at one moment of the race.
 
-Readings only -- no laps of any kind. The whole list runs to the end of the
-race, and handing it out beside values that stop at the clock is how future data
-gets read by accident; the laps up to this moment are
-[`lapHistory`](#lapHistory)'s to give out, already cut. A lap the car has
-already turned is here as what was read off it -- `standing.lapsCompleted`, and
+Readings only, and no laps: the laps up to this moment are
+[`lapHistory`](#lapHistory)'s to give out, already cut. A lap the car has turned
+is here as what was read off it -- `standing.lapsCompleted`, and
 [`lastLap`](#LastLap) -- rather than as the lap itself.
 
-Three groups, by what the reading is of. Where the car stands in the field is
-[`standing`](#Standing); what was read off the lap it is on and off the one it
-just finished is [`currentLap`](#CurrentLap) and [`lastLap`](#LastLap). Who the
-car is stays at the top, and so does `bestLap`, for the reason below.
+Grouped by what the reading is of: where the car stands in the field
+([`standing`](#Standing)), and what the lap it is on and the one it just
+finished read as ([`currentLap`](#CurrentLap), [`lastLap`](#LastLap)). Who the
+car is stays at the top.
 
-Grouping the two laps apart is by which lap the reading came off, which cuts
-across the other question one can ask of these fields: whether the reading is a
-position or a rating. Every rating here -- `currentLap.performance`,
-`currentLap.sectorStates`, `currentLap.miniSectorStates`, `lastLap.rated`,
-`lastLap.sectors`, `lastLap.miniSectors` and `bestLap` -- is measured against
-the records held at this moment rather than the ones the race ends on, and the
-grouping leaves them in three separate places. That is why it is said here,
-once, instead of at each of them; see
+Every rating here is measured against the records as they stood at this moment,
+not as the race leaves them. Two records: the race's, which is
+[`bestTimes`](#bestTimes)'s to hold, and the car's own, which is `bestLap` --
+and that is what puts `bestLap` outside the groups, since it belongs to no one
+lap and every other rating of this car is read against it. See
 [`Lap.Performance`](Motorsport-Lap-Performance).
-
-Two records, in fact: the race's, which is [`bestTimes`](#bestTimes)'s to hold,
-and the car's own, which is `bestLap`. That is what puts `bestLap` at the top
-rather than in a group -- it is the least time the car had turned by this
-moment, so it is neither the lap it is on nor the one it just finished, and it
-is the baseline every other rating of this car is read against.
 
 -}
 type alias CarAt =
@@ -128,19 +117,15 @@ type alias CarAt =
     }
 
 
-{-| Where the car stands in the race at this moment.
+{-| Where the car stands in the race at this moment: the five a classification
+line is made of, in the order one prints them.
 
-The five a classification line is made of, in the order one prints them: what
-the car is placed overall and in its class, how many laps it has behind it, and
-how far back it is from the leader and from the car it is actually racing.
+The placings and the gaps are read off the same running order, in one pass; see
+[`at`](#at). `lapsCompleted` counts laps the car has finished, so a car on its
+opening lap has none.
 
-The placings and the gaps are read off the same running order, in the same pass;
-see [`at`](#at). `lapsCompleted` counts laps the car has finished, so a car on
-its opening lap has none.
-
-Both gaps are [`Gap.none`](Motorsport-Gap#none) for the leading car, and only
-for it: it is both the car the race is measured to and the car nothing runs
-ahead of, so there is nothing for either gap to reach.
+Both gaps are [`Gap.none`](Motorsport-Gap#none) for the leading car and only for
+it: nothing runs ahead of it, and it is what the race is measured to.
 
 -}
 type alias Standing =
@@ -154,32 +139,22 @@ type alias Standing =
 
 {-| The lap the car is on, as it reads at this moment.
 
-Every car of a [`Snapshot`](#Snapshot) has one, because a car that has turned no
-lap is not in the field at all -- see [`at`](#at). A car that has finished a lap
-keeps it, since a lap stays the car's current one until the next begins, so a
-car that has retired or taken the flag still reads the last lap it ran.
+Every car of a [`Snapshot`](#Snapshot) has one -- a car that has turned no lap
+is not in the field, and a lap stays the car's current one until the next
+begins, so a car that has retired or taken the flag keeps the last it ran.
 
 `elapsed` is how long the car has been on it, counted from the last time it
-crossed the line -- or from the race start, for a car still on its opening lap.
-`performance` is how that reads against the records, and `progress` is how far
-through the lap it puts the car. Nothing here is the lap's eventual time, which
-is the one figure of a lap in progress that the clock has not reached: what a
-caller wants of it is `progress`, so `progress` is what it is kept for.
+crossed the line -- or from the race start, for a car on its opening lap.
+`performance` is how that reads against the records (see [`CarAt`](#CarAt) for
+which), and `progress` how far through the lap it puts the car. `sector` and
+`miniSector` say where on the lap the car is; `sectorStates` and
+`miniSectorStates` say as much of every sector and every mini-sector at once,
+which is what a strip of cells is drawn from.
 
-`sector` and `miniSector` say where on the lap the car has got to.
-`sectorStates` and `miniSectorStates` say as much of every sector and every
-mini-sector at once -- how much of each is behind the car and how it rates --
-which is what a strip of cells is drawn from. All of it is cut at the clock, so
-a view draws it without asking what the car has reached.
-
-The two mini-sector readings are what remains `Maybe` here, and for a reason of
-their own: a lap with no mini-sector times has none to be in or to rate, and
-away from Le Mans no lap has any. `miniSector` is also `Nothing` for a clock
-past the last mini-sector of the lap, which is in none of them -- the same
-lap-is-over reading that fills `miniSectorStates` in.
-
-What `performance`, `sectorStates` and `miniSectorStates` are rated against is
-[`CarAt`](#CarAt)'s to say, along with every other rating on a car.
+The mini-sector readings are the only `Maybe`s, for the reason
+[`CurrentMiniSectorStates`](#CurrentMiniSectorStates) gives. `miniSector` is
+`Nothing` in one case more: a clock past the last mini-sector of the lap is in
+none of them.
 
 -}
 type alias CurrentLap =
@@ -248,8 +223,7 @@ at clock race =
 
         -- A car carries only its laps, so what it is doing at this moment is
         -- read off the clock here. Who is ahead of whom follows from that, and
-        -- every position below is read off the resulting order. A car with no
-        -- lap in progress drops out; see `sampleCar`.
+        -- every position below is read off the resulting order.
         sampled =
             race.cars
                 |> List.filterMap (sampleCar clock race)
@@ -453,20 +427,16 @@ type alias SampledCar =
 
 {-| Read a car at the clock, where it is running.
 
-`Nothing` for a car with no lap in progress, which is a car that has turned no
-lap at all: a lap stays the car's current one until the next begins, so a car
-that has retired or taken the flag still has one. Such a car is not in the
-field -- there is no answer to where it stands, and nothing to report of it but
-its number.
+`Nothing` for a car with no lap in progress, which is one that has turned no lap
+at all -- a lap stays the car's current one until the next begins. Such a car is
+not in the field: there is no answer to where it stands, and nothing to report
+of it but its number. Nor can the data produce one, since the loader builds the
+entry list out of the lap records themselves.
 
-This is the one place that is settled, and everything downstream is written
-knowing it: [`Ordering.runningOrder`](Motorsport-Ordering#runningOrder) and
-[`Gap.Competitor`](Motorsport-Gap#Competitor) both ask for a lap rather than a
+Settled here once, and everything downstream is written knowing it:
+[`Ordering.runningOrder`](Motorsport-Ordering#runningOrder) and
+[`Gap.Competitor`](Motorsport-Gap#Competitor) ask for a lap rather than a
 `Maybe` of one, and a [`CarAt`](#CarAt) carries its lap plainly.
-
-Nor can the data produce such a car. The loader builds the entry list out of the
-lap records themselves, so one that completed no lap is in neither of the files
-the app reads.
 
 -}
 sampleCar : { elapsed : Instant } -> Race -> Car -> Maybe SampledCar
@@ -656,18 +626,11 @@ readCarAt frame placed =
                 }
                 car
 
-        -- The car's own record as it stood at this moment, taken off the last
-        -- lap it finished rather than the one it is running.
-        --
-        -- A lap's `best` is the least time the car had turned up to and
-        -- including that lap, so the lap in progress carries a `best` that
-        -- already counts a time the clock has not reached -- its own. Reading
-        -- it off the finished lap is what stops the lap being rated against
-        -- itself. A car on its opening lap has no record yet, which is what
-        -- `Nothing` says here.
-        --
-        -- Read once: both the baseline `currentLap.performance` is read against
-        -- and `bestLap` come off this, so the two cannot come apart.
+        -- The car's own record at this moment. A lap's `best` counts its own
+        -- time, so the lap in progress carries one the clock has not reached;
+        -- reading it off the finished lap is what stops the lap being rated
+        -- against itself. Read once, so `currentLap.performance`'s baseline and
+        -- `bestLap` cannot come apart.
         personalBest =
             car.lastLap |> Maybe.andThen .best
     in
@@ -705,9 +668,6 @@ readCarAt frame placed =
             car.lastLap |> Maybe.andThen (Performance.ofMiniSectors frame.records)
         }
     , bestLap =
-        -- The record itself, rated: `rateTime` gives nothing back for a car
-        -- that has not set one, which is the same `Nothing` `personalBest`
-        -- already carries.
         Performance.rateTime frame.fastestLapTime
             { time = personalBest, personalBest = personalBest }
     }

--- a/package/src/Motorsport/Race/Snapshot.elm
+++ b/package/src/Motorsport/Race/Snapshot.elm
@@ -95,17 +95,22 @@ already turned is here as what was read off it -- `standing.lapsCompleted`, and
 Three groups, by what the reading is of. Where the car stands in the field is
 [`standing`](#Standing); what was read off the lap it is on and off the one it
 just finished is [`currentLap`](#CurrentLap) and [`lastLap`](#LastLap). Who the
-car is stays at the top, and so does `bestLapRated`, which belongs to no group.
+car is stays at the top, and so does `bestLapRated`, for the reason below.
 
 Grouping the two laps apart is by which lap the reading came off, which cuts
-across the other
-question one can ask of these fields: whether the reading is a position or a
-rating. Every rating here -- `currentLap.rated`, `currentLap.sectorStates`,
+across the other question one can ask of these fields: whether the reading is a
+position or a rating. Every rating here -- `currentLap.rated`, `currentLap.sectorStates`,
 `lastLap.rated`, `lastLap.sectors`, `lastLap.miniSectors` and `bestLapRated` --
-is measured against the record the race held at this moment rather than the one
-it ends on, and the grouping leaves them in three separate places. That is why
+is measured against the records held at this moment rather than the ones the
+race ends on, and the grouping leaves them in three separate places. That is why
 it is said here, once, instead of at each of them; see
 [`Lap.Performance`](Motorsport-Lap-Performance).
+
+Two records, in fact: the race's, which is [`bestTimes`](#bestTimes)'s to hold,
+and the car's own, which is `bestLapRated`. That is what puts `bestLapRated` at
+the top rather than in a group -- it is the least time the car had turned by
+this moment, so it is neither the lap it is on nor the one it just finished, and
+it is the baseline every other rating of this car is read against.
 
 -}
 type alias CarAt =
@@ -115,10 +120,6 @@ type alias CarAt =
     , standing : Standing
     , currentLap : CurrentLap
     , lastLap : LastLap
-
-    -- The quickest lap the car has turned by this moment, rated. Neither the
-    -- lap it is on nor the one it just finished, so it belongs to neither
-    -- group.
     , bestLapRated : Maybe RatedTime
     }
 
@@ -152,11 +153,6 @@ type alias Standing =
 crossed the line -- or from the race start, for a car still on its opening lap.
 It is the only lap time here the clock has actually reached.
 
-`best` is not this lap's anything: it is the car's own record, the least time it
-had turned by this moment, and it is what a time of this car's is rated against.
-It is taken off the last lap the car finished, so a car on its opening lap has
-none.
-
 `time` and `miniSectors` are the source data's, and the source data runs to the
 end of the race: they are this lap's eventual time and its full set of
 mini-sector times, including the parts of the lap the car has not driven yet.
@@ -179,7 +175,6 @@ along with every other rating on a car.
 -}
 type alias CurrentLap =
     { time : Maybe Duration
-    , best : Maybe Duration
     , miniSectors : Maybe MiniSectors
     , elapsed : Duration
     , progress : Float
@@ -586,7 +581,6 @@ readCarAt frame placed =
         }
     , currentLap =
         { time = car.currentLap |> Maybe.andThen .time
-        , best = personalBest
         , miniSectors = car.currentLap |> Maybe.andThen .miniSectors
         , elapsed = timing.currentLapElapsed
         , progress =

--- a/package/src/Motorsport/Race/Snapshot.elm
+++ b/package/src/Motorsport/Race/Snapshot.elm
@@ -120,7 +120,7 @@ is the baseline every other rating of this car is read against.
 type alias CarAt =
     { metadata : Car.Metadata
     , status : Status
-    , currentDriver : Maybe Driver
+    , currentDriver : Driver
     , standing : Standing
     , currentLap : CurrentLap
     , lastLap : LastLap
@@ -448,7 +448,7 @@ type alias SampledCar =
         , lapInProgress : Lap
         , lastLap : Maybe Lap
         , status : Status
-        , currentDriver : Maybe Driver
+        , currentDriver : Driver
         }
 
 
@@ -482,7 +482,7 @@ sampleCar clock race car =
                 , lapInProgress = lap
                 , lastLap = Lap.findLastLapAt clock car.laps
                 , status = Race.statusAt clock car.metadata.carNumber race
-                , currentDriver = Just lap.driver
+                , currentDriver = lap.driver
                 }
             )
 

--- a/package/src/Motorsport/Race/Snapshot.elm
+++ b/package/src/Motorsport/Race/Snapshot.elm
@@ -1,5 +1,6 @@
 module Motorsport.Race.Snapshot exposing
-    ( Snapshot, CarAt, Standing, CurrentLap, LastLap, CurrentSectorStates
+    ( Snapshot, CarAt, Standing, CurrentLap, LastLap
+    , CurrentSectorStates, CurrentMiniSectorStates
     , at
     , toList, toClassList, get, inClass, leader, lapCount, elapsed
     , bestTimes, lapHistory
@@ -29,7 +30,8 @@ Reading one car or one class out of the field is the snapshot's own business --
 `get` and `inClass` below -- so that a view narrowing the field does not have to
 scan `toList` for it.
 
-@docs Snapshot, CarAt, Standing, CurrentLap, LastLap, CurrentSectorStates
+@docs Snapshot, CarAt, Standing, CurrentLap, LastLap
+@docs CurrentSectorStates, CurrentMiniSectorStates
 @docs at
 @docs toList, toClassList, get, inClass, leader, lapCount, elapsed
 @docs bestTimes, lapHistory
@@ -38,12 +40,13 @@ scan `toList` for it.
 
 import Dict exposing (Dict)
 import Motorsport.BestTimes as BestTimes
+import Motorsport.Circuit.LeMans as LeMans exposing (ByMiniSector)
 import Motorsport.Class as Class exposing (Class)
 import Motorsport.Driver exposing (Driver)
 import Motorsport.Duration exposing (Duration)
 import Motorsport.Gap as Gap exposing (Gap)
 import Motorsport.Instant as Instant exposing (Instant)
-import Motorsport.Lap as Lap exposing (Lap, MiniSectors)
+import Motorsport.Lap as Lap exposing (Lap)
 import Motorsport.Lap.Performance as Performance exposing (MiniSectorPerformance, RatedTime, SectorPerformance)
 import Motorsport.Ordering as Ordering exposing (ByPosition)
 import Motorsport.Race as Race exposing (Race)
@@ -100,9 +103,9 @@ car is stays at the top, and so does `bestLap`, for the reason below.
 Grouping the two laps apart is by which lap the reading came off, which cuts
 across the other question one can ask of these fields: whether the reading is a
 position or a rating. Every rating here -- `currentLap.rated`, `currentLap.sectorStates`,
-`lastLap.rated`, `lastLap.sectors`, `lastLap.miniSectors` and `bestLap` --
-is measured against the records held at this moment rather than the ones the
-race ends on, and the grouping leaves them in three separate places. That is why
+`currentLap.miniSectorStates`, `lastLap.rated`, `lastLap.sectors`,
+`lastLap.miniSectors` and `bestLap` -- is measured against the records held at
+this moment rather than the ones the race ends on, and the grouping leaves them in three separate places. That is why
 it is said here, once, instead of at each of them; see
 [`Lap.Performance`](Motorsport-Lap-Performance).
 
@@ -152,22 +155,21 @@ type alias Standing =
 
 `elapsed` is how long the car has been on it, counted from the last time it
 crossed the line -- or from the race start, for a car still on its opening lap.
-It is the only lap time here the clock has actually reached.
 
-`time` and `miniSectors` are the source data's, and the source data runs to the
-end of the race: `time` is what the lap will have taken once it is over, and
-`miniSectors` carries every mini-sector time of it, the ones the car has not
-reached included. Neither is cut at the clock, and nothing here cuts them --
-`progress` is `elapsed` measured against `time`, which is a use of the future
-figure rather than a guard on it. A view that shows either has to do the cutting
-itself, as the mini-sector strip does by filling each cell only as far as
-`miniSector` says the car has got. Nothing else here runs ahead of the clock.
+`time` is the source data's, and the source data runs to the end of the race: it
+is what the lap will have taken once it is over, not anything the clock has
+reached. Nothing here cuts it -- `progress` is `elapsed` measured against it,
+which is a use of the future figure rather than a guard on it -- so a view that
+shows `time` has to do the cutting itself. It is the only field here that runs
+ahead of the clock.
 
-`progress`, `sector` and `miniSector` say how far around the car has got. All
-three come off the clock and the lap's own times, so they say where the car is,
-not how anything is drawn. Singular `miniSector` is one of those three -- which
-mini-sector the car is in, and how far through it; plural `miniSectors` is the
-lap's recorded mini-sector times, which is data rather than a position.
+`progress`, `sector` and `miniSector` say how far around the car has got, read
+off the clock and the lap's own times, so they say where the car is rather than
+how anything is drawn. `sectorStates` and `miniSectorStates` say as much of
+every sector and every mini-sector at once -- how much of each is behind the car
+and how it rates -- which is what a strip of cells is drawn from. They are cut
+at the clock already, so a view draws them without asking what the car has
+reached.
 
 `sector` and `sectorStates` are `Nothing` together, for a car with no lap in
 progress: a car that is not on a lap is nowhere on the track. In practice that
@@ -175,23 +177,26 @@ means a car that has turned no lap at all -- a lap the car has finished stays
 its current one until the next begins, so a car that has retired or taken the
 flag keeps the last lap it ran.
 
-`miniSector` is `Nothing` under that same condition and one more: a lap with no
-mini-sector times has no mini-sector to be in. Away from Le Mans no lap has any,
-so there `miniSector` is `Nothing` throughout while the two above are not.
+`miniSectorStates` is `Nothing` under that same condition and one more: a lap
+with no mini-sector times has none to rate. Away from Le Mans no lap has any, so
+there it is `Nothing` throughout while the two above are not. `miniSector` is
+`Nothing` in both those cases and in one of its own -- a clock past the last
+mini-sector of the lap is in none of them, which is the same lap-is-over reading
+that fills `miniSectorStates` in.
 
-What `rated` and `sectorStates` are rated against is [`CarAt`](#CarAt)'s to say,
-along with every other rating on a car.
+What `rated`, `sectorStates` and `miniSectorStates` are rated against is
+[`CarAt`](#CarAt)'s to say, along with every other rating on a car.
 
 -}
 type alias CurrentLap =
     { time : Maybe Duration
-    , miniSectors : Maybe MiniSectors
     , elapsed : Duration
     , progress : Float
     , sector : Maybe Lap.SectorProgress
     , miniSector : Maybe Lap.MiniSectorProgress
     , rated : Maybe RatedTime
     , sectorStates : Maybe CurrentSectorStates
+    , miniSectorStates : Maybe CurrentMiniSectorStates
     }
 
 
@@ -220,6 +225,17 @@ a mini-sector's is; there is nothing to colour it by.
 -}
 type alias CurrentSectorStates =
     BySector { progress : Float, rated : Maybe RatedTime }
+
+
+{-| The same reading at the finer grain, where the circuit records mini-sectors:
+where the car stands in each of them, and how the time reads where there is one.
+
+`Nothing` on a [`CurrentLap`](#CurrentLap) rather than empty, because away from
+Le Mans there are no mini-sectors to stand anywhere in.
+
+-}
+type alias CurrentMiniSectorStates =
+    ByMiniSector { progress : Float, rated : Maybe RatedTime }
 
 
 {-| Read the whole race at a moment of it.
@@ -293,6 +309,39 @@ currentSectorStates sectorProgress rated =
     in
     Sector.map2 (\progress rating -> { progress = progress, rated = rating })
         (Sector.initialize progressOf)
+        rated
+
+
+{-| The mini-sector counterpart of [`currentSectorStates`](#currentSectorStates),
+reading the same way: behind the car complete, ahead of it untouched, and no
+mini-sector in progress at all meaning the lap is over.
+
+Joined here rather than by the view that draws the strip, as the sectors' is:
+a cell wants to know how much of its mini-sector is behind the car and how that
+mini-sector rates, and neither is a question about drawing.
+
+-}
+currentMiniSectorStates : Maybe Lap.MiniSectorProgress -> MiniSectorPerformance -> CurrentMiniSectorStates
+currentMiniSectorStates miniSectorProgress rated =
+    let
+        progressOf mini =
+            case miniSectorProgress of
+                Just current ->
+                    case LeMans.compare mini current.miniSector of
+                        LT ->
+                            1
+
+                        EQ ->
+                            current.progress
+
+                        GT ->
+                            0
+
+                Nothing ->
+                    1
+    in
+    LeMans.map2 (\progress rating -> { progress = progress, rated = rating })
+        (LeMans.initialize progressOf)
         rated
 
 
@@ -594,7 +643,6 @@ readCarAt frame placed =
         }
     , currentLap =
         { time = car.currentLap |> Maybe.andThen .time
-        , miniSectors = car.currentLap |> Maybe.andThen .miniSectors
         , elapsed = timing.currentLapElapsed
         , progress =
             car.currentLap
@@ -621,6 +669,10 @@ readCarAt frame placed =
                     (Performance.ofSectors frame.records
                         >> currentSectorStates timing.sector
                     )
+        , miniSectorStates =
+            car.currentLap
+                |> Maybe.andThen (Performance.ofMiniSectors frame.records)
+                |> Maybe.map (currentMiniSectorStates timing.miniSector)
         }
     , lastLap =
         { rated =

--- a/package/src/Motorsport/Race/Snapshot.elm
+++ b/package/src/Motorsport/Race/Snapshot.elm
@@ -102,11 +102,12 @@ car is stays at the top, and so does `bestLap`, for the reason below.
 
 Grouping the two laps apart is by which lap the reading came off, which cuts
 across the other question one can ask of these fields: whether the reading is a
-position or a rating. Every rating here -- `currentLap.rated`, `currentLap.sectorStates`,
-`currentLap.miniSectorStates`, `lastLap.rated`, `lastLap.sectors`,
-`lastLap.miniSectors` and `bestLap` -- is measured against the records held at
-this moment rather than the ones the race ends on, and the grouping leaves them in three separate places. That is why
-it is said here, once, instead of at each of them; see
+position or a rating. Every rating here -- `currentLap.rated`,
+`currentLap.sectorStates`, `currentLap.miniSectorStates`, `lastLap.rated`,
+`lastLap.sectors`, `lastLap.miniSectors` and `bestLap` -- is measured against
+the records held at this moment rather than the ones the race ends on, and the
+grouping leaves them in three separate places. That is why it is said here,
+once, instead of at each of them; see
 [`Lap.Performance`](Motorsport-Lap-Performance).
 
 Two records, in fact: the race's, which is [`bestTimes`](#bestTimes)'s to hold,
@@ -121,7 +122,7 @@ type alias CarAt =
     , status : Status
     , currentDriver : Maybe Driver
     , standing : Standing
-    , currentLap : CurrentLap
+    , currentLap : Maybe CurrentLap
     , lastLap : LastLap
     , bestLap : Maybe RatedTime
     }
@@ -153,6 +154,12 @@ type alias Standing =
 
 {-| The lap the car is on, as it reads at this moment.
 
+Held as a `Maybe` on [`CarAt`](#CarAt) rather than field by field, because
+whether the car is on a lap at all is one question and it is asked there once. A
+car that has turned no lap has none of this; a car that has finished one keeps
+it, since a lap stays the car's current one until the next begins, so a car that
+has retired or taken the flag still reads the last lap it ran.
+
 `elapsed` is how long the car has been on it, counted from the last time it
 crossed the line -- or from the race start, for a car still on its opening lap.
 
@@ -171,18 +178,11 @@ and how it rates -- which is what a strip of cells is drawn from. They are cut
 at the clock already, so a view draws them without asking what the car has
 reached.
 
-`sector` and `sectorStates` are `Nothing` together, for a car with no lap in
-progress: a car that is not on a lap is nowhere on the track. In practice that
-means a car that has turned no lap at all -- a lap the car has finished stays
-its current one until the next begins, so a car that has retired or taken the
-flag keeps the last lap it ran.
-
-`miniSectorStates` is `Nothing` under that same condition and one more: a lap
-with no mini-sector times has none to rate. Away from Le Mans no lap has any, so
-there it is `Nothing` throughout while the two above are not. `miniSector` is
-`Nothing` in both those cases and in one of its own -- a clock past the last
-mini-sector of the lap is in none of them, which is the same lap-is-over reading
-that fills `miniSectorStates` in.
+The two mini-sector readings are what remains `Maybe` here, and for a reason of
+their own: a lap with no mini-sector times has none to be in or to rate, and
+away from Le Mans no lap has any. `miniSector` is also `Nothing` for a clock
+past the last mini-sector of the lap, which is in none of them -- the same
+lap-is-over reading that fills `miniSectorStates` in.
 
 What `rated`, `sectorStates` and `miniSectorStates` are rated against is
 [`CarAt`](#CarAt)'s to say, along with every other rating on a car.
@@ -192,10 +192,10 @@ type alias CurrentLap =
     { time : Maybe Duration
     , elapsed : Duration
     , progress : Float
-    , sector : Maybe Lap.SectorProgress
+    , rated : RatedTime
+    , sector : Lap.SectorProgress
+    , sectorStates : CurrentSectorStates
     , miniSector : Maybe Lap.MiniSectorProgress
-    , rated : Maybe RatedTime
-    , sectorStates : Maybe CurrentSectorStates
     , miniSectorStates : Maybe CurrentMiniSectorStates
     }
 
@@ -286,26 +286,21 @@ at clock race =
         }
 
 
-currentSectorStates : Maybe Lap.SectorProgress -> SectorPerformance -> CurrentSectorStates
-currentSectorStates sectorProgress rated =
+currentSectorStates : Lap.SectorProgress -> SectorPerformance -> CurrentSectorStates
+currentSectorStates current rated =
     let
         -- Sectors already driven through are complete, the ones ahead
-        -- untouched; no sector in progress at all means the lap is over.
+        -- untouched.
         progressOf sector =
-            case sectorProgress of
-                Just current ->
-                    case Sector.compare sector current.sector of
-                        LT ->
-                            1
-
-                        EQ ->
-                            current.progress
-
-                        GT ->
-                            0
-
-                Nothing ->
+            case Sector.compare sector current.sector of
+                LT ->
                     1
+
+                EQ ->
+                    current.progress
+
+                GT ->
+                    0
     in
     Sector.map2 (\progress rating -> { progress = progress, rated = rating })
         (Sector.initialize progressOf)
@@ -479,8 +474,6 @@ sampleCar clock race car =
 
 type alias Timing =
     { currentLapElapsed : Duration
-    , sector : Maybe Lap.SectorProgress
-    , miniSector : Maybe Lap.MiniSectorProgress
     , gapToLeader : Gap
     , intervalToAhead : Gap
     }
@@ -491,35 +484,64 @@ timingOf raceElapsed rivals car =
     let
         raceClock =
             { elapsed = raceElapsed }
-
-        -- A car on its opening lap has no lap behind it, and that lap began at
-        -- the race start -- which is the instant `Lap.empty` carries. So the
-        -- empty lap stands in for the missing one here rather than papering
-        -- over it: both the elapsed time below and the mini-sector's own start
-        -- come out right for a first lap.
-        lastLap =
-            Maybe.withDefault Lap.empty car.lastLap
     in
-    { currentLapElapsed = Instant.since { from = lastLap.elapsed, to = raceClock.elapsed }
-    , sector =
-        -- Only a car with a lap in progress is anywhere on the lap. Reading a
-        -- sector off `Lap.empty` would place every car without lap data at the
-        -- start of the track, which is a position it does not hold.
-        car.currentLap
-            |> Maybe.map
-                (\lap ->
-                    let
-                        sectorProgress =
-                            Lap.progressAt raceClock lap
-                    in
-                    { sectorProgress | progress = min 1 sectorProgress.progress }
-                )
-    , miniSector =
-        car.currentLap
-            |> Maybe.andThen
-                (\lap -> Lap.miniSectorProgressAt raceClock { current = lap, previous = lastLap })
+    { currentLapElapsed =
+        -- A car on its opening lap has no lap behind it, and that lap began at
+        -- the race start -- which is the instant `Lap.empty` carries, so the
+        -- empty lap stands in for the missing one rather than papering over it.
+        Instant.since
+            { from = (Maybe.withDefault Lap.empty car.lastLap).elapsed
+            , to = raceClock.elapsed
+            }
     , gapToLeader = gapTo raceClock car rivals.leader
     , intervalToAhead = gapTo raceClock car rivals.rival
+    }
+
+
+{-| Read the lap a car is on at this moment.
+
+Only ever called with the lap the car is actually on, which is what lets the
+readings that need one be plain rather than `Maybe`: there is a sector the car
+is in, and a running time to rate, because there is a lap.
+
+-}
+readCurrentLap :
+    { clock : { elapsed : Instant }
+    , records : BestTimes.Snapshot
+    , fastestLapTime : Maybe Duration
+    , personalBest : Maybe Duration
+    , elapsed : Duration
+    , previousLap : Lap
+    }
+    -> Lap
+    -> CurrentLap
+readCurrentLap frame lap =
+    let
+        sector =
+            let
+                sectorProgress =
+                    Lap.progressAt frame.clock lap
+            in
+            { sectorProgress | progress = min 1 sectorProgress.progress }
+
+        miniSector =
+            Lap.miniSectorProgressAt frame.clock { current = lap, previous = frame.previousLap }
+    in
+    { time = lap.time
+    , elapsed = frame.elapsed
+    , progress =
+        lap.time
+            |> Maybe.map (\lapTime -> min 1.0 (toFloat frame.elapsed / toFloat lapTime))
+            |> Maybe.withDefault 0
+    , rated =
+        Performance.rate frame.fastestLapTime
+            { time = frame.elapsed, personalBest = frame.personalBest }
+    , sector = sector
+    , sectorStates = currentSectorStates sector (Performance.ofSectors frame.records lap)
+    , miniSector = miniSector
+    , miniSectorStates =
+        Performance.ofMiniSectors frame.records lap
+            |> Maybe.map (currentMiniSectorStates miniSector)
     }
 
 
@@ -642,38 +664,17 @@ readCarAt frame placed =
         , intervalToAhead = timing.intervalToAhead
         }
     , currentLap =
-        { time = car.currentLap |> Maybe.andThen .time
-        , elapsed = timing.currentLapElapsed
-        , progress =
-            car.currentLap
-                |> Maybe.andThen .time
-                |> Maybe.map (\lapTime -> min 1.0 (toFloat timing.currentLapElapsed / toFloat lapTime))
-                |> Maybe.withDefault 0
-        , sector = timing.sector
-        , miniSector = timing.miniSector
-        , rated =
-            -- On the lap for its presence alone, which is why the lap itself
-            -- goes unread: there is a running time to rate only while the car
-            -- is on a lap, and that time is the clock's, not the lap's.
-            car.currentLap
-                |> Maybe.andThen
-                    (\_ ->
-                        Performance.rateTime frame.fastestLapTime
-                            { time = Just timing.currentLapElapsed
-                            , personalBest = personalBest
-                            }
-                    )
-        , sectorStates =
-            car.currentLap
-                |> Maybe.map
-                    (Performance.ofSectors frame.records
-                        >> currentSectorStates timing.sector
-                    )
-        , miniSectorStates =
-            car.currentLap
-                |> Maybe.andThen (Performance.ofMiniSectors frame.records)
-                |> Maybe.map (currentMiniSectorStates timing.miniSector)
-        }
+        car.currentLap
+            |> Maybe.map
+                (readCurrentLap
+                    { clock = { elapsed = frame.raceElapsed }
+                    , records = frame.records
+                    , fastestLapTime = frame.fastestLapTime
+                    , personalBest = personalBest
+                    , elapsed = timing.currentLapElapsed
+                    , previousLap = Maybe.withDefault Lap.empty car.lastLap
+                    }
+                )
     , lastLap =
         { rated =
             car.lastLap

--- a/package/src/Motorsport/Race/Snapshot.elm
+++ b/package/src/Motorsport/Race/Snapshot.elm
@@ -93,9 +93,18 @@ already turned is here as what was read off it -- `lapsCompleted`, and
 [`lastLap`](#LastLap) -- rather than as the lap itself.
 
 What is read off the lap in progress and off the one just finished is grouped
-under [`currentLap`](#CurrentLap) and [`lastLap`](#LastLap), so that the two
-cannot be mistaken for one another at a call site; what stands apart from both
--- who the car is, where it stands, the gaps it holds -- stays at the top.
+under [`currentLap`](#CurrentLap) and [`lastLap`](#LastLap); what stands apart
+from both -- who the car is, where it stands, the gaps it holds -- stays at the
+top.
+
+That grouping is by which lap the reading came off, which cuts across the other
+question one can ask of these fields: whether the reading is a position or a
+rating. Every rating here -- `currentLap.rated`, `currentLap.sectorStates`,
+`lastLap.rated`, `lastLap.sectors`, `lastLap.miniSectors` and `bestLapRated` --
+is measured against the record the race held at this moment rather than the one
+it ends on, and the grouping leaves them in three separate places. That is why
+it is said here, once, instead of at each of them; see
+[`Lap.Performance`](Motorsport-Lap-Performance).
 
 -}
 type alias CarAt =
@@ -132,8 +141,8 @@ lap's recorded mini-sector times, which is data rather than a position.
 `sector`, `miniSector` and `sectorStates` are `Nothing` together, for a car with
 no lap in progress: a car that is not on a lap is nowhere on the track.
 
-`rated` and `sectorStates` are rated against the record the race held at this
-moment; see [`Lap.Performance`](Motorsport-Lap-Performance).
+What `rated` and `sectorStates` are rated against is [`CarAt`](#CarAt)'s to say,
+along with every other rating on a car.
 
 -}
 type alias CurrentLap =
@@ -152,8 +161,7 @@ type alias CurrentLap =
 {-| The lap the car has just finished, as it was read off it.
 
 The lap itself is not here -- see [`CarAt`](#CarAt) -- only what was read: the
-time it took and how its sectors went, each rated against the record the race
-held at this moment.
+time it took and how its sectors went, each rated as every rating on a car is.
 
 `miniSectors` is `Nothing` away from Le Mans, where the source data records no
 mini-sectors to rate.

--- a/package/src/Motorsport/Race/Snapshot.elm
+++ b/package/src/Motorsport/Race/Snapshot.elm
@@ -27,8 +27,8 @@ same clock, so they are taken here too rather than by each caller: see
 [`bestTimes`](#bestTimes) and [`lapHistory`](#lapHistory).
 
 Reading one car or one class out of the field is the snapshot's own business --
-`get` and `inClass` below -- so that a view narrowing the field does not have to
-scan `toList` for it.
+`get` and `inClass` below -- so that a view narrowing the field says which one
+it wants rather than working it out of `toList`.
 
 @docs Snapshot, CarAt, Standing, CurrentLap, LastLap
 @docs CurrentSectorStates, CurrentMiniSectorStates
@@ -38,7 +38,7 @@ scan `toList` for it.
 
 -}
 
-import Dict exposing (Dict)
+import Dict
 import Motorsport.BestTimes as BestTimes
 import Motorsport.Circuit.LeMans as LeMans exposing (ByMiniSector)
 import Motorsport.Class as Class exposing (Class)
@@ -77,12 +77,6 @@ type Snapshot
         -- never re-sort them, so the phantom-typed SortedList guarantee isn't
         -- worth the extra unwrapping at each call site.
         , carsByClass : List ( Class, List CarAt )
-
-        -- The same cars again, to look one up by number. Built with the rest of
-        -- the frame so that `get` costs a lookup rather than a scan of the
-        -- field; two cars sharing a number leave only the leading one here,
-        -- which is the one a caller asking by number wants.
-        , carsByNumber : Dict CarNumber CarAt
         }
 
 
@@ -248,7 +242,6 @@ at clock race =
         , lapCount = Race.lapCountAt clock race
         , cars = sortedCars
         , carsByClass = groupByClass sortedCars
-        , carsByNumber = indexByCarNumber cars
         , bestTimes = records
         , lapHistory = LapHistory.at clock race.cars
         }
@@ -308,18 +301,6 @@ currentMiniSectorStates miniSectorProgress rated =
         rated
 
 
-{-| Index the field by car number.
-
-Folded from the right so that the leading car wins a number two cars share:
-`Dict.insert` keeps the last write, and folding backwards makes that the car
-earliest in the running order.
-
--}
-indexByCarNumber : List CarAt -> Dict CarNumber CarAt
-indexByCarNumber =
-    List.foldr (\car -> Dict.insert car.metadata.carNumber car) Dict.empty
-
-
 groupByClass : SortedList ByPosition CarAt -> List ( Class, List CarAt )
 groupByClass sortedCars =
     sortedCars
@@ -342,10 +323,18 @@ toClassList (Snapshot s) =
 
 
 {-| One car of the field by its number, where the race has such a car.
+
+A scan of the field, which is what a call that comes now and then wants: an
+index would be built every frame whether anything asked for a car or not. Two
+cars sharing a number -- which the source data occasionally has -- give the one
+running ahead, since the field is in running order.
+
 -}
 get : CarNumber -> Snapshot -> Maybe CarAt
 get carNumber (Snapshot s) =
-    Dict.get carNumber s.carsByNumber
+    SortedList.toList s.cars
+        |> List.filter (\car -> car.metadata.carNumber == carNumber)
+        |> List.head
 
 
 {-| The cars racing in one class, in running order.

--- a/package/src/Motorsport/Race/Snapshot.elm
+++ b/package/src/Motorsport/Race/Snapshot.elm
@@ -134,8 +134,9 @@ The placings and the gaps are read off the same running order, in the same pass;
 see [`at`](#at). `lapsCompleted` counts laps the car has finished, so a car on
 its opening lap has none.
 
-Both gaps are [`Gap.none`](Motorsport-Gap#none) where there is no car to measure
-to: the leader holds neither, and the first car of the field has no interval.
+Both gaps are [`Gap.none`](Motorsport-Gap#none) for the leading car, and only
+for it: it is both the car the race is measured to and the car nothing runs
+ahead of, so there is nothing for either gap to reach.
 
 -}
 type alias Standing =
@@ -166,8 +167,15 @@ not how anything is drawn. Singular `miniSector` is one of those three -- which
 mini-sector the car is in, and how far through it; plural `miniSectors` is the
 lap's recorded mini-sector times, which is data rather than a position.
 
-`sector`, `miniSector` and `sectorStates` are `Nothing` together, for a car with
-no lap in progress: a car that is not on a lap is nowhere on the track.
+`sector` and `sectorStates` are `Nothing` together, for a car with no lap in
+progress: a car that is not on a lap is nowhere on the track. In practice that
+means a car that has turned no lap at all -- a lap the car has finished stays
+its current one until the next begins, so a car that has retired or taken the
+flag keeps the last lap it ran.
+
+`miniSector` is `Nothing` under that same condition and one more: a lap with no
+mini-sector times has no mini-sector to be in. Away from Le Mans no lap has any,
+so there `miniSector` is `Nothing` throughout while the two above are not.
 
 What `rated` and `sectorStates` are rated against is [`CarAt`](#CarAt)'s to say,
 along with every other rating on a car.
@@ -566,6 +574,9 @@ readCarAt frame placed =
         -- it off the finished lap is what stops the lap being rated against
         -- itself. A car on its opening lap has no record yet, which is what
         -- `Nothing` says here.
+        --
+        -- Read once: both the baseline `currentLap.rated` is rated against and
+        -- `bestLapRated` come off this, so the two cannot come apart.
         personalBest =
             car.lastLap |> Maybe.andThen .best
     in
@@ -620,10 +631,9 @@ readCarAt frame placed =
             car.lastLap |> Maybe.andThen (Performance.ofMiniSectors frame.records)
         }
     , bestLapRated =
-        car.lastLap
-            |> Maybe.andThen
-                (\lap ->
-                    Performance.rateTime frame.fastestLapTime
-                        { time = lap.best, personalBest = lap.best }
-                )
+        -- The record itself, rated: `rateTime` gives nothing back for a car
+        -- that has not set one, which is the same `Nothing` `personalBest`
+        -- already carries.
+        Performance.rateTime frame.fastestLapTime
+            { time = personalBest, personalBest = personalBest }
     }

--- a/package/src/Motorsport/Race/Snapshot.elm
+++ b/package/src/Motorsport/Race/Snapshot.elm
@@ -1,5 +1,5 @@
 module Motorsport.Race.Snapshot exposing
-    ( Snapshot, CarAt, CurrentLap, LastLap, CurrentSectorStates
+    ( Snapshot, CarAt, Standing, CurrentLap, LastLap, CurrentSectorStates
     , at
     , toList, toClassList, get, inClass, leader, lapCount, elapsed
     , bestTimes, lapHistory
@@ -29,7 +29,7 @@ Reading one car or one class out of the field is the snapshot's own business --
 `get` and `inClass` below -- so that a view narrowing the field does not have to
 scan `toList` for it.
 
-@docs Snapshot, CarAt, CurrentLap, LastLap, CurrentSectorStates
+@docs Snapshot, CarAt, Standing, CurrentLap, LastLap, CurrentSectorStates
 @docs at
 @docs toList, toClassList, get, inClass, leader, lapCount, elapsed
 @docs bestTimes, lapHistory
@@ -89,15 +89,16 @@ Readings only -- no laps of any kind. The whole list runs to the end of the
 race, and handing it out beside values that stop at the clock is how future data
 gets read by accident; the laps up to this moment are
 [`lapHistory`](#lapHistory)'s to give out, already cut. A lap the car has
-already turned is here as what was read off it -- `lapsCompleted`, and
+already turned is here as what was read off it -- `standing.lapsCompleted`, and
 [`lastLap`](#LastLap) -- rather than as the lap itself.
 
-What is read off the lap in progress and off the one just finished is grouped
-under [`currentLap`](#CurrentLap) and [`lastLap`](#LastLap); what stands apart
-from both -- who the car is, where it stands, the gaps it holds -- stays at the
-top.
+Three groups, by what the reading is of. Where the car stands in the field is
+[`standing`](#Standing); what was read off the lap it is on and off the one it
+just finished is [`currentLap`](#CurrentLap) and [`lastLap`](#LastLap). Who the
+car is stays at the top, and so does `bestLapRated`, which belongs to no group.
 
-That grouping is by which lap the reading came off, which cuts across the other
+Grouping the two laps apart is by which lap the reading came off, which cuts
+across the other
 question one can ask of these fields: whether the reading is a position or a
 rating. Every rating here -- `currentLap.rated`, `currentLap.sectorStates`,
 `lastLap.rated`, `lastLap.sectors`, `lastLap.miniSectors` and `bestLapRated` --
@@ -111,11 +112,7 @@ type alias CarAt =
     { metadata : Car.Metadata
     , status : Status
     , currentDriver : Maybe Driver
-    , position : Int
-    , positionInClass : Int
-    , lapsCompleted : Int
-    , gapToLeader : Gap
-    , intervalToAhead : Gap
+    , standing : Standing
     , currentLap : CurrentLap
     , lastLap : LastLap
 
@@ -123,6 +120,29 @@ type alias CarAt =
     -- lap it is on nor the one it just finished, so it belongs to neither
     -- group.
     , bestLapRated : Maybe RatedTime
+    }
+
+
+{-| Where the car stands in the race at this moment.
+
+The five a classification line is made of, in the order one prints them: what
+the car is placed overall and in its class, how many laps it has behind it, and
+how far back it is from the leader and from the car it is actually racing.
+
+The placings and the gaps are read off the same running order, in the same pass;
+see [`at`](#at). `lapsCompleted` counts laps the car has finished, so a car on
+its opening lap has none.
+
+Both gaps are [`Gap.none`](Motorsport-Gap#none) where there is no car to measure
+to: the leader holds neither, and the first car of the field has no interval.
+
+-}
+type alias Standing =
+    { position : Int
+    , positionInClass : Int
+    , lapsCompleted : Int
+    , gapToLeader : Gap
+    , intervalToAhead : Gap
     }
 
 
@@ -220,7 +240,7 @@ at clock race =
                     )
 
         sortedCars =
-            Ordering.byPosition cars
+            Ordering.byPosition (.standing >> .position) cars
     in
     Snapshot
         { elapsed = clock.elapsed
@@ -533,11 +553,13 @@ readCarAt frame placed =
     { metadata = car.metadata
     , status = car.status
     , currentDriver = car.currentDriver
-    , position = placed.position
-    , positionInClass = placed.positionInClass
-    , lapsCompleted = car.lastLap |> Maybe.map .lap |> Maybe.withDefault 0
-    , gapToLeader = timing.gapToLeader
-    , intervalToAhead = timing.intervalToAhead
+    , standing =
+        { position = placed.position
+        , positionInClass = placed.positionInClass
+        , lapsCompleted = car.lastLap |> Maybe.map .lap |> Maybe.withDefault 0
+        , gapToLeader = timing.gapToLeader
+        , intervalToAhead = timing.intervalToAhead
+        }
     , currentLap =
         { time = car.currentLap |> Maybe.andThen .time
         , best = car.currentLap |> Maybe.andThen .best

--- a/package/src/Motorsport/Race/Snapshot.elm
+++ b/package/src/Motorsport/Race/Snapshot.elm
@@ -445,7 +445,6 @@ The status is looked up rather than worked out here; see
 type alias SampledCar =
     Gap.Competitor
         { metadata : Car.Metadata
-        , lapInProgress : Lap
         , lastLap : Maybe Lap
         , status : Status
         , currentDriver : Driver
@@ -457,18 +456,17 @@ type alias SampledCar =
 `Nothing` for a car with no lap in progress, which is a car that has turned no
 lap at all: a lap stays the car's current one until the next begins, so a car
 that has retired or taken the flag still has one. Such a car is not in the
-field. It holds no place in a running order --
-[`Ordering.runningOrder`](Motorsport-Ordering#runningOrder) says as much of two
-of them -- and there is nothing to report of it but its number.
+field -- there is no answer to where it stands, and nothing to report of it but
+its number.
 
-Nor can the data produce one. The loader builds the entry list out of the lap
-records themselves, so a car that completed no lap is in neither of the files
-the app reads; keeping it out here is what lets a [`CarAt`](#CarAt) carry its
-lap plainly rather than as a `Maybe` no race could fill.
+This is the one place that is settled, and everything downstream is written
+knowing it: [`Ordering.runningOrder`](Motorsport-Ordering#runningOrder) and
+[`Gap.Competitor`](Motorsport-Gap#Competitor) both ask for a lap rather than a
+`Maybe` of one, and a [`CarAt`](#CarAt) carries its lap plainly.
 
-`lapInProgress` is that lap, and `currentLap` is the same lap in the shape
-[`Gap.Competitor`](Motorsport-Gap#Competitor) and the ordering read it in. The
-`Maybe` is theirs, not this module's.
+Nor can the data produce such a car. The loader builds the entry list out of the
+lap records themselves, so one that completed no lap is in neither of the files
+the app reads.
 
 -}
 sampleCar : { elapsed : Instant } -> Race -> Car -> Maybe SampledCar
@@ -478,8 +476,7 @@ sampleCar clock race car =
             (\lap ->
                 { metadata = car.metadata
                 , laps = car.laps
-                , currentLap = Just lap
-                , lapInProgress = lap
+                , currentLap = lap
                 , lastLap = Lap.findLastLapAt clock car.laps
                 , status = Race.statusAt clock car.metadata.carNumber race
                 , currentDriver = lap.driver
@@ -693,7 +690,7 @@ readCarAt frame placed =
             , elapsed = timing.currentLapElapsed
             , previousLap = Maybe.withDefault Lap.empty car.lastLap
             }
-            car.lapInProgress
+            car.currentLap
     , lastLap =
         { rated =
             car.lastLap

--- a/package/src/Motorsport/Widget/Compare/CarSelector.elm
+++ b/package/src/Motorsport/Widget/Compare/CarSelector.elm
@@ -10,7 +10,6 @@ import Css exposing (num, opacity, property)
 import Html.Styled exposing (Html, button, div, text)
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events exposing (onClick)
-import List.Extra
 import Motorsport.Class as Class exposing (Class)
 import Motorsport.Manufacturer as Manufacturer
 import Motorsport.Race.Snapshot as Snapshot exposing (CarAt, Snapshot)
@@ -23,10 +22,7 @@ carSelector : (String -> msg) -> Snapshot -> Class -> List String -> Html msg
 carSelector onToggleCar standings class selectedCarNumbers =
     let
         classCars =
-            Snapshot.toClassList standings
-                |> List.Extra.find (\( carClass, _ ) -> carClass == class)
-                |> Maybe.map Tuple.second
-                |> Maybe.withDefault []
+            Snapshot.inClass class standings
     in
     div
         [ css

--- a/package/src/Motorsport/Widget/Compare/CarSummary.elm
+++ b/package/src/Motorsport/Widget/Compare/CarSummary.elm
@@ -125,9 +125,7 @@ driverList : CarAt -> Html msg
 driverList item =
     let
         isCurrentDriver driver =
-            item.currentDriver
-                |> Maybe.map (Driver.isSame driver)
-                |> Maybe.withDefault False
+            Driver.isSame driver item.currentDriver
     in
     div
         [ css

--- a/package/src/Motorsport/Widget/Compare/CarSummary.elm
+++ b/package/src/Motorsport/Widget/Compare/CarSummary.elm
@@ -198,11 +198,11 @@ summaryStats item =
             , property "grid-template-columns" "repeat(5, minmax(0, 1fr))"
             ]
         ]
-        [ statCell "Pos" (text ("P" ++ String.fromInt item.position))
-        , statCell "Class" (text ("P" ++ String.fromInt item.positionInClass))
-        , statCell "Laps" (text (String.fromInt item.lapsCompleted))
-        , statCell "Gap" (text (Gap.toString item.gapToLeader))
-        , statCell "Int" (text (Gap.toString item.intervalToAhead))
+        [ statCell "Pos" (text ("P" ++ String.fromInt item.standing.position))
+        , statCell "Class" (text ("P" ++ String.fromInt item.standing.positionInClass))
+        , statCell "Laps" (text (String.fromInt item.standing.lapsCompleted))
+        , statCell "Gap" (text (Gap.toString item.standing.gapToLeader))
+        , statCell "Int" (text (Gap.toString item.standing.intervalToAhead))
         ]
 
 

--- a/package/src/Motorsport/Widget/Compare/Distribution.elm
+++ b/package/src/Motorsport/Widget/Compare/Distribution.elm
@@ -50,7 +50,7 @@ seriesOf lapHistory range entry =
     { color = Manufacturer.toColorWithFallback entry.metadata
     , emphasis = Focused
     , times = racingTimes lapHistory range entry
-    , lastLap = entry.lastLapRated |> Maybe.map .time
+    , lastLap = entry.lastLap.rated |> Maybe.map .time
     }
 
 

--- a/package/src/Motorsport/Widget/Compare/PositionProgression.elm
+++ b/package/src/Motorsport/Widget/Compare/PositionProgression.elm
@@ -41,14 +41,6 @@ lapRange snapshot class =
     Maybe.map2 Tuple.pair (List.minimum lapNumbers) (List.maximum lapNumbers)
 
 
-classEntriesOf : Snapshot -> Class -> List CarAt
-classEntriesOf snapshot class =
-    Snapshot.toClassList snapshot
-        |> List.Extra.find (\( carClass, _ ) -> carClass == class)
-        |> Maybe.map Tuple.second
-        |> Maybe.withDefault []
-
-
 {-| Builds the "position points past the threshold" for each car in the class,
 keeping only cars with two or more points. Centralizes the point-extraction
 condition here so the chart itself and `lapRange` share the same X axis.
@@ -62,7 +54,7 @@ classPositionPoints snapshot class =
         lapHistory =
             Snapshot.lapHistory snapshot
     in
-    classEntriesOf snapshot class
+    Snapshot.inClass class snapshot
         |> List.map (\item -> ( item, buildPositionPoints lapThreshold (LapHistory.get item.metadata.carNumber lapHistory) ))
         |> List.filter (\( _, points ) -> List.length points >= 2)
 

--- a/package/src/Motorsport/Widget/Leaderboard.elm
+++ b/package/src/Motorsport/Widget/Leaderboard.elm
@@ -61,14 +61,13 @@ import Html.Styled.Attributes exposing (alt, css, src)
 import Html.Styled.Lazy as Lazy
 import Motorsport.BestTimes as BestTimes exposing (Holder)
 import Motorsport.Chart.Histogram as Histogram
-import Motorsport.Circuit.LeMans as LeMans exposing (ByMiniSector)
 import Motorsport.Class as Class exposing (Class)
 import Motorsport.Driver as Driver exposing (Driver)
 import Motorsport.Duration as Duration exposing (Duration)
-import Motorsport.Lap exposing (Lap, MiniSectorProgress, MiniSectors, SectorProgress)
+import Motorsport.Lap exposing (Lap)
 import Motorsport.Lap.Performance as Performance exposing (MiniSectorPerformance, RatedTime, SectorPerformance, performanceLevel)
 import Motorsport.Manufacturer as Manufacturer exposing (Manufacturer)
-import Motorsport.Race.Snapshot as Snapshot exposing (CarAt, CurrentSectorStates, Snapshot)
+import Motorsport.Race.Snapshot as Snapshot exposing (CarAt, CurrentMiniSectorStates, CurrentSectorStates, Snapshot)
 import Motorsport.Sector as Sector
 import Motorsport.Status as Status exposing (Status)
 
@@ -134,6 +133,68 @@ colorOfRated =
 colorOfPerformance : Maybe Performance.PerformanceLevel -> String
 colorOfPerformance =
     Maybe.withDefault Performance.Standard >> Performance.toColorVariable
+
+
+{-| One cell of a sector or mini-sector strip: white as far as the car has got
+while it is still in that stretch, and its rating's colour once the whole of it
+is behind.
+
+Both strips draw from [`Race.Snapshot`](Motorsport-Race-Snapshot)'s reading of
+where the car stands, so at three sectors and at fifteen mini-sectors the cell
+is the same cell.
+
+-}
+progressCell : { a | progress : Float, rated : Maybe RatedTime } -> Html msg
+progressCell { progress, rated } =
+    div
+        [ css
+            [ height (px 3)
+            , borderRadius (px 1)
+            , batch <|
+                if progress < 1 then
+                    [ width (pct (progress * 100))
+                    , backgroundColor (oklch 1 0 0)
+                    ]
+
+                else
+                    [ width (pct 100)
+                    , property "background-color" (colorOfRated rated)
+                    ]
+            ]
+        ]
+        []
+
+
+{-| The seventeen columns of the Le Mans strip: the fifteen mini-sectors in
+track order, with a spacer where each of the first two sectors ends.
+-}
+miniSectorStrip : Snapshot.CurrentMiniSectorStates -> Html msg
+miniSectorStrip states =
+    div
+        [ css
+            [ property "display" "grid"
+            , property "grid-template-columns" "2fr 2fr 3fr 0.5fr 5fr 1fr 3fr 3fr 0.5fr 1fr 5fr 3fr 2fr 1fr 1fr 1fr 1fr"
+            , property "column-gap" "1px"
+            ]
+        ]
+        [ progressCell states.scl2
+        , progressCell states.z4
+        , progressCell states.ip1
+        , div [] []
+        , progressCell states.z12
+        , progressCell states.sclc
+        , progressCell states.a7_1
+        , progressCell states.ip2
+        , div [] []
+        , progressCell states.a8_1
+        , progressCell states.sclb
+        , progressCell states.porin
+        , progressCell states.porout
+        , progressCell states.pitref
+        , progressCell states.scl1
+        , progressCell states.fordout
+        , progressCell states.fl
+        ]
 
 
 
@@ -415,25 +476,6 @@ viewCurrentLapColumn_Wec { status, currentLap } =
                     ]
                 ]
                 [ text (Duration.toString time) ]
-
-        sectorCell { progress, rated } =
-            div
-                [ css
-                    [ height (px 3)
-                    , borderRadius (px 1)
-                    , batch <|
-                        if progress < 1 then
-                            [ width (pct (progress * 100))
-                            , backgroundColor (oklch 1 0 0)
-                            ]
-
-                        else
-                            [ width (pct 100)
-                            , property "background-color" (colorOfRated rated)
-                            ]
-                    ]
-                ]
-                []
     in
     if Status.hasRetired status then
         div [ css [ textAlign center ] ] [ text "Retired" ]
@@ -450,7 +492,7 @@ viewCurrentLapColumn_Wec { status, currentLap } =
                             , property "column-gap" "4px"
                             ]
                         ]
-                        (List.map sectorCell (Sector.values slots))
+                        (List.map progressCell (Sector.values slots))
                     ]
             )
             currentLap.rated
@@ -468,13 +510,11 @@ currentLapColumn_LeMans24h :
                 , currentLap :
                     { c
                         | elapsed : Duration
-                        , miniSectors : Maybe MiniSectors
-                        , sector : Maybe SectorProgress
-                        , miniSector : Maybe MiniSectorProgress
+                        , miniSectorStates : Maybe CurrentMiniSectorStates
                     }
             }
     , sorter : data -> data -> Order
-    , bestTimes : { b | fastestLapTime : Maybe Holder, fastestMiniSectors : ByMiniSector (Maybe Holder) }
+    , bestTimes : { b | fastestLapTime : Maybe Holder }
     }
     -> Column data msg
 currentLapColumn_LeMans24h { getter, sorter, bestTimes } =
@@ -486,7 +526,7 @@ currentLapColumn_LeMans24h { getter, sorter, bestTimes } =
 
 
 viewCurrentLapColumn_LeMans24h :
-    { b | fastestLapTime : Maybe Holder, fastestMiniSectors : ByMiniSector (Maybe Holder) }
+    { b | fastestLapTime : Maybe Holder }
     ->
         { a
             | status : Status
@@ -494,9 +534,7 @@ viewCurrentLapColumn_LeMans24h :
             , currentLap :
                 { c
                     | elapsed : Duration
-                    , miniSectors : Maybe MiniSectors
-                    , sector : Maybe SectorProgress
-                    , miniSector : Maybe MiniSectorProgress
+                    , miniSectorStates : Maybe CurrentMiniSectorStates
                 }
         }
     -> Html msg
@@ -523,36 +561,6 @@ viewCurrentLapColumn_LeMans24h bestTimes { status, bestLap, currentLap } =
                     ]
                 ]
                 [ text (Duration.toString time) ]
-
-        sectorCell sector_ =
-            div
-                [ css
-                    [ height (px 3)
-                    , borderRadius (px 1)
-                    , batch <|
-                        if sector_.progress < 1 then
-                            [ width (pct (sector_.progress * 100))
-                            , backgroundColor (oklch 1 0 0)
-                            ]
-
-                        else
-                            [ width (pct 100)
-                            , property "background-color"
-                                (sector_.time
-                                    |> Maybe.map
-                                        (\time ->
-                                            performanceLevel
-                                                { time = time
-                                                , personalBest = sector_.personalBest
-                                                , fastest = sector_.fastest
-                                                }
-                                        )
-                                    |> colorOfPerformance
-                                )
-                            ]
-                    ]
-                ]
-                []
     in
     if Status.hasRetired status then
         div [ css [ textAlign center ] ] [ text "Retired" ]
@@ -563,29 +571,9 @@ viewCurrentLapColumn_LeMans24h bestTimes { status, bestLap, currentLap } =
                 (\best ->
                     div [ css [ displayFlex, flexDirection column, property "row-gap" "5px" ] ]
                         [ lapTime { time = currentLap.elapsed, personalBest = Just best.time }
-                        , let
-                            progressMap =
-                                LeMans.calculateMiniSectorProgress currentLap.miniSector
-                          in
-                          div [ css [ property "display" "grid", property "grid-template-columns" "2fr 2fr 3fr 0.5fr 5fr 1fr 3fr 3fr 0.5fr 1fr 5fr 3fr 2fr 1fr 1fr 1fr 1fr", property "column-gap" "1px" ] ]
-                            [ sectorCell { time = Maybe.andThen (.scl2 >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.scl2 >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.scl2, progress = progressMap.scl2 }
-                            , sectorCell { time = Maybe.andThen (.z4 >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.z4 >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.z4, progress = progressMap.z4 }
-                            , sectorCell { time = Maybe.andThen (.ip1 >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.ip1 >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.ip1, progress = progressMap.ip1 }
-                            , div [] [] -- spacer
-                            , sectorCell { time = Maybe.andThen (.z12 >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.z12 >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.z12, progress = progressMap.z12 }
-                            , sectorCell { time = Maybe.andThen (.sclc >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.sclc >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.sclc, progress = progressMap.sclc }
-                            , sectorCell { time = Maybe.andThen (.a7_1 >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.a7_1 >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.a7_1, progress = progressMap.a7_1 }
-                            , sectorCell { time = Maybe.andThen (.ip2 >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.ip2 >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.ip2, progress = progressMap.ip2 }
-                            , div [] [] -- spacer
-                            , sectorCell { time = Maybe.andThen (.a8_1 >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.a8_1 >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.a8_1, progress = progressMap.a8_1 }
-                            , sectorCell { time = Maybe.andThen (.sclb >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.sclb >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.sclb, progress = progressMap.sclb }
-                            , sectorCell { time = Maybe.andThen (.porin >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.porin >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.porin, progress = progressMap.porin }
-                            , sectorCell { time = Maybe.andThen (.porout >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.porout >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.porout, progress = progressMap.porout }
-                            , sectorCell { time = Maybe.andThen (.pitref >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.pitref >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.pitref, progress = progressMap.pitref }
-                            , sectorCell { time = Maybe.andThen (.scl1 >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.scl1 >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.scl1, progress = progressMap.scl1 }
-                            , sectorCell { time = Maybe.andThen (.fordout >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.fordout >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.fordout, progress = progressMap.fordout }
-                            , sectorCell { time = Maybe.andThen (.fl >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.fl >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.fl, progress = progressMap.fl }
-                            ]
+                        , currentLap.miniSectorStates
+                            |> Maybe.map miniSectorStrip
+                            |> Maybe.withDefault (text "")
                         ]
                 )
             |> Maybe.withDefault (text "-")

--- a/package/src/Motorsport/Widget/Leaderboard.elm
+++ b/package/src/Motorsport/Widget/Leaderboard.elm
@@ -464,10 +464,10 @@ currentLapColumn_LeMans24h :
         ->
             { a
                 | status : Status
+                , bestLapRated : Maybe RatedTime
                 , currentLap :
                     { c
                         | elapsed : Duration
-                        , best : Maybe Duration
                         , miniSectors : Maybe MiniSectors
                         , sector : Maybe SectorProgress
                         , miniSector : Maybe MiniSectorProgress
@@ -490,17 +490,17 @@ viewCurrentLapColumn_LeMans24h :
     ->
         { a
             | status : Status
+            , bestLapRated : Maybe RatedTime
             , currentLap :
                 { c
                     | elapsed : Duration
-                    , best : Maybe Duration
                     , miniSectors : Maybe MiniSectors
                     , sector : Maybe SectorProgress
                     , miniSector : Maybe MiniSectorProgress
                 }
         }
     -> Html msg
-viewCurrentLapColumn_LeMans24h bestTimes { status, currentLap } =
+viewCurrentLapColumn_LeMans24h bestTimes { status, bestLapRated, currentLap } =
     let
         lapTime { time, personalBest } =
             div
@@ -558,11 +558,11 @@ viewCurrentLapColumn_LeMans24h bestTimes { status, currentLap } =
         div [ css [ textAlign center ] ] [ text "Retired" ]
 
     else
-        currentLap.best
+        bestLapRated
             |> Maybe.map
-                (\best ->
+                (\bestLap ->
                     div [ css [ displayFlex, flexDirection column, property "row-gap" "5px" ] ]
-                        [ lapTime { time = currentLap.elapsed, personalBest = Just best }
+                        [ lapTime { time = currentLap.elapsed, personalBest = Just bestLap.time }
                         , let
                             progressMap =
                                 LeMans.calculateMiniSectorProgress currentLap.miniSector

--- a/package/src/Motorsport/Widget/Leaderboard.elm
+++ b/package/src/Motorsport/Widget/Leaderboard.elm
@@ -437,7 +437,8 @@ currentLapColumn_Wec :
                 , currentLap :
                     Maybe
                         { b
-                            | rated : RatedTime
+                            | elapsed : Duration
+                            , performance : Performance.PerformanceLevel
                             , sectorStates : CurrentSectorStates
                         }
             }
@@ -458,7 +459,8 @@ viewCurrentLapColumn_Wec :
         , currentLap :
             Maybe
                 { b
-                    | rated : RatedTime
+                    | elapsed : Duration
+                    , performance : Performance.PerformanceLevel
                     , sectorStates : CurrentSectorStates
                 }
     }
@@ -487,7 +489,7 @@ viewCurrentLapColumn_Wec { status, currentLap } =
             |> Maybe.map
                 (\lap ->
                     div [ css [ displayFlex, flexDirection column, property "row-gap" "5px" ] ]
-                        [ lapTime lap.rated
+                        [ lapTime { time = lap.elapsed, performance = lap.performance }
                         , div
                             [ css
                                 [ property "display" "grid"

--- a/package/src/Motorsport/Widget/Leaderboard.elm
+++ b/package/src/Motorsport/Widget/Leaderboard.elm
@@ -435,10 +435,11 @@ currentLapColumn_Wec :
             { a
                 | status : Status
                 , currentLap :
-                    { b
-                        | rated : Maybe RatedTime
-                        , sectorStates : Maybe CurrentSectorStates
-                    }
+                    Maybe
+                        { b
+                            | rated : RatedTime
+                            , sectorStates : CurrentSectorStates
+                        }
             }
     , sorter : data -> data -> Order
     }
@@ -455,10 +456,11 @@ viewCurrentLapColumn_Wec :
     { a
         | status : Status
         , currentLap :
-            { b
-                | rated : Maybe RatedTime
-                , sectorStates : Maybe CurrentSectorStates
-            }
+            Maybe
+                { b
+                    | rated : RatedTime
+                    , sectorStates : CurrentSectorStates
+                }
     }
     -> Html msg
 viewCurrentLapColumn_Wec { status, currentLap } =
@@ -481,22 +483,21 @@ viewCurrentLapColumn_Wec { status, currentLap } =
         div [ css [ textAlign center ] ] [ text "Retired" ]
 
     else
-        Maybe.map2
-            (\rated slots ->
-                div [ css [ displayFlex, flexDirection column, property "row-gap" "5px" ] ]
-                    [ lapTime rated
-                    , div
-                        [ css
-                            [ property "display" "grid"
-                            , property "grid-template-columns" "1fr 1fr 1fr"
-                            , property "column-gap" "4px"
+        currentLap
+            |> Maybe.map
+                (\lap ->
+                    div [ css [ displayFlex, flexDirection column, property "row-gap" "5px" ] ]
+                        [ lapTime lap.rated
+                        , div
+                            [ css
+                                [ property "display" "grid"
+                                , property "grid-template-columns" "1fr 1fr 1fr"
+                                , property "column-gap" "4px"
+                                ]
                             ]
+                            (List.map progressCell (Sector.values lap.sectorStates))
                         ]
-                        (List.map progressCell (Sector.values slots))
-                    ]
-            )
-            currentLap.rated
-            currentLap.sectorStates
+                )
             |> Maybe.withDefault (text "-")
 
 
@@ -508,10 +509,11 @@ currentLapColumn_LeMans24h :
                 | status : Status
                 , bestLap : Maybe RatedTime
                 , currentLap :
-                    { c
-                        | elapsed : Duration
-                        , miniSectorStates : Maybe CurrentMiniSectorStates
-                    }
+                    Maybe
+                        { c
+                            | elapsed : Duration
+                            , miniSectorStates : Maybe CurrentMiniSectorStates
+                        }
             }
     , sorter : data -> data -> Order
     , bestTimes : { b | fastestLapTime : Maybe Holder }
@@ -532,10 +534,11 @@ viewCurrentLapColumn_LeMans24h :
             | status : Status
             , bestLap : Maybe RatedTime
             , currentLap :
-                { c
-                    | elapsed : Duration
-                    , miniSectorStates : Maybe CurrentMiniSectorStates
-                }
+                Maybe
+                    { c
+                        | elapsed : Duration
+                        , miniSectorStates : Maybe CurrentMiniSectorStates
+                    }
         }
     -> Html msg
 viewCurrentLapColumn_LeMans24h bestTimes { status, bestLap, currentLap } =
@@ -566,16 +569,17 @@ viewCurrentLapColumn_LeMans24h bestTimes { status, bestLap, currentLap } =
         div [ css [ textAlign center ] ] [ text "Retired" ]
 
     else
-        bestLap
-            |> Maybe.map
-                (\best ->
-                    div [ css [ displayFlex, flexDirection column, property "row-gap" "5px" ] ]
-                        [ lapTime { time = currentLap.elapsed, personalBest = Just best.time }
-                        , currentLap.miniSectorStates
-                            |> Maybe.map miniSectorStrip
-                            |> Maybe.withDefault (text "")
-                        ]
-                )
+        Maybe.map2
+            (\best lap ->
+                div [ css [ displayFlex, flexDirection column, property "row-gap" "5px" ] ]
+                    [ lapTime { time = lap.elapsed, personalBest = Just best.time }
+                    , lap.miniSectorStates
+                        |> Maybe.map miniSectorStrip
+                        |> Maybe.withDefault (text "")
+                    ]
+            )
+            bestLap
+            currentLap
             |> Maybe.withDefault (text "-")
 
 

--- a/package/src/Motorsport/Widget/Leaderboard.elm
+++ b/package/src/Motorsport/Widget/Leaderboard.elm
@@ -435,12 +435,11 @@ currentLapColumn_Wec :
             { a
                 | status : Status
                 , currentLap :
-                    Maybe
-                        { b
-                            | elapsed : Duration
-                            , performance : Performance.PerformanceLevel
-                            , sectorStates : CurrentSectorStates
-                        }
+                    { b
+                        | elapsed : Duration
+                        , performance : Performance.PerformanceLevel
+                        , sectorStates : CurrentSectorStates
+                    }
             }
     , sorter : data -> data -> Order
     }
@@ -457,12 +456,11 @@ viewCurrentLapColumn_Wec :
     { a
         | status : Status
         , currentLap :
-            Maybe
-                { b
-                    | elapsed : Duration
-                    , performance : Performance.PerformanceLevel
-                    , sectorStates : CurrentSectorStates
-                }
+            { b
+                | elapsed : Duration
+                , performance : Performance.PerformanceLevel
+                , sectorStates : CurrentSectorStates
+            }
     }
     -> Html msg
 viewCurrentLapColumn_Wec { status, currentLap } =
@@ -485,22 +483,17 @@ viewCurrentLapColumn_Wec { status, currentLap } =
         div [ css [ textAlign center ] ] [ text "Retired" ]
 
     else
-        currentLap
-            |> Maybe.map
-                (\lap ->
-                    div [ css [ displayFlex, flexDirection column, property "row-gap" "5px" ] ]
-                        [ lapTime { time = lap.elapsed, performance = lap.performance }
-                        , div
-                            [ css
-                                [ property "display" "grid"
-                                , property "grid-template-columns" "1fr 1fr 1fr"
-                                , property "column-gap" "4px"
-                                ]
-                            ]
-                            (List.map progressCell (Sector.values lap.sectorStates))
-                        ]
-                )
-            |> Maybe.withDefault (text "-")
+        div [ css [ displayFlex, flexDirection column, property "row-gap" "5px" ] ]
+            [ lapTime { time = currentLap.elapsed, performance = currentLap.performance }
+            , div
+                [ css
+                    [ property "display" "grid"
+                    , property "grid-template-columns" "1fr 1fr 1fr"
+                    , property "column-gap" "4px"
+                    ]
+                ]
+                (List.map progressCell (Sector.values currentLap.sectorStates))
+            ]
 
 
 currentLapColumn_LeMans24h :
@@ -511,11 +504,10 @@ currentLapColumn_LeMans24h :
                 | status : Status
                 , bestLap : Maybe RatedTime
                 , currentLap :
-                    Maybe
-                        { c
-                            | elapsed : Duration
-                            , miniSectorStates : Maybe CurrentMiniSectorStates
-                        }
+                    { c
+                        | elapsed : Duration
+                        , miniSectorStates : Maybe CurrentMiniSectorStates
+                    }
             }
     , sorter : data -> data -> Order
     , bestTimes : { b | fastestLapTime : Maybe Holder }
@@ -536,11 +528,10 @@ viewCurrentLapColumn_LeMans24h :
             | status : Status
             , bestLap : Maybe RatedTime
             , currentLap :
-                Maybe
-                    { c
-                        | elapsed : Duration
-                        , miniSectorStates : Maybe CurrentMiniSectorStates
-                    }
+                { c
+                    | elapsed : Duration
+                    , miniSectorStates : Maybe CurrentMiniSectorStates
+                }
         }
     -> Html msg
 viewCurrentLapColumn_LeMans24h bestTimes { status, bestLap, currentLap } =
@@ -571,17 +562,16 @@ viewCurrentLapColumn_LeMans24h bestTimes { status, bestLap, currentLap } =
         div [ css [ textAlign center ] ] [ text "Retired" ]
 
     else
-        Maybe.map2
-            (\best lap ->
-                div [ css [ displayFlex, flexDirection column, property "row-gap" "5px" ] ]
-                    [ lapTime { time = lap.elapsed, personalBest = Just best.time }
-                    , lap.miniSectorStates
-                        |> Maybe.map miniSectorStrip
-                        |> Maybe.withDefault (text "")
-                    ]
-            )
-            bestLap
-            currentLap
+        bestLap
+            |> Maybe.map
+                (\best ->
+                    div [ css [ displayFlex, flexDirection column, property "row-gap" "5px" ] ]
+                        [ lapTime { time = currentLap.elapsed, personalBest = Just best.time }
+                        , currentLap.miniSectorStates
+                            |> Maybe.map miniSectorStrip
+                            |> Maybe.withDefault (text "")
+                        ]
+                )
             |> Maybe.withDefault (text "-")
 
 

--- a/package/src/Motorsport/Widget/Leaderboard.elm
+++ b/package/src/Motorsport/Widget/Leaderboard.elm
@@ -361,7 +361,7 @@ viewCarNumberColumn_Wec { carNumber, manufacturer } =
         )
 
 
-driverAndTeamColumn_Wec : { getter : data -> { a | metadata : { b | drivers : List Driver, team : String }, currentDriver : Maybe Driver } } -> Column data msg
+driverAndTeamColumn_Wec : { getter : data -> { a | metadata : { b | drivers : List Driver, team : String }, currentDriver : Driver } } -> Column data msg
 driverAndTeamColumn_Wec { getter } =
     { name = "Team / Driver"
     , view = getter >> Lazy.lazy viewDriverAndTeamColumn_Wec
@@ -370,13 +370,11 @@ driverAndTeamColumn_Wec { getter } =
     }
 
 
-viewDriverAndTeamColumn_Wec : { a | metadata : { b | drivers : List Driver, team : String }, currentDriver : Maybe Driver } -> Html msg
+viewDriverAndTeamColumn_Wec : { a | metadata : { b | drivers : List Driver, team : String }, currentDriver : Driver } -> Html msg
 viewDriverAndTeamColumn_Wec { metadata, currentDriver } =
     let
         isCurrentDriver driver =
-            currentDriver
-                |> Maybe.map (Driver.isSame driver)
-                |> Maybe.withDefault False
+            Driver.isSame driver currentDriver
     in
     div [ css [ displayFlex, flexDirection column, property "row-gap" "5px" ] ]
         [ div [] [ text metadata.team ]

--- a/package/src/Motorsport/Widget/Leaderboard.elm
+++ b/package/src/Motorsport/Widget/Leaderboard.elm
@@ -464,7 +464,7 @@ currentLapColumn_LeMans24h :
         ->
             { a
                 | status : Status
-                , bestLapRated : Maybe RatedTime
+                , bestLap : Maybe RatedTime
                 , currentLap :
                     { c
                         | elapsed : Duration
@@ -490,7 +490,7 @@ viewCurrentLapColumn_LeMans24h :
     ->
         { a
             | status : Status
-            , bestLapRated : Maybe RatedTime
+            , bestLap : Maybe RatedTime
             , currentLap :
                 { c
                     | elapsed : Duration
@@ -500,7 +500,7 @@ viewCurrentLapColumn_LeMans24h :
                 }
         }
     -> Html msg
-viewCurrentLapColumn_LeMans24h bestTimes { status, bestLapRated, currentLap } =
+viewCurrentLapColumn_LeMans24h bestTimes { status, bestLap, currentLap } =
     let
         lapTime { time, personalBest } =
             div
@@ -558,11 +558,11 @@ viewCurrentLapColumn_LeMans24h bestTimes { status, bestLapRated, currentLap } =
         div [ css [ textAlign center ] ] [ text "Retired" ]
 
     else
-        bestLapRated
+        bestLap
             |> Maybe.map
-                (\bestLap ->
+                (\best ->
                     div [ css [ displayFlex, flexDirection column, property "row-gap" "5px" ] ]
-                        [ lapTime { time = currentLap.elapsed, personalBest = Just bestLap.time }
+                        [ lapTime { time = currentLap.elapsed, personalBest = Just best.time }
                         , let
                             progressMap =
                                 LeMans.calculateMiniSectorProgress currentLap.miniSector

--- a/package/src/Motorsport/Widget/Leaderboard.elm
+++ b/package/src/Motorsport/Widget/Leaderboard.elm
@@ -337,7 +337,7 @@ viewDriverAndTeamColumn_Wec { metadata, currentDriver } =
 
 
 lastLapColumn :
-    { getter : data -> { a | lastLapRated : Maybe RatedTime }
+    { getter : data -> { a | lastLap : { b | rated : Maybe RatedTime } }
     , sorter : data -> data -> Order
     }
     -> Column data msg
@@ -345,7 +345,8 @@ lastLapColumn { getter, sorter } =
     { name = "Last Lap"
     , view =
         getter
-            >> .lastLapRated
+            >> .lastLap
+            >> .rated
             >> Maybe.map
                 (\{ time, performance } ->
                     span
@@ -372,8 +373,11 @@ currentLapColumn_Wec :
         ->
             { a
                 | status : Status
-                , currentLapRated : Maybe RatedTime
-                , currentLapSectorStates : Maybe CurrentSectorStates
+                , currentLap :
+                    { b
+                        | rated : Maybe RatedTime
+                        , sectorStates : Maybe CurrentSectorStates
+                    }
             }
     , sorter : data -> data -> Order
     }
@@ -389,11 +393,14 @@ currentLapColumn_Wec { getter, sorter } =
 viewCurrentLapColumn_Wec :
     { a
         | status : Status
-        , currentLapRated : Maybe RatedTime
-        , currentLapSectorStates : Maybe CurrentSectorStates
+        , currentLap :
+            { b
+                | rated : Maybe RatedTime
+                , sectorStates : Maybe CurrentSectorStates
+            }
     }
     -> Html msg
-viewCurrentLapColumn_Wec { status, currentLapRated, currentLapSectorStates } =
+viewCurrentLapColumn_Wec { status, currentLap } =
     let
         lapTime { time, performance } =
             div
@@ -446,8 +453,8 @@ viewCurrentLapColumn_Wec { status, currentLapRated, currentLapSectorStates } =
                         (List.map sectorCell (Sector.values slots))
                     ]
             )
-            currentLapRated
-            currentLapSectorStates
+            currentLap.rated
+            currentLap.sectorStates
             |> Maybe.withDefault (text "-")
 
 
@@ -457,11 +464,14 @@ currentLapColumn_LeMans24h :
         ->
             { a
                 | status : Status
-                , currentLapElapsed : Duration
-                , currentLapBest : Maybe Duration
-                , currentLapMiniSectors : Maybe MiniSectors
-                , sector : Maybe SectorProgress
-                , miniSector : Maybe MiniSectorProgress
+                , currentLap :
+                    { c
+                        | elapsed : Duration
+                        , best : Maybe Duration
+                        , miniSectors : Maybe MiniSectors
+                        , sector : Maybe SectorProgress
+                        , miniSector : Maybe MiniSectorProgress
+                    }
             }
     , sorter : data -> data -> Order
     , bestTimes : { b | fastestLapTime : Maybe Holder, fastestMiniSectors : ByMiniSector (Maybe Holder) }
@@ -480,14 +490,17 @@ viewCurrentLapColumn_LeMans24h :
     ->
         { a
             | status : Status
-            , currentLapElapsed : Duration
-            , currentLapBest : Maybe Duration
-            , currentLapMiniSectors : Maybe MiniSectors
-            , sector : Maybe SectorProgress
-            , miniSector : Maybe MiniSectorProgress
+            , currentLap :
+                { c
+                    | elapsed : Duration
+                    , best : Maybe Duration
+                    , miniSectors : Maybe MiniSectors
+                    , sector : Maybe SectorProgress
+                    , miniSector : Maybe MiniSectorProgress
+                }
         }
     -> Html msg
-viewCurrentLapColumn_LeMans24h bestTimes { status, currentLapElapsed, currentLapBest, currentLapMiniSectors, miniSector } =
+viewCurrentLapColumn_LeMans24h bestTimes { status, currentLap } =
     let
         lapTime { time, personalBest } =
             div
@@ -545,33 +558,33 @@ viewCurrentLapColumn_LeMans24h bestTimes { status, currentLapElapsed, currentLap
         div [ css [ textAlign center ] ] [ text "Retired" ]
 
     else
-        currentLapBest
+        currentLap.best
             |> Maybe.map
                 (\best ->
                     div [ css [ displayFlex, flexDirection column, property "row-gap" "5px" ] ]
-                        [ lapTime { time = currentLapElapsed, personalBest = Just best }
+                        [ lapTime { time = currentLap.elapsed, personalBest = Just best }
                         , let
                             progressMap =
-                                LeMans.calculateMiniSectorProgress miniSector
+                                LeMans.calculateMiniSectorProgress currentLap.miniSector
                           in
                           div [ css [ property "display" "grid", property "grid-template-columns" "2fr 2fr 3fr 0.5fr 5fr 1fr 3fr 3fr 0.5fr 1fr 5fr 3fr 2fr 1fr 1fr 1fr 1fr", property "column-gap" "1px" ] ]
-                            [ sectorCell { time = Maybe.andThen (.scl2 >> .time) currentLapMiniSectors, personalBest = Maybe.andThen (.scl2 >> .best) currentLapMiniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.scl2, progress = progressMap.scl2 }
-                            , sectorCell { time = Maybe.andThen (.z4 >> .time) currentLapMiniSectors, personalBest = Maybe.andThen (.z4 >> .best) currentLapMiniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.z4, progress = progressMap.z4 }
-                            , sectorCell { time = Maybe.andThen (.ip1 >> .time) currentLapMiniSectors, personalBest = Maybe.andThen (.ip1 >> .best) currentLapMiniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.ip1, progress = progressMap.ip1 }
+                            [ sectorCell { time = Maybe.andThen (.scl2 >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.scl2 >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.scl2, progress = progressMap.scl2 }
+                            , sectorCell { time = Maybe.andThen (.z4 >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.z4 >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.z4, progress = progressMap.z4 }
+                            , sectorCell { time = Maybe.andThen (.ip1 >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.ip1 >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.ip1, progress = progressMap.ip1 }
                             , div [] [] -- spacer
-                            , sectorCell { time = Maybe.andThen (.z12 >> .time) currentLapMiniSectors, personalBest = Maybe.andThen (.z12 >> .best) currentLapMiniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.z12, progress = progressMap.z12 }
-                            , sectorCell { time = Maybe.andThen (.sclc >> .time) currentLapMiniSectors, personalBest = Maybe.andThen (.sclc >> .best) currentLapMiniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.sclc, progress = progressMap.sclc }
-                            , sectorCell { time = Maybe.andThen (.a7_1 >> .time) currentLapMiniSectors, personalBest = Maybe.andThen (.a7_1 >> .best) currentLapMiniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.a7_1, progress = progressMap.a7_1 }
-                            , sectorCell { time = Maybe.andThen (.ip2 >> .time) currentLapMiniSectors, personalBest = Maybe.andThen (.ip2 >> .best) currentLapMiniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.ip2, progress = progressMap.ip2 }
+                            , sectorCell { time = Maybe.andThen (.z12 >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.z12 >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.z12, progress = progressMap.z12 }
+                            , sectorCell { time = Maybe.andThen (.sclc >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.sclc >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.sclc, progress = progressMap.sclc }
+                            , sectorCell { time = Maybe.andThen (.a7_1 >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.a7_1 >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.a7_1, progress = progressMap.a7_1 }
+                            , sectorCell { time = Maybe.andThen (.ip2 >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.ip2 >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.ip2, progress = progressMap.ip2 }
                             , div [] [] -- spacer
-                            , sectorCell { time = Maybe.andThen (.a8_1 >> .time) currentLapMiniSectors, personalBest = Maybe.andThen (.a8_1 >> .best) currentLapMiniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.a8_1, progress = progressMap.a8_1 }
-                            , sectorCell { time = Maybe.andThen (.sclb >> .time) currentLapMiniSectors, personalBest = Maybe.andThen (.sclb >> .best) currentLapMiniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.sclb, progress = progressMap.sclb }
-                            , sectorCell { time = Maybe.andThen (.porin >> .time) currentLapMiniSectors, personalBest = Maybe.andThen (.porin >> .best) currentLapMiniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.porin, progress = progressMap.porin }
-                            , sectorCell { time = Maybe.andThen (.porout >> .time) currentLapMiniSectors, personalBest = Maybe.andThen (.porout >> .best) currentLapMiniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.porout, progress = progressMap.porout }
-                            , sectorCell { time = Maybe.andThen (.pitref >> .time) currentLapMiniSectors, personalBest = Maybe.andThen (.pitref >> .best) currentLapMiniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.pitref, progress = progressMap.pitref }
-                            , sectorCell { time = Maybe.andThen (.scl1 >> .time) currentLapMiniSectors, personalBest = Maybe.andThen (.scl1 >> .best) currentLapMiniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.scl1, progress = progressMap.scl1 }
-                            , sectorCell { time = Maybe.andThen (.fordout >> .time) currentLapMiniSectors, personalBest = Maybe.andThen (.fordout >> .best) currentLapMiniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.fordout, progress = progressMap.fordout }
-                            , sectorCell { time = Maybe.andThen (.fl >> .time) currentLapMiniSectors, personalBest = Maybe.andThen (.fl >> .best) currentLapMiniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.fl, progress = progressMap.fl }
+                            , sectorCell { time = Maybe.andThen (.a8_1 >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.a8_1 >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.a8_1, progress = progressMap.a8_1 }
+                            , sectorCell { time = Maybe.andThen (.sclb >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.sclb >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.sclb, progress = progressMap.sclb }
+                            , sectorCell { time = Maybe.andThen (.porin >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.porin >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.porin, progress = progressMap.porin }
+                            , sectorCell { time = Maybe.andThen (.porout >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.porout >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.porout, progress = progressMap.porout }
+                            , sectorCell { time = Maybe.andThen (.pitref >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.pitref >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.pitref, progress = progressMap.pitref }
+                            , sectorCell { time = Maybe.andThen (.scl1 >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.scl1 >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.scl1, progress = progressMap.scl1 }
+                            , sectorCell { time = Maybe.andThen (.fordout >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.fordout >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.fordout, progress = progressMap.fordout }
+                            , sectorCell { time = Maybe.andThen (.fl >> .time) currentLap.miniSectors, personalBest = Maybe.andThen (.fl >> .best) currentLap.miniSectors, fastest = BestTimes.timeOf bestTimes.fastestMiniSectors.fl, progress = progressMap.fl }
                             ]
                         ]
                 )
@@ -579,7 +592,7 @@ viewCurrentLapColumn_LeMans24h bestTimes { status, currentLapElapsed, currentLap
 
 
 lastLapColumn_Wec :
-    { getter : data -> { a | lastLapRated : Maybe RatedTime, lastLapSectors : Maybe SectorPerformance }
+    { getter : data -> { a | lastLap : { b | rated : Maybe RatedTime, sectors : Maybe SectorPerformance } }
     , sorter : data -> data -> Order
     }
     -> Column data msg
@@ -591,8 +604,8 @@ lastLapColumn_Wec { getter, sorter } =
     }
 
 
-viewLastLapColumn_Wec : { a | lastLapRated : Maybe RatedTime, lastLapSectors : Maybe SectorPerformance } -> Html msg
-viewLastLapColumn_Wec { lastLapRated, lastLapSectors } =
+viewLastLapColumn_Wec : { a | lastLap : { b | rated : Maybe RatedTime, sectors : Maybe SectorPerformance } } -> Html msg
+viewLastLapColumn_Wec { lastLap } =
     let
         lapTimeView { time, performance } =
             div
@@ -618,11 +631,11 @@ viewLastLapColumn_Wec { lastLapRated, lastLapSectors } =
                 ]
                 []
     in
-    case lastLapRated of
+    case lastLap.rated of
         Just lapTime ->
             div [ css [ displayFlex, flexDirection column, property "row-gap" "5px" ] ]
                 [ lapTimeView lapTime
-                , case lastLapSectors of
+                , case lastLap.sectors of
                     Just slots ->
                         div
                             [ css
@@ -642,7 +655,7 @@ viewLastLapColumn_Wec { lastLapRated, lastLapSectors } =
 
 
 lastLapColumn_LeMans24h :
-    { getter : data -> { a | lastLapRated : Maybe RatedTime, lastLapMiniSectors : Maybe MiniSectorPerformance }
+    { getter : data -> { a | lastLap : { b | rated : Maybe RatedTime, miniSectors : Maybe MiniSectorPerformance } }
     , sorter : data -> data -> Order
     }
     -> Column data msg
@@ -654,8 +667,8 @@ lastLapColumn_LeMans24h { getter, sorter } =
     }
 
 
-viewLastLapColumn_LeMans24h : { a | lastLapRated : Maybe RatedTime, lastLapMiniSectors : Maybe MiniSectorPerformance } -> Html msg
-viewLastLapColumn_LeMans24h { lastLapRated, lastLapMiniSectors } =
+viewLastLapColumn_LeMans24h : { a | lastLap : { b | rated : Maybe RatedTime, miniSectors : Maybe MiniSectorPerformance } } -> Html msg
+viewLastLapColumn_LeMans24h { lastLap } =
     let
         lapTimeView { time, performance } =
             div
@@ -681,11 +694,11 @@ viewLastLapColumn_LeMans24h { lastLapRated, lastLapMiniSectors } =
                 ]
                 []
     in
-    case lastLapRated of
+    case lastLap.rated of
         Just lapTime ->
             div [ css [ displayFlex, flexDirection column, property "row-gap" "5px" ] ]
                 [ lapTimeView lapTime
-                , lastLapMiniSectors
+                , lastLap.miniSectors
                     |> Maybe.map
                         (\ms ->
                             div [ css [ property "display" "grid", property "grid-template-columns" "2fr 2fr 3fr 0.5fr 5fr 1fr 3fr 3fr 0.5fr 1fr 5fr 3fr 2fr 1fr 1fr 1fr 1fr", property "column-gap" "1px" ] ]

--- a/package/src/Motorsport/Widget/LiveStandings.elm
+++ b/package/src/Motorsport/Widget/LiveStandings.elm
@@ -112,12 +112,12 @@ carRow popoverTarget onSelect item =
 
 carRowContent : CarAt -> List (Html msg)
 carRowContent item =
-    [ div [ class "text-center text-xs" ] [ text (String.fromInt item.position) ]
+    [ div [ class "text-center text-xs" ] [ text (String.fromInt item.standing.position) ]
     , CarNumberBadge.viewRow item.metadata
     , div [ class "text-xs opacity-70" ]
         [ text (item.currentDriver |> Maybe.withDefault Driver.unknown |> Driver.toSurname) ]
     , div [ class "text-xs text-right" ]
-        [ text (Gap.toString item.intervalToAhead) ]
+        [ text (Gap.toString item.standing.intervalToAhead) ]
     , if item.status == Status.InPit then
         div
             [ class "w-4 h-4 rounded-full border border-white-500 flex items-center justify-center text-white text-[9px] font-bold" ]

--- a/package/src/Motorsport/Widget/LiveStandings.elm
+++ b/package/src/Motorsport/Widget/LiveStandings.elm
@@ -115,7 +115,7 @@ carRowContent item =
     [ div [ class "text-center text-xs" ] [ text (String.fromInt item.standing.position) ]
     , CarNumberBadge.viewRow item.metadata
     , div [ class "text-xs opacity-70" ]
-        [ text (item.currentDriver |> Maybe.withDefault Driver.unknown |> Driver.toSurname) ]
+        [ text (Driver.toSurname item.currentDriver) ]
     , div [ class "text-xs text-right" ]
         [ text (Gap.toString item.standing.intervalToAhead) ]
     , if item.status == Status.InPit then

--- a/package/src/Motorsport/Widget/SectorAndLaps.elm
+++ b/package/src/Motorsport/Widget/SectorAndLaps.elm
@@ -79,9 +79,9 @@ currentLapTimeCell : CarAt -> Html msg
 currentLapTimeCell item =
     let
         colorStyle =
-            case item.currentLap.rated of
-                Just { performance } ->
-                    applyPerformanceColor performance
+            case item.currentLap of
+                Just { rated } ->
+                    applyPerformanceColor rated.performance
 
                 Nothing ->
                     batch []
@@ -95,11 +95,12 @@ currentLapTimeCell item =
             ]
         ]
         [ text
-            (if Status.hasRetired item.status then
-                "-"
+            (case ( item.currentLap, Status.hasRetired item.status ) of
+                ( Just { elapsed }, False ) ->
+                    Duration.toString elapsed
 
-             else
-                Duration.toString item.currentLap.elapsed
+                _ ->
+                    "-"
             )
         ]
 
@@ -137,9 +138,9 @@ sectors are filled with their performance color.
 -}
 currentSectorPie : CarAt -> Html msg
 currentSectorPie item =
-    case ( item.currentLap.sectorStates, Status.hasRetired item.status ) of
-        ( Just slots, False ) ->
-            sectorPie (List.map currentSectorSlot (Sector.values slots))
+    case ( item.currentLap, Status.hasRetired item.status ) of
+        ( Just { sectorStates }, False ) ->
+            sectorPie (List.map currentSectorSlot (Sector.values sectorStates))
 
         _ ->
             emptyPie

--- a/package/src/Motorsport/Widget/SectorAndLaps.elm
+++ b/package/src/Motorsport/Widget/SectorAndLaps.elm
@@ -79,12 +79,7 @@ currentLapTimeCell : CarAt -> Html msg
 currentLapTimeCell item =
     let
         colorStyle =
-            case item.currentLap of
-                Just { performance } ->
-                    applyPerformanceColor performance
-
-                Nothing ->
-                    batch []
+            applyPerformanceColor item.currentLap.performance
     in
     div
         [ css
@@ -95,12 +90,11 @@ currentLapTimeCell item =
             ]
         ]
         [ text
-            (case ( item.currentLap, Status.hasRetired item.status ) of
-                ( Just { elapsed }, False ) ->
-                    Duration.toString elapsed
+            (if Status.hasRetired item.status then
+                "-"
 
-                _ ->
-                    "-"
+             else
+                Duration.toString item.currentLap.elapsed
             )
         ]
 
@@ -138,12 +132,11 @@ sectors are filled with their performance color.
 -}
 currentSectorPie : CarAt -> Html msg
 currentSectorPie item =
-    case ( item.currentLap, Status.hasRetired item.status ) of
-        ( Just { sectorStates }, False ) ->
-            sectorPie (List.map currentSectorSlot (Sector.values sectorStates))
+    if Status.hasRetired item.status then
+        emptyPie
 
-        _ ->
-            emptyPie
+    else
+        sectorPie (List.map currentSectorSlot (Sector.values item.currentLap.sectorStates))
 
 
 {-| Convert one sector into `(fill color, fill fraction 0..1)`:

--- a/package/src/Motorsport/Widget/SectorAndLaps.elm
+++ b/package/src/Motorsport/Widget/SectorAndLaps.elm
@@ -79,7 +79,7 @@ currentLapTimeCell : CarAt -> Html msg
 currentLapTimeCell item =
     let
         colorStyle =
-            case item.currentLapRated of
+            case item.currentLap.rated of
                 Just { performance } ->
                     applyPerformanceColor performance
 
@@ -99,7 +99,7 @@ currentLapTimeCell item =
                 "-"
 
              else
-                Duration.toString item.currentLapElapsed
+                Duration.toString item.currentLap.elapsed
             )
         ]
 
@@ -111,7 +111,7 @@ lastLapTimeCell item =
             [ property "font-size" "13px"
             , property "font-variant-numeric" "tabular-nums"
             , property "text-align" "right"
-            , case item.lastLapRated of
+            , case item.lastLap.rated of
                 Just { performance } ->
                     applyPerformanceColor performance
 
@@ -119,7 +119,7 @@ lastLapTimeCell item =
                     batch []
             ]
         ]
-        [ text (item.lastLapRated |> Maybe.map (.time >> Duration.toString) |> Maybe.withDefault "-") ]
+        [ text (item.lastLap.rated |> Maybe.map (.time >> Duration.toString) |> Maybe.withDefault "-") ]
 
 
 applyPerformanceColor : Performance.PerformanceLevel -> Css.Style
@@ -137,7 +137,7 @@ sectors are filled with their performance color.
 -}
 currentSectorPie : CarAt -> Html msg
 currentSectorPie item =
-    case ( item.currentLapSectorStates, Status.hasRetired item.status ) of
+    case ( item.currentLap.sectorStates, Status.hasRetired item.status ) of
         ( Just slots, False ) ->
             sectorPie (List.map currentSectorSlot (Sector.values slots))
 

--- a/package/src/Motorsport/Widget/SectorAndLaps.elm
+++ b/package/src/Motorsport/Widget/SectorAndLaps.elm
@@ -80,8 +80,8 @@ currentLapTimeCell item =
     let
         colorStyle =
             case item.currentLap of
-                Just { rated } ->
-                    applyPerformanceColor rated.performance
+                Just { performance } ->
+                    applyPerformanceColor performance
 
                 Nothing ->
                     batch []

--- a/package/src/Motorsport/Widget/SelectedCarsStrip/CarCard.elm
+++ b/package/src/Motorsport/Widget/SelectedCarsStrip/CarCard.elm
@@ -79,7 +79,7 @@ cardHeader item =
                 , property "text-overflow" "ellipsis"
                 ]
             ]
-            [ text (item.currentDriver |> Maybe.withDefault Driver.unknown |> Driver.toFullName) ]
+            [ text (Driver.toFullName item.currentDriver) ]
         ]
 
 

--- a/package/src/Motorsport/Widget/SelectedCarsStrip/CarCard.elm
+++ b/package/src/Motorsport/Widget/SelectedCarsStrip/CarCard.elm
@@ -137,7 +137,7 @@ positionLabel item =
                 ]
             ]
         ]
-        [ text ("P" ++ String.fromInt item.position) ]
+        [ text ("P" ++ String.fromInt item.standing.position) ]
 
 
 gapsRow : CarAt -> Html msg
@@ -151,7 +151,7 @@ gapsRow item =
             , opacity (num 0.75)
             ]
         ]
-        [ gapCell "Interval" item.intervalToAhead ]
+        [ gapCell "Interval" item.standing.intervalToAhead ]
 
 
 gapCell : String -> Gap -> Html msg

--- a/package/src/Motorsport/Widget/SelectedCarsStrip/RivalGapSparkline.elm
+++ b/package/src/Motorsport/Widget/SelectedCarsStrip/RivalGapSparkline.elm
@@ -57,7 +57,7 @@ view lapHistory allCars item =
             findNeighbors allCars item
 
         currentLap =
-            item.lapsCompleted
+            item.standing.lapsCompleted
 
         aheadLines =
             neighbors.ahead |> List.map (GapChart.carLine lapHistory (Recent currentLap) Related)

--- a/package/tests/Motorsport/GapTest.elm
+++ b/package/tests/Motorsport/GapTest.elm
@@ -28,7 +28,7 @@ following lapNumber delay =
         car =
             onLap lapNumber
     in
-    { currentLap = Maybe.map (delayBy delay) car.currentLap
+    { currentLap = delayBy delay car.currentLap
     , laps = List.map (delayBy delay) car.laps
     }
 
@@ -41,13 +41,13 @@ onLap lapNumber =
         laps =
             List.map lap (List.range 1 lapNumber)
     in
-    { currentLap = List.drop (lapNumber - 1) laps |> List.head
+    { currentLap = lap lapNumber
     , laps = laps
     }
 
 
 type alias Competitor =
-    { currentLap : Maybe Lap, laps : List Lap }
+    { currentLap : Lap, laps : List Lap }
 
 
 lap : Int -> Lap
@@ -83,11 +83,6 @@ tests =
                     Gap.at { elapsed = Instant.fromDuration 25000 }
                         { ahead = leader, behind = following 3 1500 }
                         |> Expect.equal (Gap.seconds 1500)
-            , test "reports no gap for a car that has not started a lap" <|
-                \_ ->
-                    Gap.at { elapsed = Instant.fromDuration 25000 }
-                        { ahead = leader, behind = { currentLap = Nothing, laps = [] } }
-                        |> Expect.equal Gap.none
             , test "reports no gap where the car ahead has no record of the lap being compared" <|
                 \_ ->
                     Gap.at { elapsed = Instant.fromDuration 25000 }

--- a/package/tests/Motorsport/Race/SnapshotTest.elm
+++ b/package/tests/Motorsport/Race/SnapshotTest.elm
@@ -116,9 +116,6 @@ suite =
                         |> Expect.equal (Just ( 1, 0.5, 0 ))
             , test "and where the data records none there is no mini-sector to be in, though there is still a sector" <|
                 \_ ->
-                    -- Away from Le Mans this is every car of every frame, which
-                    -- is why the mini-sector readings do not go `Nothing` in
-                    -- step with `sector` the way the rest of the lap does.
                     carAt "1" (snapshotAt 7000)
                         |> Maybe.map
                             (.currentLap
@@ -131,10 +128,8 @@ suite =
         , describe "the record a running lap is rated against is the car's own, at that moment"
             [ test "it is the best of the laps the car has finished, not of the one it is running" <|
                 \_ ->
-                    -- Car 2's second lap is a 4.000 and at 7.000 it is still on
-                    -- it, so that time is not its record yet: the 5.000 of its
-                    -- first lap is. The lap carries a best that counts itself,
-                    -- which is why this is read off the finished lap instead.
+                    -- Car 2's second lap is a 4.000 and at 7.000 it is still
+                    -- on it, so its record is the 5.000 of the first.
                     carAt "2" (snapshotAt 7000)
                         |> Maybe.andThen .bestLap
                         |> Maybe.map .time
@@ -149,10 +144,6 @@ suite =
         , describe "the field is the cars that are running"
             [ test "a car that has turned no lap is not in it" <|
                 \_ ->
-                    -- Which is every car the data can hand over: the loader
-                    -- builds the entry list out of the lap records, so a car
-                    -- that completed no lap reaches neither file. The fixture
-                    -- can still make one, and this is what becomes of it.
                     fieldWithTailenders
                         |> Snapshot.toList
                         |> List.map (.metadata >> .carNumber)
@@ -229,11 +220,8 @@ sectorStatesOf carNumber snapshot =
 
 
 {-| A wider field, for what two cars cannot show: two of them sharing a class,
-and one that never took to the track at all and so does not join it.
-
-Read at 7.000, as the two-car fixture is, so the cars it has in common with it
-stand where they stand there.
-
+and one that never took to the track and so does not join it. Read at 7.000, as
+the two-car fixture is, so the cars they share stand where they stand there.
 -}
 fieldWithTailenders : Snapshot
 fieldWithTailenders =
@@ -253,12 +241,9 @@ carThree =
 
 
 {-| A car from a circuit whose source data records mini-sectors, which the two
-above are not from.
-
-Its one lap runs for 15.000 in fifteen even mini-sectors of 1.000 apiece, so the
-mini-sector a clock falls in is the clock divided by a thousand, and how far
-through it is the remainder.
-
+above are not from. Its one lap runs for 15.000 in fifteen even mini-sectors of
+1.000 apiece, so the mini-sector a clock falls in is the clock divided by a
+thousand, and how far through it is the remainder.
 -}
 leMansFieldAt : Duration -> Snapshot
 leMansFieldAt elapsed =
@@ -304,12 +289,8 @@ withEvenMiniSectors each lap =
 
 {-| Fill each lap's `best` in as the loader does: the least time the car had
 turned up to and including that lap, so the lap in progress carries a record
-that already counts its own time.
-
-Without this every fixture lap would carry none at all, and a test asking what
-record a car held would read `Nothing` whatever the answer ought to be -- which
-is exactly the shape a test of the record reading too far ahead would take.
-
+that already counts its own time. Without it every fixture lap carries none, and
+a test of what record a car held reads `Nothing` whatever the answer should be.
 -}
 withRunningBests : List Lap -> List Lap
 withRunningBests laps =
@@ -335,10 +316,9 @@ withRunningBests laps =
         |> List.reverse
 
 
-{-| A car that turned no lap at all, which is a car the loader cannot produce:
-the entry list is built out of the lap records, so an entry with no laps is in
-neither file. Here to pin what `Snapshot` does with one anyway -- leaves it out
-of the field.
+{-| A car that turned no lap at all -- which the loader cannot produce, since it
+builds the entry list out of the lap records. Here to pin what `Snapshot` does
+with one anyway: leaves it out of the field.
 -}
 nonStarter : Car
 nonStarter =

--- a/package/tests/Motorsport/Race/SnapshotTest.elm
+++ b/package/tests/Motorsport/Race/SnapshotTest.elm
@@ -103,14 +103,12 @@ suite =
                     -- Fifteen even mini-sectors of 1.000, so 3.500 is half way
                     -- through the fourth of them in track order.
                     carAt "7" (leMansFieldAt 3500)
-                        |> Maybe.andThen .currentLap
-                        |> Maybe.andThen .miniSector
+                        |> Maybe.andThen (.currentLap >> .miniSector)
                         |> Expect.equal (Just { miniSector = Z12, progress = 0.5 })
             , test "each of them reads complete behind the car, part way at it, and untouched ahead" <|
                 \_ ->
                     carAt "7" (leMansFieldAt 3500)
-                        |> Maybe.andThen .currentLap
-                        |> Maybe.andThen .miniSectorStates
+                        |> Maybe.andThen (.currentLap >> .miniSectorStates)
                         |> Maybe.map
                             (\states ->
                                 ( states.ip1.progress, states.z12.progress, states.sclc.progress )
@@ -122,10 +120,11 @@ suite =
                     -- is why the mini-sector readings do not go `Nothing` in
                     -- step with `sector` the way the rest of the lap does.
                     carAt "1" (snapshotAt 7000)
-                        |> Maybe.andThen .currentLap
                         |> Maybe.map
-                            (\lap ->
-                                ( lap.miniSector, lap.miniSectorStates, lap.sector.sector )
+                            (.currentLap
+                                >> (\lap ->
+                                        ( lap.miniSector, lap.miniSectorStates, lap.sector.sector )
+                                   )
                             )
                         |> Expect.equal (Just ( Nothing, Nothing, S2 ))
             ]
@@ -147,24 +146,26 @@ suite =
                         |> Maybe.map .time
                         |> Expect.equal Nothing
             ]
-        , describe "a car with no lap in progress is nowhere on the track"
-            [ test "it is on no lap at all, so there is no reading of one" <|
+        , describe "the field is the cars that are running"
+            [ test "a car that has turned no lap is not in it" <|
                 \_ ->
-                    carAt "4" fieldWithTailenders
-                        |> Maybe.andThen .currentLap
-                        |> Maybe.map (always ())
-                        |> Expect.equal Nothing
-            , test "it has completed no laps" <|
-                \_ ->
-                    carAt "4" fieldWithTailenders
-                        |> Maybe.map (.standing >> .lapsCompleted)
-                        |> Expect.equal (Just 0)
-            , test "and it sorts behind every car that is running" <|
-                \_ ->
+                    -- Which is every car the data can hand over: the loader
+                    -- builds the entry list out of the lap records, so a car
+                    -- that completed no lap reaches neither file. The fixture
+                    -- can still make one, and this is what becomes of it.
                     fieldWithTailenders
                         |> Snapshot.toList
                         |> List.map (.metadata >> .carNumber)
-                        |> Expect.equal [ "2", "1", "3", "4" ]
+                        |> Expect.equal [ "2", "1", "3" ]
+            , test "nor can it be looked up by number" <|
+                \_ ->
+                    Snapshot.get "4" fieldWithTailenders
+                        |> Expect.equal Nothing
+            , test "nor does it take a place in its class" <|
+                \_ ->
+                    Snapshot.inClass (classOf "LMGT3") fieldWithTailenders
+                        |> List.map (.metadata >> .carNumber)
+                        |> Expect.equal [ "2" ]
             ]
         , describe "class position is counted off the running order"
             [ test "a class of two numbers its cars 1 and 2, whatever they stand overall" <|
@@ -172,11 +173,6 @@ suite =
                     Snapshot.inClass (classOf "HYPERCAR") fieldWithTailenders
                         |> List.map (\car -> ( car.metadata.carNumber, car.standing.positionInClass ))
                         |> Expect.equal [ ( "1", 1 ), ( "3", 2 ) ]
-            , test "a car that is not running is still placed in its class, at the back of it" <|
-                \_ ->
-                    Snapshot.inClass (classOf "LMGT3") fieldWithTailenders
-                        |> List.map (\car -> ( car.metadata.carNumber, car.standing.positionInClass ))
-                        |> Expect.equal [ ( "2", 1 ), ( "4", 2 ) ]
             , test "a class no car races in is empty" <|
                 \_ ->
                     Snapshot.inClass (classOf "LMP2") fieldWithTailenders
@@ -229,12 +225,11 @@ carAt =
 sectorStatesOf : String -> Snapshot -> Maybe Snapshot.CurrentSectorStates
 sectorStatesOf carNumber snapshot =
     carAt carNumber snapshot
-        |> Maybe.andThen .currentLap
-        |> Maybe.map .sectorStates
+        |> Maybe.map (.currentLap >> .sectorStates)
 
 
 {-| A wider field, for what two cars cannot show: two of them sharing a class,
-and one that never took to the track at all.
+and one that never took to the track at all and so does not join it.
 
 Read at 7.000, as the two-car fixture is, so the cars it has in common with it
 stand where they stand there.
@@ -340,8 +335,10 @@ withRunningBests laps =
         |> List.reverse
 
 
-{-| A car that turned no lap at all -- so it is on no lap, in no sector, and
-holds no gap to anyone.
+{-| A car that turned no lap at all, which is a car the loader cannot produce:
+the entry list is built out of the lap records, so an entry with no laps is in
+neither file. Here to pin what `Snapshot` does with one anyway -- leaves it out
+of the field.
 -}
 nonStarter : Car
 nonStarter =

--- a/package/tests/Motorsport/Race/SnapshotTest.elm
+++ b/package/tests/Motorsport/Race/SnapshotTest.elm
@@ -66,13 +66,18 @@ suite =
                             )
                         |> Expect.equal (Just True)
             ]
-        , describe "each car is placed within its class as well as within the field"
-            [ test "a class of one puts its car first, whatever it stands overall" <|
+        , describe "cars are placed within their class as well as within the field"
+            [ test "a class of two numbers its cars 1 and 2, whatever they stand overall" <|
                 \_ ->
-                    snapshotAt 7000
-                        |> Snapshot.toList
+                    -- Car 1 is second overall and first of its class.
+                    Snapshot.inClass (classOf "HYPERCAR") fieldWithTailenders
                         |> List.map (\car -> ( car.metadata.carNumber, car.standing.positionInClass ))
-                        |> Expect.equal [ ( "2", 1 ), ( "1", 1 ) ]
+                        |> Expect.equal [ ( "1", 1 ), ( "3", 2 ) ]
+            , test "a class no car races in is empty" <|
+                \_ ->
+                    Snapshot.inClass (classOf "LMP2") fieldWithTailenders
+                        |> List.map (.metadata >> .carNumber)
+                        |> Expect.equal []
             , test "the classes come out grouped, the leader's first" <|
                 \_ ->
                     snapshotAt 7000
@@ -148,27 +153,11 @@ suite =
                         |> Snapshot.toList
                         |> List.map (.metadata >> .carNumber)
                         |> Expect.equal [ "2", "1", "3" ]
-            , test "nor can it be looked up by number" <|
-                \_ ->
-                    Snapshot.get "4" fieldWithTailenders
-                        |> Expect.equal Nothing
             , test "nor does it take a place in its class" <|
                 \_ ->
                     Snapshot.inClass (classOf "LMGT3") fieldWithTailenders
                         |> List.map (.metadata >> .carNumber)
                         |> Expect.equal [ "2" ]
-            ]
-        , describe "class position is counted off the running order"
-            [ test "a class of two numbers its cars 1 and 2, whatever they stand overall" <|
-                \_ ->
-                    Snapshot.inClass (classOf "HYPERCAR") fieldWithTailenders
-                        |> List.map (\car -> ( car.metadata.carNumber, car.standing.positionInClass ))
-                        |> Expect.equal [ ( "1", 1 ), ( "3", 2 ) ]
-            , test "a class no car races in is empty" <|
-                \_ ->
-                    Snapshot.inClass (classOf "LMP2") fieldWithTailenders
-                        |> List.map (.metadata >> .carNumber)
-                        |> Expect.equal []
             ]
         , describe "one car can be read out of the field by number"
             [ test "the car that carries the number" <|

--- a/package/tests/Motorsport/Race/SnapshotTest.elm
+++ b/package/tests/Motorsport/Race/SnapshotTest.elm
@@ -87,12 +87,14 @@ suite =
                     -- first lap is. The lap carries a best that counts itself,
                     -- which is why this is read off the finished lap instead.
                     carAt "2" (snapshotAt 7000)
-                        |> Maybe.andThen (.currentLap >> .best)
+                        |> Maybe.andThen .bestLapRated
+                        |> Maybe.map .time
                         |> Expect.equal (Just 5000)
             , test "a car on its opening lap has no record to be rated against" <|
                 \_ ->
                     carAt "2" (snapshotAt 3000)
-                        |> Maybe.andThen (.currentLap >> .best)
+                        |> Maybe.andThen .bestLapRated
+                        |> Maybe.map .time
                         |> Expect.equal Nothing
             ]
         , describe "a car with no lap in progress is nowhere on the track"

--- a/package/tests/Motorsport/Race/SnapshotTest.elm
+++ b/package/tests/Motorsport/Race/SnapshotTest.elm
@@ -127,13 +127,13 @@ suite =
                     -- first lap is. The lap carries a best that counts itself,
                     -- which is why this is read off the finished lap instead.
                     carAt "2" (snapshotAt 7000)
-                        |> Maybe.andThen .bestLapRated
+                        |> Maybe.andThen .bestLap
                         |> Maybe.map .time
                         |> Expect.equal (Just 5000)
             , test "a car on its opening lap has no record to be rated against" <|
                 \_ ->
                     carAt "2" (snapshotAt 3000)
-                        |> Maybe.andThen .bestLapRated
+                        |> Maybe.andThen .bestLap
                         |> Maybe.map .time
                         |> Expect.equal Nothing
             ]

--- a/package/tests/Motorsport/Race/SnapshotTest.elm
+++ b/package/tests/Motorsport/Race/SnapshotTest.elm
@@ -83,7 +83,7 @@ suite =
             [ test "it reports no sector, as it reports no sector states" <|
                 \_ ->
                     carAt "4" fieldWithTailenders
-                        |> Maybe.map (\car -> ( car.sector, car.currentLapSectorStates ))
+                        |> Maybe.map (\car -> ( car.currentLap.sector, car.currentLap.sectorStates ))
                         |> Expect.equal (Just ( Nothing, Nothing ))
             , test "it has completed no laps" <|
                 \_ ->
@@ -160,7 +160,7 @@ carAt =
 sectorStatesOf : String -> Snapshot -> Maybe Snapshot.CurrentSectorStates
 sectorStatesOf carNumber snapshot =
     carAt carNumber snapshot
-        |> Maybe.andThen .currentLapSectorStates
+        |> Maybe.andThen (.currentLap >> .sectorStates)
 
 
 {-| A wider field, for what two cars cannot show: two of them sharing a class,

--- a/package/tests/Motorsport/Race/SnapshotTest.elm
+++ b/package/tests/Motorsport/Race/SnapshotTest.elm
@@ -26,7 +26,7 @@ suite =
                 \_ ->
                     snapshotAt 7000
                         |> Snapshot.toList
-                        |> List.map (\car -> ( car.position, car.metadata.carNumber ))
+                        |> List.map (\car -> ( car.standing.position, car.metadata.carNumber ))
                         |> Expect.equal [ ( 1, "2" ), ( 2, "1" ) ]
             , test "the leader is the car in first" <|
                 \_ ->
@@ -38,14 +38,14 @@ suite =
                 \_ ->
                     snapshotAt 7000
                         |> Snapshot.toList
-                        |> List.map (.gapToLeader >> Gap.toString)
+                        |> List.map (.standing >> .gapToLeader >> Gap.toString)
                         |> List.head
                         |> Expect.equal (Just "-")
             , test "the car behind reports one" <|
                 \_ ->
                     snapshotAt 7000
                         |> carAt "1"
-                        |> Maybe.map (.gapToLeader >> Gap.toString)
+                        |> Maybe.map (.standing >> .gapToLeader >> Gap.toString)
                         |> Expect.notEqual (Just "-")
             ]
         , describe "each car is placed within its class as well as within the field"
@@ -53,7 +53,7 @@ suite =
                 \_ ->
                     snapshotAt 7000
                         |> Snapshot.toList
-                        |> List.map (\car -> ( car.metadata.carNumber, car.positionInClass ))
+                        |> List.map (\car -> ( car.metadata.carNumber, car.standing.positionInClass ))
                         |> Expect.equal [ ( "2", 1 ), ( "1", 1 ) ]
             , test "the classes come out grouped, the leader's first" <|
                 \_ ->
@@ -88,7 +88,7 @@ suite =
             , test "it has completed no laps" <|
                 \_ ->
                     carAt "4" fieldWithTailenders
-                        |> Maybe.map .lapsCompleted
+                        |> Maybe.map (.standing >> .lapsCompleted)
                         |> Expect.equal (Just 0)
             , test "and it sorts behind every car that is running" <|
                 \_ ->
@@ -101,12 +101,12 @@ suite =
             [ test "a class of two numbers its cars 1 and 2, whatever they stand overall" <|
                 \_ ->
                     Snapshot.inClass (classOf "HYPERCAR") fieldWithTailenders
-                        |> List.map (\car -> ( car.metadata.carNumber, car.positionInClass ))
+                        |> List.map (\car -> ( car.metadata.carNumber, car.standing.positionInClass ))
                         |> Expect.equal [ ( "1", 1 ), ( "3", 2 ) ]
             , test "a car that is not running is still placed in its class, at the back of it" <|
                 \_ ->
                     Snapshot.inClass (classOf "LMGT3") fieldWithTailenders
-                        |> List.map (\car -> ( car.metadata.carNumber, car.positionInClass ))
+                        |> List.map (\car -> ( car.metadata.carNumber, car.standing.positionInClass ))
                         |> Expect.equal [ ( "2", 1 ), ( "4", 2 ) ]
             , test "a class no car races in is empty" <|
                 \_ ->
@@ -118,7 +118,7 @@ suite =
             [ test "the car that carries the number" <|
                 \_ ->
                     Snapshot.get "3" fieldWithTailenders
-                        |> Maybe.map .position
+                        |> Maybe.map (.standing >> .position)
                         |> Expect.equal (Just 3)
             , test "and nothing for a number no car carries" <|
                 \_ ->

--- a/package/tests/Motorsport/Race/SnapshotTest.elm
+++ b/package/tests/Motorsport/Race/SnapshotTest.elm
@@ -1,7 +1,9 @@
 module Motorsport.Race.SnapshotTest exposing (suite)
 
 import Expect
+import List.Extra
 import Motorsport.BestTimes as BestTimes
+import Motorsport.Circuit.LeMans as LeMans exposing (LeMans2025MiniSector(..))
 import Motorsport.Class as Class exposing (Class)
 import Motorsport.Class.Era as Era
 import Motorsport.Driver as Driver
@@ -47,6 +49,22 @@ suite =
                         |> carAt "1"
                         |> Maybe.map (.standing >> .gapToLeader >> Gap.toString)
                         |> Expect.notEqual (Just "-")
+            , test "nothing runs ahead of the leader either, so it reports no interval" <|
+                \_ ->
+                    snapshotAt 7000
+                        |> carAt "2"
+                        |> Maybe.map (.standing >> .intervalToAhead >> Gap.toString)
+                        |> Expect.equal (Just "-")
+            , test "and the car in second is racing the leader, so its interval is that same gap" <|
+                \_ ->
+                    snapshotAt 7000
+                        |> carAt "1"
+                        |> Maybe.map
+                            (\car ->
+                                Gap.toString car.standing.intervalToAhead
+                                    == Gap.toString car.standing.gapToLeader
+                            )
+                        |> Expect.equal (Just True)
             ]
         , describe "each car is placed within its class as well as within the field"
             [ test "a class of one puts its car first, whatever it stands overall" <|
@@ -78,6 +96,28 @@ suite =
                         |> Maybe.map (Sector.toList >> List.map (\( sector, state ) -> ( sector, Maybe.map .performance state.rated )))
                         |> Expect.equal
                             (Just [ ( S1, Just Fastest ), ( S2, Just Standard ), ( S3, Just Standard ) ])
+            ]
+        , describe "the mini-sector a car is in, where the source data records mini-sectors"
+            [ test "is the one the clock falls in, and says how far through it the car is" <|
+                \_ ->
+                    -- Fifteen even mini-sectors of 1.000, so 3.500 is half way
+                    -- through the fourth of them in track order.
+                    carAt "7" (leMansFieldAt 3500)
+                        |> Maybe.andThen (.currentLap >> .miniSector)
+                        |> Expect.equal (Just { miniSector = Z12, progress = 0.5 })
+            , test "and where the data records none there is no mini-sector to be in, though there is still a sector" <|
+                \_ ->
+                    -- Away from Le Mans this is every car of every frame, which
+                    -- is why `miniSector` does not go `Nothing` in step with
+                    -- `sector` the way the other readings of the lap do.
+                    carAt "1" (snapshotAt 7000)
+                        |> Maybe.map
+                            (\car ->
+                                ( car.currentLap.miniSector
+                                , car.currentLap.sector |> Maybe.map .sector
+                                )
+                            )
+                        |> Expect.equal (Just ( Nothing, Just S2 ))
             ]
         , describe "the record a running lap is rated against is the car's own, at that moment"
             [ test "it is the best of the laps the car has finished, not of the one it is running" <|
@@ -201,8 +241,91 @@ carThree : Car
 carThree =
     { metadata = metadataOf "3" (classOf "HYPERCAR")
     , startPosition = 3
-    , laps = [ lapOf "3" 1 20000 20000 { s1 = 6000, s2 = 7000, s3 = 7000 } ]
+    , laps = withRunningBests [ lapOf "3" 1 20000 20000 { s1 = 6000, s2 = 7000, s3 = 7000 } ]
     }
+
+
+{-| A car from a circuit whose source data records mini-sectors, which the two
+above are not from.
+
+Its one lap runs for 15.000 in fifteen even mini-sectors of 1.000 apiece, so the
+mini-sector a clock falls in is the clock divided by a thousand, and how far
+through it is the remainder.
+
+-}
+leMansFieldAt : Duration -> Snapshot
+leMansFieldAt elapsed =
+    Race.fromCars [ leMansCar ]
+        |> Snapshot.at { elapsed = Instant.fromDuration elapsed }
+
+
+leMansCar : Car
+leMansCar =
+    { metadata = metadataOf "7" (classOf "HYPERCAR")
+    , startPosition = 1
+    , laps =
+        withRunningBests
+            [ lapOf "7" 1 15000 15000 { s1 = 3000, s2 = 4000, s3 = 8000 }
+                |> withEvenMiniSectors 1000
+            ]
+    }
+
+
+{-| Give a lap the fifteen mini-sectors of Le Mans, each taking `each`, so the
+nth of them in track order ends `n * each` into the lap.
+-}
+withEvenMiniSectors : Duration -> Lap -> Lap
+withEvenMiniSectors each lap =
+    { lap
+        | miniSectors =
+            LeMans.initialize
+                (\mini ->
+                    let
+                        position =
+                            LeMans.miniSectorOrder
+                                |> List.Extra.elemIndex mini
+                                |> Maybe.withDefault 0
+                    in
+                    { time = Just each
+                    , elapsed = Just (each * (position + 1))
+                    , best = Nothing
+                    }
+                )
+                |> Just
+    }
+
+
+{-| Fill each lap's `best` in as the loader does: the least time the car had
+turned up to and including that lap, so the lap in progress carries a record
+that already counts its own time.
+
+Without this every fixture lap would carry none at all, and a test asking what
+record a car held would read `Nothing` whatever the answer ought to be -- which
+is exactly the shape a test of the record reading too far ahead would take.
+
+-}
+withRunningBests : List Lap -> List Lap
+withRunningBests laps =
+    laps
+        |> List.foldl
+            (\lap ( standing, acc ) ->
+                let
+                    best =
+                        case ( standing, lap.time ) of
+                            ( Just held, Just time ) ->
+                                Just (min held time)
+
+                            ( Nothing, _ ) ->
+                                lap.time
+
+                            ( _, Nothing ) ->
+                                standing
+                in
+                ( best, { lap | best = best } :: acc )
+            )
+            ( Nothing, [] )
+        |> Tuple.second
+        |> List.reverse
 
 
 {-| A car that turned no lap at all -- so it is on no lap, in no sector, and
@@ -221,9 +344,10 @@ carOne =
     { metadata = metadataOf "1" (classOf "HYPERCAR")
     , startPosition = 1
     , laps =
-        [ lapOf "1" 1 6000 6000 { s1 = 1000, s2 = 2000, s3 = 3000 }
-        , lapOf "1" 2 6000 12000 { s1 = 1000, s2 = 2000, s3 = 3000 }
-        ]
+        withRunningBests
+            [ lapOf "1" 1 6000 6000 { s1 = 1000, s2 = 2000, s3 = 3000 }
+            , lapOf "1" 2 6000 12000 { s1 = 1000, s2 = 2000, s3 = 3000 }
+            ]
     }
 
 
@@ -232,9 +356,10 @@ carTwo =
     { metadata = metadataOf "2" (classOf "LMGT3")
     , startPosition = 2
     , laps =
-        [ lapOf "2" 1 5000 5000 { s1 = 1500, s2 = 1500, s3 = 2000 }
-        , lapOf "2" 2 4000 9000 { s1 = 1500, s2 = 1500, s3 = 1000 }
-        ]
+        withRunningBests
+            [ lapOf "2" 1 5000 5000 { s1 = 1500, s2 = 1500, s3 = 2000 }
+            , lapOf "2" 2 4000 9000 { s1 = 1500, s2 = 1500, s3 = 1000 }
+            ]
     }
 
 

--- a/package/tests/Motorsport/Race/SnapshotTest.elm
+++ b/package/tests/Motorsport/Race/SnapshotTest.elm
@@ -103,12 +103,14 @@ suite =
                     -- Fifteen even mini-sectors of 1.000, so 3.500 is half way
                     -- through the fourth of them in track order.
                     carAt "7" (leMansFieldAt 3500)
-                        |> Maybe.andThen (.currentLap >> .miniSector)
+                        |> Maybe.andThen .currentLap
+                        |> Maybe.andThen .miniSector
                         |> Expect.equal (Just { miniSector = Z12, progress = 0.5 })
             , test "each of them reads complete behind the car, part way at it, and untouched ahead" <|
                 \_ ->
                     carAt "7" (leMansFieldAt 3500)
-                        |> Maybe.andThen (.currentLap >> .miniSectorStates)
+                        |> Maybe.andThen .currentLap
+                        |> Maybe.andThen .miniSectorStates
                         |> Maybe.map
                             (\states ->
                                 ( states.ip1.progress, states.z12.progress, states.sclc.progress )
@@ -120,14 +122,12 @@ suite =
                     -- is why the mini-sector readings do not go `Nothing` in
                     -- step with `sector` the way the rest of the lap does.
                     carAt "1" (snapshotAt 7000)
+                        |> Maybe.andThen .currentLap
                         |> Maybe.map
-                            (\car ->
-                                ( car.currentLap.miniSector
-                                , car.currentLap.miniSectorStates
-                                , car.currentLap.sector |> Maybe.map .sector
-                                )
+                            (\lap ->
+                                ( lap.miniSector, lap.miniSectorStates, lap.sector.sector )
                             )
-                        |> Expect.equal (Just ( Nothing, Nothing, Just S2 ))
+                        |> Expect.equal (Just ( Nothing, Nothing, S2 ))
             ]
         , describe "the record a running lap is rated against is the car's own, at that moment"
             [ test "it is the best of the laps the car has finished, not of the one it is running" <|
@@ -148,11 +148,12 @@ suite =
                         |> Expect.equal Nothing
             ]
         , describe "a car with no lap in progress is nowhere on the track"
-            [ test "it reports no sector, as it reports no sector states" <|
+            [ test "it is on no lap at all, so there is no reading of one" <|
                 \_ ->
                     carAt "4" fieldWithTailenders
-                        |> Maybe.map (\car -> ( car.currentLap.sector, car.currentLap.sectorStates ))
-                        |> Expect.equal (Just ( Nothing, Nothing ))
+                        |> Maybe.andThen .currentLap
+                        |> Maybe.map (always ())
+                        |> Expect.equal Nothing
             , test "it has completed no laps" <|
                 \_ ->
                     carAt "4" fieldWithTailenders
@@ -228,7 +229,8 @@ carAt =
 sectorStatesOf : String -> Snapshot -> Maybe Snapshot.CurrentSectorStates
 sectorStatesOf carNumber snapshot =
     carAt carNumber snapshot
-        |> Maybe.andThen (.currentLap >> .sectorStates)
+        |> Maybe.andThen .currentLap
+        |> Maybe.map .sectorStates
 
 
 {-| A wider field, for what two cars cannot show: two of them sharing a class,

--- a/package/tests/Motorsport/Race/SnapshotTest.elm
+++ b/package/tests/Motorsport/Race/SnapshotTest.elm
@@ -79,6 +79,22 @@ suite =
                         |> Expect.equal
                             (Just [ ( S1, Just Fastest ), ( S2, Just Standard ), ( S3, Just Standard ) ])
             ]
+        , describe "the record a running lap is rated against is the car's own, at that moment"
+            [ test "it is the best of the laps the car has finished, not of the one it is running" <|
+                \_ ->
+                    -- Car 2's second lap is a 4.000 and at 7.000 it is still on
+                    -- it, so that time is not its record yet: the 5.000 of its
+                    -- first lap is. The lap carries a best that counts itself,
+                    -- which is why this is read off the finished lap instead.
+                    carAt "2" (snapshotAt 7000)
+                        |> Maybe.andThen (.currentLap >> .best)
+                        |> Expect.equal (Just 5000)
+            , test "a car on its opening lap has no record to be rated against" <|
+                \_ ->
+                    carAt "2" (snapshotAt 3000)
+                        |> Maybe.andThen (.currentLap >> .best)
+                        |> Expect.equal Nothing
+            ]
         , describe "a car with no lap in progress is nowhere on the track"
             [ test "it reports no sector, as it reports no sector states" <|
                 \_ ->

--- a/package/tests/Motorsport/Race/SnapshotTest.elm
+++ b/package/tests/Motorsport/Race/SnapshotTest.elm
@@ -105,19 +105,29 @@ suite =
                     carAt "7" (leMansFieldAt 3500)
                         |> Maybe.andThen (.currentLap >> .miniSector)
                         |> Expect.equal (Just { miniSector = Z12, progress = 0.5 })
+            , test "each of them reads complete behind the car, part way at it, and untouched ahead" <|
+                \_ ->
+                    carAt "7" (leMansFieldAt 3500)
+                        |> Maybe.andThen (.currentLap >> .miniSectorStates)
+                        |> Maybe.map
+                            (\states ->
+                                ( states.ip1.progress, states.z12.progress, states.sclc.progress )
+                            )
+                        |> Expect.equal (Just ( 1, 0.5, 0 ))
             , test "and where the data records none there is no mini-sector to be in, though there is still a sector" <|
                 \_ ->
                     -- Away from Le Mans this is every car of every frame, which
-                    -- is why `miniSector` does not go `Nothing` in step with
-                    -- `sector` the way the other readings of the lap do.
+                    -- is why the mini-sector readings do not go `Nothing` in
+                    -- step with `sector` the way the rest of the lap does.
                     carAt "1" (snapshotAt 7000)
                         |> Maybe.map
                             (\car ->
                                 ( car.currentLap.miniSector
+                                , car.currentLap.miniSectorStates
                                 , car.currentLap.sector |> Maybe.map .sector
                                 )
                             )
-                        |> Expect.equal (Just ( Nothing, Just S2 ))
+                        |> Expect.equal (Just ( Nothing, Nothing, Just S2 ))
             ]
         , describe "the record a running lap is rated against is the car's own, at that moment"
             [ test "it is the best of the laps the car has finished, not of the one it is running" <|

--- a/package/tests/Motorsport/Race/SnapshotTest.elm
+++ b/package/tests/Motorsport/Race/SnapshotTest.elm
@@ -79,6 +79,52 @@ suite =
                         |> Expect.equal
                             (Just [ ( S1, Just Fastest ), ( S2, Just Standard ), ( S3, Just Standard ) ])
             ]
+        , describe "a car with no lap in progress is nowhere on the track"
+            [ test "it reports no sector, as it reports no sector states" <|
+                \_ ->
+                    carAt "4" fieldWithTailenders
+                        |> Maybe.map (\car -> ( car.sector, car.currentLapSectorStates ))
+                        |> Expect.equal (Just ( Nothing, Nothing ))
+            , test "it has completed no laps" <|
+                \_ ->
+                    carAt "4" fieldWithTailenders
+                        |> Maybe.map .lapsCompleted
+                        |> Expect.equal (Just 0)
+            , test "and it sorts behind every car that is running" <|
+                \_ ->
+                    fieldWithTailenders
+                        |> Snapshot.toList
+                        |> List.map (.metadata >> .carNumber)
+                        |> Expect.equal [ "2", "1", "3", "4" ]
+            ]
+        , describe "class position is counted off the running order"
+            [ test "a class of two numbers its cars 1 and 2, whatever they stand overall" <|
+                \_ ->
+                    Snapshot.inClass (classOf "HYPERCAR") fieldWithTailenders
+                        |> List.map (\car -> ( car.metadata.carNumber, car.positionInClass ))
+                        |> Expect.equal [ ( "1", 1 ), ( "3", 2 ) ]
+            , test "a car that is not running is still placed in its class, at the back of it" <|
+                \_ ->
+                    Snapshot.inClass (classOf "LMGT3") fieldWithTailenders
+                        |> List.map (\car -> ( car.metadata.carNumber, car.positionInClass ))
+                        |> Expect.equal [ ( "2", 1 ), ( "4", 2 ) ]
+            , test "a class no car races in is empty" <|
+                \_ ->
+                    Snapshot.inClass (classOf "LMP2") fieldWithTailenders
+                        |> List.map (.metadata >> .carNumber)
+                        |> Expect.equal []
+            ]
+        , describe "one car can be read out of the field by number"
+            [ test "the car that carries the number" <|
+                \_ ->
+                    Snapshot.get "3" fieldWithTailenders
+                        |> Maybe.map .position
+                        |> Expect.equal (Just 3)
+            , test "and nothing for a number no car carries" <|
+                \_ ->
+                    Snapshot.get "99" fieldWithTailenders
+                        |> Expect.equal Nothing
+            ]
         , -- What `at` does with the records is BestTimes' own, and tested there.
           -- What is this module's is which of the two it asks for: at 7.000 the
           -- quickest lap run so far is a 5.000, where the race's final answer
@@ -107,16 +153,49 @@ snapshotAt elapsed =
 
 
 carAt : String -> Snapshot -> Maybe CarAt
-carAt carNumber snapshot =
-    Snapshot.toList snapshot
-        |> List.filter (\car -> car.metadata.carNumber == carNumber)
-        |> List.head
+carAt =
+    Snapshot.get
 
 
 sectorStatesOf : String -> Snapshot -> Maybe Snapshot.CurrentSectorStates
 sectorStatesOf carNumber snapshot =
     carAt carNumber snapshot
         |> Maybe.andThen .currentLapSectorStates
+
+
+{-| A wider field, for what two cars cannot show: two of them sharing a class,
+and one that never took to the track at all.
+
+Read at 7.000, as the two-car fixture is, so the cars it has in common with it
+stand where they stand there.
+
+-}
+fieldWithTailenders : Snapshot
+fieldWithTailenders =
+    Race.fromCars [ carOne, carTwo, carThree, nonStarter ]
+        |> Snapshot.at { elapsed = Instant.fromDuration 7000 }
+
+
+{-| Car 1's classmate, and a long way behind it: still on its opening lap at
+7.000, where cars 1 and 2 are both on their second.
+-}
+carThree : Car
+carThree =
+    { metadata = metadataOf "3" (classOf "HYPERCAR")
+    , startPosition = 3
+    , laps = [ lapOf "3" 1 20000 20000 { s1 = 6000, s2 = 7000, s3 = 7000 } ]
+    }
+
+
+{-| A car that turned no lap at all -- so it is on no lap, in no sector, and
+holds no gap to anyone.
+-}
+nonStarter : Car
+nonStarter =
+    { metadata = metadataOf "4" (classOf "LMGT3")
+    , startPosition = 4
+    , laps = []
+    }
 
 
 carOne : Car


### PR DESCRIPTION
A car with no lap in progress was still reporting a sector: `timingOf` filled the missing lap in with `Lap.empty` and wrapped the result in `Just`, so every car without lap data was placed somewhere on the track. `currentLapSectorStates` was already absent for those cars, so the two disagreed. Both now follow `currentLap`, which makes Tracker's own `( Nothing, Nothing )` branch reachable for the first time.

Class position was worked out separately, keyed by car number, and fell back to 1 -- class leader -- for a car the lookup missed. It is now counted off the running order in the same pass that numbers the field overall, alongside the car ahead that each interval is measured to. Nothing can be missing from a count, so the fallback is gone with the lookup, and cars sharing a number no longer collapse into one another.

`get` and `inClass` give back one car or one class of the frozen field, which two widgets were each scanning `toList` and `toClassList` for.