### PR TITLE
refactor: Give a round one state in Shared instead of seven fields

### DIFF
--- a/app/src/Page/Debug.elm
+++ b/app/src/Page/Debug.elm
@@ -10,7 +10,7 @@ import Compare
 import Css exposing (backgroundColor, displayFlex, hsl, justifyContent, position, spaceBetween, sticky, top, zero)
 import DataView
 import Effect exposing (Effect)
-import Html.Styled exposing (div, header, input, nav, text)
+import Html.Styled exposing (Html, div, header, input, nav, text)
 import Html.Styled.Attributes as Attributes exposing (class, css, type_, value)
 import Html.Styled.Events exposing (onClick, onInput)
 import List.Extra
@@ -79,70 +79,80 @@ update msg model =
 
 
 view : Shared.Model -> Model -> View Msg
-view { replay } { leaderboardState } =
+view shared { leaderboardState } =
     { title = "Wec"
     , body =
-        let
-            { playback, race } =
-                replay
+        case Shared.race shared of
+            Nothing ->
+                []
 
-            lapCount =
-                Replay.lapCount replay
-
-            -- The whole race's records, not the clock's: this page reports what
-            -- the data holds, and the slider must not change what a record means.
-            bestTimes =
-                BestTimes.final race.bestTimeChanges
-        in
-        [ header
-            [ css
-                [ position sticky
-                , top zero
-                , displayFlex
-                , justifyContent spaceBetween
-                , backgroundColor (hsl 0 0 0.4)
-                ]
-            ]
-            [ nav []
-                [ input
-                    [ type_ "range"
-                    , Attributes.max <| String.fromInt race.lapTotal
-                    , value (String.fromInt lapCount)
-                    , onInput (String.toInt >> Maybe.withDefault 0 >> Replay.SetCount >> ReplayMsg)
-                    ]
-                    []
-                , labeledButton []
-                    [ button [ class "join-item", onClick (ReplayMsg Replay.PreviousLap) ] [ text "-" ]
-                    , basicLabel [ class "join-item" ] [ text (String.fromInt lapCount) ]
-                    , button [ class "join-item", onClick (ReplayMsg Replay.NextLap) ] [ text "+" ]
-                    ]
-                , text (Clock.getElapsed playback |> Instant.toString)
-                ]
-            , div []
-                ([ div [] [ text "fastestLapTime: ", text (bestTimeText bestTimes.fastestLapTime) ]
-                 , div [] [ text "slowestLapTime: ", text (bestTimeText bestTimes.slowestLapTime) ]
-                 ]
-                    ++ (Sector.toList bestTimes.fastestSectors
-                            |> List.map
-                                (\( sector, fastest ) ->
-                                    div []
-                                        [ text (Sector.toString sector ++ "_fastest: ")
-                                        , text (bestTimeText fastest)
-                                        ]
-                                )
-                       )
-                )
-            ]
-        , let
-            laps =
-                race.cars
-                    |> List.Extra.find (\car -> car.metadata.carNumber == "2")
-                    |> Maybe.map (\car -> List.take lapCount car.laps)
-                    |> Maybe.withDefault []
-          in
-          DataView.view (config bestTimes) leaderboardState (List.indexedMap (lapRow bestTimes) laps)
-        ]
+            Just { replay } ->
+                debugView replay leaderboardState
     }
+
+
+debugView : Replay.Model -> Leaderboard.Model -> List (Html Msg)
+debugView replay leaderboardState =
+    let
+        { playback, race } =
+            replay
+
+        lapCount =
+            Replay.lapCount replay
+
+        -- The whole race's records, not the clock's: this page reports what
+        -- the data holds, and the slider must not change what a record means.
+        bestTimes =
+            BestTimes.final race.bestTimeChanges
+    in
+    [ header
+        [ css
+            [ position sticky
+            , top zero
+            , displayFlex
+            , justifyContent spaceBetween
+            , backgroundColor (hsl 0 0 0.4)
+            ]
+        ]
+        [ nav []
+            [ input
+                [ type_ "range"
+                , Attributes.max <| String.fromInt race.lapTotal
+                , value (String.fromInt lapCount)
+                , onInput (String.toInt >> Maybe.withDefault 0 >> Replay.SetCount >> ReplayMsg)
+                ]
+                []
+            , labeledButton []
+                [ button [ class "join-item", onClick (ReplayMsg Replay.PreviousLap) ] [ text "-" ]
+                , basicLabel [ class "join-item" ] [ text (String.fromInt lapCount) ]
+                , button [ class "join-item", onClick (ReplayMsg Replay.NextLap) ] [ text "+" ]
+                ]
+            , text (Clock.getElapsed playback |> Instant.toString)
+            ]
+        , div []
+            ([ div [] [ text "fastestLapTime: ", text (bestTimeText bestTimes.fastestLapTime) ]
+             , div [] [ text "slowestLapTime: ", text (bestTimeText bestTimes.slowestLapTime) ]
+             ]
+                ++ (Sector.toList bestTimes.fastestSectors
+                        |> List.map
+                            (\( sector, fastest ) ->
+                                div []
+                                    [ text (Sector.toString sector ++ "_fastest: ")
+                                    , text (bestTimeText fastest)
+                                    ]
+                            )
+                   )
+            )
+        ]
+    , let
+        laps =
+            race.cars
+                |> List.Extra.find (\car -> car.metadata.carNumber == "2")
+                |> Maybe.map (\car -> List.take lapCount car.laps)
+                |> Maybe.withDefault []
+      in
+      DataView.view (config bestTimes) leaderboardState (List.indexedMap (lapRow bestTimes) laps)
+    ]
 
 
 {-| One row of this page is one lap of one car, not one car of the race. The

--- a/app/src/Page/Wec/Event.elm
+++ b/app/src/Page/Wec/Event.elm
@@ -16,7 +16,6 @@ import Html.Styled exposing (Html, a, button, div, main_, nav, text)
 import Html.Styled.Attributes as Attributes exposing (attribute, css)
 import Html.Styled.Events exposing (onClick)
 import Motorsport.Chart.Tracker as TrackerChart
-import Motorsport.Clock exposing (State(..))
 import Motorsport.Race.Snapshot as Snapshot exposing (Snapshot)
 import Motorsport.Replay as Replay
 import Motorsport.Widget.Compare as CompareWidget
@@ -148,12 +147,11 @@ update msg m =
 
 subscriptions : Shared.Model -> Model -> Sub Msg
 subscriptions shared _ =
-    case Shared.race shared |> Maybe.map (.replay >> .playback >> .state) of
-        Just (Started _ _) ->
-            Browser.Events.onAnimationFrame (Replay.Tick >> ReplayMsg)
+    if Shared.isPlaying shared then
+        Browser.Events.onAnimationFrame (Replay.Tick >> ReplayMsg)
 
-        _ ->
-            Sub.none
+    else
+        Sub.none
 
 
 
@@ -163,8 +161,27 @@ subscriptions shared _ =
 view : Shared.Model -> Model -> View Msg
 view shared m =
     let
-        maybeRace =
-            Shared.race shared
+        -- Both halves turn on the same question, so it is asked once. Named but
+        -- not loaded draws nothing rather than the round before it.
+        ( playbackControls, body ) =
+            case Shared.race shared of
+                Nothing ->
+                    ( text "", div [ css [ property "grid-row" "2" ] ] [] )
+
+                Just race ->
+                    ( PlaybackControls.view
+                        { replay = race.replay
+                        , onStart = StartRace
+                        , onPause = PauseRace
+                        , toReplayMsg = ReplayMsg
+                        }
+                    , case m.mode of
+                        Tracker ->
+                            trackerView race.track race.snapshot m
+
+                        Events ->
+                            RaceEvents.view EventsMsg m.eventsState race.replay
+                    )
     in
     { title = "Wec"
     , body =
@@ -176,20 +193,8 @@ view shared m =
                 , property "grid-template-rows" "auto 1fr"
                 ]
             ]
-            [ navigation (headerTitle shared) maybeRace m.mode
-            , case maybeRace of
-                Nothing ->
-                    -- Named but not loaded. Nothing is drawn rather than the
-                    -- round before it.
-                    div [ css [ property "grid-row" "2" ] ] []
-
-                Just race ->
-                    case m.mode of
-                        Tracker ->
-                            trackerView race.track race.snapshot m
-
-                        Events ->
-                            RaceEvents.view EventsMsg m.eventsState race.replay
+            [ navigation (headerTitle shared) playbackControls m.mode
+            , body
             ]
         ]
     }
@@ -197,12 +202,9 @@ view shared m =
 
 headerTitle : Shared.Model -> String
 headerTitle shared =
-    case Shared.roundId shared of
-        Just round ->
-            round.name ++ " (" ++ String.fromInt round.season ++ ")"
-
-        Nothing ->
-            ""
+    Shared.roundId shared
+        |> Maybe.map (\round -> round.name ++ " (" ++ String.fromInt round.season ++ ")")
+        |> Maybe.withDefault ""
 
 
 trackerView : TrackerChart.Track -> Snapshot -> Model -> Html Msg
@@ -272,8 +274,8 @@ trackerView track snapshot m =
         ]
 
 
-navigation : String -> Maybe Shared.Race -> Mode -> Html Msg
-navigation title maybeRace currentMode =
+navigation : String -> Html Msg -> Mode -> Html Msg
+navigation title playbackControls currentMode =
     nav
         [ Attributes.class "p-3"
         , css
@@ -287,17 +289,7 @@ navigation title maybeRace currentMode =
             [ backLink
             , div [ Attributes.class "text-sm" ] [ text title ]
             ]
-        , case maybeRace of
-            Nothing ->
-                text ""
-
-            Just race ->
-                PlaybackControls.view
-                    { replay = race.replay
-                    , onStart = StartRace
-                    , onPause = PauseRace
-                    , toReplayMsg = ReplayMsg
-                    }
+        , playbackControls
         , viewModeSelector currentMode
         ]
 

--- a/app/src/Page/Wec/Event.elm
+++ b/app/src/Page/Wec/Event.elm
@@ -161,27 +161,8 @@ subscriptions shared _ =
 view : Shared.Model -> Model -> View Msg
 view shared m =
     let
-        -- Both halves turn on the same question, so it is asked once. Named but
-        -- not loaded draws nothing rather than the round before it.
-        ( playbackControls, body ) =
-            case Shared.race shared of
-                Nothing ->
-                    ( text "", div [ css [ property "grid-row" "2" ] ] [] )
-
-                Just race ->
-                    ( PlaybackControls.view
-                        { replay = race.replay
-                        , onStart = StartRace
-                        , onPause = PauseRace
-                        , toReplayMsg = ReplayMsg
-                        }
-                    , case m.mode of
-                        Tracker ->
-                            trackerView race.track race.snapshot m
-
-                        Events ->
-                            RaceEvents.view EventsMsg m.eventsState race.replay
-                    )
+        maybeRace =
+            Shared.race shared
     in
     { title = "Wec"
     , body =
@@ -193,8 +174,20 @@ view shared m =
                 , property "grid-template-rows" "auto 1fr"
                 ]
             ]
-            [ navigation (headerTitle shared) playbackControls m.mode
-            , body
+            [ navigation (headerTitle shared) maybeRace m.mode
+            , case maybeRace of
+                Nothing ->
+                    -- Named but not loaded. Nothing is drawn rather than the
+                    -- round before it.
+                    div [ css [ property "grid-row" "2" ] ] []
+
+                Just race ->
+                    case m.mode of
+                        Tracker ->
+                            trackerView race.track race.snapshot m
+
+                        Events ->
+                            RaceEvents.view EventsMsg m.eventsState race.replay
             ]
         ]
     }
@@ -274,8 +267,8 @@ trackerView track snapshot m =
         ]
 
 
-navigation : String -> Html Msg -> Mode -> Html Msg
-navigation title playbackControls currentMode =
+navigation : String -> Maybe Shared.Race -> Mode -> Html Msg
+navigation title maybeRace currentMode =
     nav
         [ Attributes.class "p-3"
         , css
@@ -289,7 +282,17 @@ navigation title playbackControls currentMode =
             [ backLink
             , div [ Attributes.class "text-sm" ] [ text title ]
             ]
-        , playbackControls
+        , case maybeRace of
+            Nothing ->
+                text ""
+
+            Just race ->
+                PlaybackControls.view
+                    { replay = race.replay
+                    , onStart = StartRace
+                    , onPause = PauseRace
+                    , toReplayMsg = ReplayMsg
+                    }
         , viewModeSelector currentMode
         ]
 

--- a/app/src/Page/Wec/Event.elm
+++ b/app/src/Page/Wec/Event.elm
@@ -179,8 +179,8 @@ view shared m =
             [ navigation (headerTitle shared) maybeRace m.mode
             , case maybeRace of
                 Nothing ->
-                    -- The round is named by now but its files are not in yet.
-                    -- Nothing is drawn rather than the round before it.
+                    -- Named but not loaded. Nothing is drawn rather than the
+                    -- round before it.
                     div [ css [ property "grid-row" "2" ] ] []
 
                 Just race ->

--- a/app/src/Page/Wec/Event.elm
+++ b/app/src/Page/Wec/Event.elm
@@ -148,8 +148,8 @@ update msg m =
 
 subscriptions : Shared.Model -> Model -> Sub Msg
 subscriptions shared _ =
-    case shared.replay.playback.state of
-        Started _ _ ->
+    case Shared.race shared |> Maybe.map (.replay >> .playback >> .state) of
+        Just (Started _ _) ->
             Browser.Events.onAnimationFrame (Replay.Tick >> ReplayMsg)
 
         _ ->
@@ -161,7 +161,11 @@ subscriptions shared _ =
 
 
 view : Shared.Model -> Model -> View Msg
-view { season, eventName, replay, snapshot, track } m =
+view shared m =
+    let
+        maybeRace =
+            Shared.race shared
+    in
     { title = "Wec"
     , body =
         [ main_
@@ -172,16 +176,33 @@ view { season, eventName, replay, snapshot, track } m =
                 , property "grid-template-rows" "auto 1fr"
                 ]
             ]
-            [ navigation { name = eventName, season = season } replay m.mode
-            , case m.mode of
-                Tracker ->
-                    trackerView track snapshot m
+            [ navigation (headerTitle shared) maybeRace m.mode
+            , case maybeRace of
+                Nothing ->
+                    -- The round is named by now but its files are not in yet.
+                    -- Nothing is drawn rather than the round before it.
+                    div [ css [ property "grid-row" "2" ] ] []
 
-                Events ->
-                    RaceEvents.view EventsMsg m.eventsState replay
+                Just race ->
+                    case m.mode of
+                        Tracker ->
+                            trackerView race.track race.snapshot m
+
+                        Events ->
+                            RaceEvents.view EventsMsg m.eventsState race.replay
             ]
         ]
     }
+
+
+headerTitle : Shared.Model -> String
+headerTitle shared =
+    case Shared.roundId shared of
+        Just round ->
+            round.name ++ " (" ++ String.fromInt round.season ++ ")"
+
+        Nothing ->
+            ""
 
 
 trackerView : TrackerChart.Track -> Snapshot -> Model -> Html Msg
@@ -251,12 +272,8 @@ trackerView track snapshot m =
         ]
 
 
-navigation : { name : String, season : Int } -> Replay.Model -> Mode -> Html Msg
-navigation event replay currentMode =
-    let
-        headerTitle =
-            event.name ++ " (" ++ String.fromInt event.season ++ ")"
-    in
+navigation : String -> Maybe Shared.Race -> Mode -> Html Msg
+navigation title maybeRace currentMode =
     nav
         [ Attributes.class "p-3"
         , css
@@ -268,14 +285,19 @@ navigation event replay currentMode =
         ]
         [ div [ Attributes.class "flex items-center gap-2 whitespace-nowrap" ]
             [ backLink
-            , div [ Attributes.class "text-sm" ] [ text headerTitle ]
+            , div [ Attributes.class "text-sm" ] [ text title ]
             ]
-        , PlaybackControls.view
-            { replay = replay
-            , onStart = StartRace
-            , onPause = PauseRace
-            , toReplayMsg = ReplayMsg
-            }
+        , case maybeRace of
+            Nothing ->
+                text ""
+
+            Just race ->
+                PlaybackControls.view
+                    { replay = race.replay
+                    , onStart = StartRace
+                    , onPause = PauseRace
+                    , toReplayMsg = ReplayMsg
+                    }
         , viewModeSelector currentMode
         ]
 

--- a/app/src/Shared.elm
+++ b/app/src/Shared.elm
@@ -137,9 +137,10 @@ race model =
             Nothing
 
 
-{-| Whether playback is running, which is the whole of what a page needs in
-order to decide about animation frames. Asked here so no page has to reach
-through a race to its clock.
+{-| Whether playback is running, which is the whole of what deciding about
+animation frames takes. Asked here so that page does not reach through a race to
+its clock for one constructor. `Page.Debug` still reaches for the elapsed time,
+which is a value and not a question.
 -}
 isPlaying : Model -> Bool
 isPlaying model =

--- a/app/src/Shared.elm
+++ b/app/src/Shared.elm
@@ -1,9 +1,15 @@
-module Shared exposing (Model, init, update, subscriptions)
+module Shared exposing
+    ( Model, Race, RoundId
+    , init, update, subscriptions
+    , race, roundId
+    )
 
 {-| Application-wide state, preserved from the elm-pages version. The data is
 loaded at runtime via `Http`, so no `BackendTask` is involved.
 
-@docs Model, init, update, subscriptions
+@docs Model, Race, RoundId
+@docs init, update, subscriptions
+@docs race, roundId
 
 -}
 
@@ -14,7 +20,7 @@ import Effect exposing (Effect)
 import Http
 import Motorsport.Chart.Tracker as Tracker
 import Motorsport.Clock as Clock
-import Motorsport.Race.Car as Car exposing (Car)
+import Motorsport.Race.Car as Car
 import Motorsport.Race.Snapshot as Snapshot exposing (Snapshot)
 import Motorsport.Replay as Replay
 import Motorsport.Wec.Era as Era
@@ -25,29 +31,68 @@ import Shared.Msg exposing (Msg(..))
 -- MODEL
 
 
-{-| `track` is the one derived value kept here rather than worked out where it
-is used: everything else about a frame follows from `replay` and the clock,
-where the track never moves once the data has loaded. See
-[`Tracker.fromConfig`](Motorsport-Chart-Tracker#fromConfig).
-
-`season` and `eventName` both come off the calendar entry the round was found
-in, so the app never holds a second opinion about what a race is called.
-
-`requestedRound` is a URL that arrived before the calendar did. The calendar is
-what says where a round's files are, so the request waits rather than being
-guessed at, and is cleared once issued so a later calendar cannot ask twice.
-
+{-| The calendar, and the one round the app is showing. Everything else about a
+round hangs off `Round` rather than sitting beside it, so a half-loaded one
+cannot be read as a loaded one.
 -}
 type alias Model =
     { calendar : Calendar
-    , season : Int
-    , eventName : String
-    , requestedRound : Maybe { season : String, event : String }
-    , replay : Replay.Model
+    , round : Round
+    }
+
+
+{-| How far the round in the URL has got.
+
+`Waiting` is a URL that arrived before the calendar did. The calendar is what
+says where a round's files are, so the request waits rather than being guessed
+at.
+
+`Loading` carries no `Race`, which is what stops the previous round's cars being
+shown under this one's name.
+
+-}
+type Round
+    = NoRound
+    | Waiting { season : String, event : String }
+    | Loading RoundId Partial
+    | Loaded RoundId Race
+
+
+{-| Which round, and what to call it. Known as soon as the calendar resolves the
+URL, so the name can be shown while the files are still on their way.
+-}
+type alias RoundId =
+    { season : Int
+    , id : String
+    , name : String
+    }
+
+
+{-| The two files arrive in either order, and a round needs both. Three cases
+rather than a pair of `Maybe`s: having both is not a state, it is the move to
+`Loaded`.
+-}
+type Partial
+    = NothingYet
+    | GotSummary Wec.Event
+    | GotLaps (List WecLaps.RawLap)
+
+
+{-| A loaded round, as the pages read it.
+
+`track` is the one derived value kept here rather than worked out where it is
+used: everything else about a frame follows from `replay` and the clock, where
+the track never moves once the data has loaded. See
+[`Tracker.fromConfig`](Motorsport-Chart-Tracker#fromConfig).
+
+`snapshot` is `replay` read at the clock, cached because every view of a frame
+shares it. The two are only ever written together.
+
+-}
+type alias Race =
+    { replay : Replay.Model
     , snapshot : Snapshot
     , track : Tracker.Track
-    , pendingWecEvent : Maybe Wec.Event
-    , pendingWecLaps : Maybe (List WecLaps.RawLap)
     }
 
 
@@ -57,29 +102,45 @@ still needs it.
 -}
 init : flags -> ( Model, Effect Msg )
 init _ =
-    let
-        replayInit =
-            Replay.empty
-
-        snapshotInit =
-            snapshotOf replayInit
-    in
-    ( { calendar = Calendar.empty
-      , season = 0
-      , eventName = ""
-      , requestedRound = Nothing
-      , replay = replayInit
-      , snapshot = snapshotInit
-      , track = Tracker.empty
-      , pendingWecEvent = Nothing
-      , pendingWecLaps = Nothing
-      }
+    ( { calendar = Calendar.empty, round = NoRound }
     , Effect.sendCmd <|
         Http.get
             { url = "/static/wec/index.json"
             , expect = Http.expectJson CalendarLoaded Calendar.decoder
             }
     )
+
+
+
+-- QUERIES
+
+
+{-| What to call the round being shown, once there is one. Answers while it is
+still loading, which is why it is separate from [`race`](#race).
+-}
+roundId : Model -> Maybe RoundId
+roundId model =
+    case model.round of
+        Loading id _ ->
+            Just id
+
+        Loaded id _ ->
+            Just id
+
+        _ ->
+            Nothing
+
+
+{-| The round's data, once all of it has arrived.
+-}
+race : Model -> Maybe Race
+race model =
+    case model.round of
+        Loaded _ loaded ->
+            Just loaded
+
+        _ ->
+            Nothing
 
 
 
@@ -90,44 +151,28 @@ update : Msg -> Model -> ( Model, Effect Msg )
 update msg m =
     case msg of
         CalendarLoaded (Ok calendar) ->
-            requestRequestedRound { m | calendar = calendar }
+            requestWaitingRound { m | calendar = calendar }
 
         CalendarLoaded (Err _) ->
             ( m, Effect.none )
 
-        FetchJson_Wec options ->
-            requestRequestedRound
-                { m
-                    | requestedRound = Just options
-                    , season = 0
-                    , eventName = ""
-                    , pendingWecEvent = Nothing
-                    , pendingWecLaps = Nothing
-                }
+        FetchJson_Wec params ->
+            requestWaitingRound { m | round = Waiting params }
 
-        JsonLoaded_Wec (Ok decoded) ->
-            finalizeWecIfReady { m | pendingWecEvent = Just decoded }
+        JsonLoaded_Wec key (Ok summary) ->
+            ( { m | round = arrived key (withSummary summary) m.round }, Effect.none )
 
-        JsonLoaded_Wec (Err _) ->
+        JsonLoaded_Wec _ (Err _) ->
             ( m, Effect.none )
 
-        LapsLoaded_Wec (Ok rawLaps) ->
-            finalizeWecIfReady { m | pendingWecLaps = Just rawLaps }
+        LapsLoaded_Wec key (Ok rawLaps) ->
+            ( { m | round = arrived key (withLaps rawLaps) m.round }, Effect.none )
 
-        LapsLoaded_Wec (Err _) ->
+        LapsLoaded_Wec _ (Err _) ->
             ( m, Effect.none )
 
         ReplayMsg replayMsg ->
-            let
-                replayNew =
-                    Replay.update replayMsg m.replay
-            in
-            ( { m
-                | replay = replayNew
-                , snapshot = snapshotOf replayNew
-              }
-            , Effect.none
-            )
+            ( { m | round = mapRace (stepReplay replayMsg) m.round }, Effect.none )
 
 
 {-| Asks for the round the URL named, once the calendar can say where its files
@@ -137,76 +182,127 @@ Called from both sides of the race between the two, so whichever of the URL and
 the calendar arrives second is the one that finds everything it needs here.
 
 -}
-requestRequestedRound : Model -> ( Model, Effect Msg )
-requestRequestedRound m =
-    case Maybe.andThen (\params -> Calendar.findRound params m.calendar) m.requestedRound of
-        Nothing ->
+requestWaitingRound : Model -> ( Model, Effect Msg )
+requestWaitingRound m =
+    case m.round of
+        Waiting params ->
+            case Calendar.findRound params m.calendar of
+                Nothing ->
+                    ( m, Effect.none )
+
+                Just ( season, round ) ->
+                    let
+                        id =
+                            { season = season.season, id = round.id, name = round.name }
+                    in
+                    ( { m | round = Loading id NothingYet }
+                    , case Era.fromSeason id.season of
+                        Just era ->
+                            Effect.sendCmd <|
+                                Cmd.batch
+                                    [ Http.get
+                                        { url = round.summary
+                                        , expect = Http.expectJson (JsonLoaded_Wec (keyOf id)) (Wec.eventDecoder era)
+                                        }
+                                    , Http.get
+                                        { url = round.laps
+                                        , expect = Http.expectJson (LapsLoaded_Wec (keyOf id)) WecLaps.decoder
+                                        }
+                                    ]
+
+                        Nothing ->
+                            -- No grid for this season, so no way to read its
+                            -- classes. The name is shown and nothing is asked
+                            -- for.
+                            Effect.none
+                    )
+
+        _ ->
             ( m, Effect.none )
 
-        Just ( season, round ) ->
-            ( { m
-                | requestedRound = Nothing
-                , season = season.season
-                , eventName = round.name
-              }
-            , case Era.fromSeason season.season of
-                Just era ->
-                    Effect.sendCmd <|
-                        Cmd.batch
-                            [ Http.get
-                                { url = round.summary
-                                , expect = Http.expectJson JsonLoaded_Wec (Wec.eventDecoder era)
-                                }
-                            , Http.get
-                                { url = round.laps
-                                , expect = Http.expectJson LapsLoaded_Wec WecLaps.decoder
-                                }
-                            ]
 
-                Nothing ->
-                    -- No grid for this season, so no way to read its classes.
-                    -- Nothing is asked for.
-                    Effect.none
-            )
+{-| Applies a file to the round that asked for it, and to no other. A response
+naming a round this one is not is one left over from a round the reader has
+already navigated away from.
+-}
+arrived : { season : Int, id : String } -> (RoundId -> Partial -> Round) -> Round -> Round
+arrived key step round =
+    case round of
+        Loading id partial ->
+            if keyOf id == key then
+                step id partial
+
+            else
+                round
+
+        _ ->
+            round
+
+
+withSummary : Wec.Event -> RoundId -> Partial -> Round
+withSummary summary id partial =
+    case partial of
+        GotLaps rawLaps ->
+            Loaded id (raceFrom summary rawLaps)
+
+        _ ->
+            Loading id (GotSummary summary)
+
+
+withLaps : List WecLaps.RawLap -> RoundId -> Partial -> Round
+withLaps rawLaps id partial =
+    case partial of
+        GotSummary summary ->
+            Loaded id (raceFrom summary rawLaps)
+
+        _ ->
+            Loading id (GotLaps rawLaps)
+
+
+raceFrom : Wec.Event -> List WecLaps.RawLap -> Race
+raceFrom summary rawLaps =
+    let
+        replay =
+            summary.startingGrid.entries
+                |> List.map Car.fromStartingGrid
+                |> WecLaps.attach rawLaps
+                |> Replay.fromCars { timeLimit = summary.timeLimit }
+    in
+    { replay = replay
+    , snapshot = snapshotOf replay
+    , track = Tracker.fromConfig summary.track
+    }
+
+
+mapRace : (Race -> Race) -> Round -> Round
+mapRace f round =
+    case round of
+        Loaded id loaded ->
+            Loaded id (f loaded)
+
+        _ ->
+            round
+
+
+stepReplay : Replay.Msg -> Race -> Race
+stepReplay replayMsg loaded =
+    let
+        replayNew =
+            Replay.update replayMsg loaded.replay
+    in
+    { loaded | replay = replayNew, snapshot = snapshotOf replayNew }
+
+
+keyOf : RoundId -> { season : Int, id : String }
+keyOf id =
+    { season = id.season, id = id.id }
 
 
 {-| The race read where playback has got to.
 -}
 snapshotOf : Replay.Model -> Snapshot
-snapshotOf { race, playback } =
-    Snapshot.at { elapsed = Clock.getElapsed playback } race
-
-
-finalizeWecIfReady : Model -> ( Model, Effect Msg )
-finalizeWecIfReady m =
-    case ( m.pendingWecEvent, m.pendingWecLaps ) of
-        ( Just event, Just rawLaps ) ->
-            let
-                carsWithLaps =
-                    event.startingGrid.entries
-                        |> List.map Car.fromStartingGrid
-                        |> WecLaps.attach rawLaps
-
-                replayNew =
-                    Replay.fromCars
-                        { timeLimit = event.timeLimit }
-                        carsWithLaps
-            in
-            ( { m
-                | replay = replayNew
-                , snapshot = snapshotOf replayNew
-
-                -- Settled here, with the race, and not touched again until the
-                -- next one loads.
-                , track = Tracker.fromConfig event.track
-                , pendingWecEvent = Nothing
-                , pendingWecLaps = Nothing
-              }
-            , Effect.none
-            )
-
-        _ ->
-            ( m, Effect.none )
+snapshotOf replay =
+    Snapshot.at { elapsed = Clock.getElapsed replay.playback } replay.race
 
 
 

--- a/app/src/Shared.elm
+++ b/app/src/Shared.elm
@@ -1,7 +1,7 @@
 module Shared exposing
     ( Model, Race, RoundId
     , init, update, subscriptions
-    , race, roundId
+    , race, roundId, isPlaying
     )
 
 {-| Application-wide state, preserved from the elm-pages version. The data is
@@ -9,7 +9,7 @@ loaded at runtime via `Http`, so no `BackendTask` is involved.
 
 @docs Model, Race, RoundId
 @docs init, update, subscriptions
-@docs race, roundId
+@docs race, roundId, isPlaying
 
 -}
 
@@ -135,6 +135,20 @@ race model =
 
         _ ->
             Nothing
+
+
+{-| Whether playback is running, which is the whole of what a page needs in
+order to decide about animation frames. Asked here so no page has to reach
+through a race to its clock.
+-}
+isPlaying : Model -> Bool
+isPlaying model =
+    case race model |> Maybe.map (.replay >> .playback >> .state) of
+        Just (Clock.Started _ _) ->
+            True
+
+        _ ->
+            False
 
 
 

--- a/app/src/Shared.elm
+++ b/app/src/Shared.elm
@@ -31,9 +31,8 @@ import Shared.Msg exposing (Msg(..))
 -- MODEL
 
 
-{-| The calendar, and the one round the app is showing. Everything else about a
-round hangs off `Round` rather than sitting beside it, so a half-loaded one
-cannot be read as a loaded one.
+{-| Everything about a round hangs off `Round` rather than sitting beside it,
+so a half-loaded one cannot be read as a loaded one.
 -}
 type alias Model =
     { calendar : Calendar
@@ -41,11 +40,9 @@ type alias Model =
     }
 
 
-{-| How far the round in the URL has got.
-
-`Waiting` is a URL that arrived before the calendar did. The calendar is what
-says where a round's files are, so the request waits rather than being guessed
-at.
+{-| `Waiting` is a URL that arrived before the calendar did. The calendar is
+what says where a round's files are, so the request waits rather than being
+guessed at.
 
 `Loading` carries no `Race`, which is what stops the previous round's cars being
 shown under this one's name.
@@ -58,8 +55,8 @@ type Round
     | Loaded RoundId Race
 
 
-{-| Which round, and what to call it. Known as soon as the calendar resolves the
-URL, so the name can be shown while the files are still on their way.
+{-| Known as soon as the calendar resolves the URL, so the name can be shown
+while the files are still on their way.
 -}
 type alias RoundId =
     { season : Int
@@ -80,13 +77,10 @@ type Partial
 
 {-| A loaded round, as the pages read it.
 
-`track` is the one derived value kept here rather than worked out where it is
-used: everything else about a frame follows from `replay` and the clock, where
-the track never moves once the data has loaded. See
-[`Tracker.fromConfig`](Motorsport-Chart-Tracker#fromConfig).
-
-`snapshot` is `replay` read at the clock, cached because every view of a frame
-shares it. The two are only ever written together.
+`track` is the one derived value kept rather than worked out where it is used:
+everything else about a frame follows from `replay` and the clock, where the
+track never moves once the data has loaded. `snapshot` is `replay` read at the
+clock, cached because every view of a frame shares it.
 
 -}
 type alias Race =
@@ -115,8 +109,8 @@ init _ =
 -- QUERIES
 
 
-{-| What to call the round being shown, once there is one. Answers while it is
-still loading, which is why it is separate from [`race`](#race).
+{-| Answers while the round is still loading, which is why it is separate from
+[`race`](#race).
 -}
 roundId : Model -> Maybe RoundId
 roundId model =
@@ -175,12 +169,8 @@ update msg m =
             ( { m | round = mapRace (stepReplay replayMsg) m.round }, Effect.none )
 
 
-{-| Asks for the round the URL named, once the calendar can say where its files
-are.
-
-Called from both sides of the race between the two, so whichever of the URL and
-the calendar arrives second is the one that finds everything it needs here.
-
+{-| Called from both sides of the race between the URL and the calendar, so
+whichever arrives second is the one that finds everything it needs here.
 -}
 requestWaitingRound : Model -> ( Model, Effect Msg )
 requestWaitingRound m =
@@ -222,8 +212,8 @@ requestWaitingRound m =
 
 
 {-| Applies a file to the round that asked for it, and to no other. A response
-naming a round this one is not is one left over from a round the reader has
-already navigated away from.
+naming any other round is one left over from a round already navigated away
+from.
 -}
 arrived : { season : Int, id : String } -> (RoundId -> Partial -> Round) -> Round -> Round
 arrived key step round =

--- a/app/src/Shared.elm
+++ b/app/src/Shared.elm
@@ -145,13 +145,13 @@ update : Msg -> Model -> ( Model, Effect Msg )
 update msg m =
     case msg of
         CalendarLoaded (Ok calendar) ->
-            requestWaitingRound { m | calendar = calendar }
+            resumeWaitingRound { m | calendar = calendar }
 
         CalendarLoaded (Err _) ->
             ( m, Effect.none )
 
         FetchJson_Wec params ->
-            requestWaitingRound { m | round = Waiting params }
+            resumeWaitingRound { m | round = Waiting params }
 
         JsonLoaded_Wec key (Ok summary) ->
             ( { m | round = arrived key (withSummary summary) m.round }, Effect.none )
@@ -172,8 +172,8 @@ update msg m =
 {-| Called from both sides of the race between the URL and the calendar, so
 whichever arrives second is the one that finds everything it needs here.
 -}
-requestWaitingRound : Model -> ( Model, Effect Msg )
-requestWaitingRound m =
+resumeWaitingRound : Model -> ( Model, Effect Msg )
+resumeWaitingRound m =
     case m.round of
         Waiting params ->
             case Calendar.findRound params m.calendar of

--- a/app/src/Shared/Msg.elm
+++ b/app/src/Shared/Msg.elm
@@ -14,10 +14,16 @@ import Http
 import Motorsport.Replay as Replay
 
 
-{-| -}
+{-| The two file responses carry the round they were asked for.
+
+Nothing cancels an `Http.get`, so navigating away from a round that is still
+loading leaves its responses in flight. Untagged, one of them lands beside the
+next round's other file and the two are assembled into a race that never ran.
+
+-}
 type Msg
     = CalendarLoaded (Result Http.Error Calendar.Calendar)
     | FetchJson_Wec { season : String, event : String }
-    | JsonLoaded_Wec (Result Http.Error Wec.Event)
-    | LapsLoaded_Wec (Result Http.Error (List WecLaps.RawLap))
+    | JsonLoaded_Wec { season : Int, id : String } (Result Http.Error Wec.Event)
+    | LapsLoaded_Wec { season : Int, id : String } (Result Http.Error (List WecLaps.RawLap))
     | ReplayMsg Replay.Msg

--- a/app/src/Shared/Msg.elm
+++ b/app/src/Shared/Msg.elm
@@ -16,9 +16,9 @@ import Motorsport.Replay as Replay
 
 {-| The two file responses carry the round they were asked for.
 
-Nothing cancels an `Http.get`, so navigating away from a round that is still
-loading leaves its responses in flight. Untagged, one of them lands beside the
-next round's other file and the two are assembled into a race that never ran.
+Nothing cancels an `Http.get`, so leaving a round mid-load leaves its responses
+in flight. Untagged, one of them lands beside the next round's other file and
+the two are assembled into a race that never ran.
 
 -}
 type Msg

--- a/package/elm.json
+++ b/package/elm.json
@@ -56,7 +56,8 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "2.2.1"
+            "elm-explorations/test": "2.2.1",
+            "elm/http": "2.0.0"
         },
         "indirect": {
             "elm/bytes": "1.0.8"

--- a/package/src/Motorsport/Chart/Tracker.elm
+++ b/package/src/Motorsport/Chart/Tracker.elm
@@ -1,8 +1,8 @@
-module Motorsport.Chart.Tracker exposing (Track, empty, fromConfig, view)
+module Motorsport.Chart.Tracker exposing (Track, fromConfig, view)
 
 {-| The field drawn going round the circuit.
 
-@docs Track, empty, fromConfig, view
+@docs Track, fromConfig, view
 
 -}
 
@@ -113,25 +113,6 @@ type Track
 fromConfig : { direction : Direction, config : TrackConfig } -> Track
 fromConfig =
     Track
-
-
-{-| The track to stand in for one whose summary has not loaded yet. Written out
-rather than worked out: the rule that divides a lap lives in the CLI now, and
-three thirds do not need it.
--}
-empty : Track
-empty =
-    Track
-        { direction = Clockwise
-        , config =
-            { sectors =
-                { s1 = { start = 0, share = 1 / 3 }
-                , s2 = { start = 1 / 3, share = 1 / 3 }
-                , s3 = { start = 2 / 3, share = 1 / 3 }
-                }
-            , miniSectors = Config.NoMiniSectors
-            }
-        }
 
 
 view : Track -> Snapshot -> Svg msg

--- a/package/src/Motorsport/Replay.elm
+++ b/package/src/Motorsport/Replay.elm
@@ -1,5 +1,5 @@
 module Motorsport.Replay exposing
-    ( Model, empty, fromCars
+    ( Model, fromCars
     , Msg(..), update
     , lapCount
     )
@@ -11,7 +11,7 @@ Two fields, and only one of them moves. `race` is settled when the data loads;
 cars are doing at the current moment is a function of `race` and the elapsed time,
 worked out where it is needed.
 
-@docs Model, empty, fromCars
+@docs Model, fromCars
 @docs Msg, update
 @docs lapCount
 
@@ -32,15 +32,6 @@ import Time exposing (Posix)
 type alias Model =
     { race : Race
     , playback : Clock.Model
-    }
-
-
-{-| A replay of no race at all, for before one has loaded.
--}
-empty : Model
-empty =
-    { race = Race.empty
-    , playback = Clock.init
     }
 
 

--- a/package/tests/SharedTest.elm
+++ b/package/tests/SharedTest.elm
@@ -10,10 +10,12 @@ import Data.Wec.Calendar as Calendar
 import Data.Wec.Laps as WecLaps
 import Expect
 import Json.Decode as Decode
+import Motorsport.Replay as Replay
 import Motorsport.Wec.Era as Era
 import Shared
 import Shared.Msg exposing (Msg(..))
 import Test exposing (Test, describe, test)
+import Time
 
 
 {-| One season of two rounds: the pair a stale response can be mistaken for.
@@ -211,6 +213,17 @@ suite =
                         |> deliverLaps fuji
                         |> Shared.race
                         |> Expect.equal Nothing
+            , test "reports playback running only once a race is loaded and started" <|
+                \_ ->
+                    let
+                        loaded =
+                            loadingSpa |> deliverSummary spa |> deliverLaps spa
+                    in
+                    [ Shared.isPlaying loadingSpa
+                    , Shared.isPlaying loaded
+                    , Shared.isPlaying (loaded |> step (ReplayMsg (Replay.Start (Time.millisToPosix 0))))
+                    ]
+                        |> Expect.equalLists [ False, False, True ]
             , test "a stale pair does not complete the round that is waiting" <|
                 \_ ->
                     -- Both files of the round left behind, arriving together.

--- a/package/tests/SharedTest.elm
+++ b/package/tests/SharedTest.elm
@@ -128,20 +128,36 @@ fuji =
     { season = 2025, id = "fuji_6h" }
 
 
-{-| A model that has the calendar and has been asked for Spa, so it is waiting
-on Spa's two files.
+calendar : Calendar.Calendar
+calendar =
+    Decode.decodeString Calendar.decoder calendarJson
+        |> Result.withDefault Calendar.empty
+
+
+fresh : Shared.Model
+fresh =
+    Shared.init () |> Tuple.first
+
+
+{-| Waiting on Spa's two files, reached the way a link from the index page
+reaches it: the calendar was already in when the URL arrived.
 -}
 loadingSpa : Shared.Model
 loadingSpa =
-    let
-        calendar =
-            Decode.decodeString Calendar.decoder calendarJson
-                |> Result.withDefault Calendar.empty
-    in
-    Shared.init ()
-        |> Tuple.first
+    fresh
         |> step (CalendarLoaded (Ok calendar))
         |> step (FetchJson_Wec { season = "2025", event = "spa_6h" })
+
+
+{-| The same round reached the other way round, which is what a deep link does:
+the URL is known before the calendar that says where its files are. Nothing can
+be asked for until the second of the two lands.
+-}
+loadingSpaByDeepLink : Shared.Model
+loadingSpaByDeepLink =
+    fresh
+        |> step (FetchJson_Wec { season = "2025", event = "spa_6h" })
+        |> step (CalendarLoaded (Ok calendar))
 
 
 step : Msg -> Shared.Model -> Shared.Model
@@ -157,12 +173,27 @@ suite =
                 ( summary /= Nothing, List.length laps )
                     |> Expect.equal ( True, 1 )
         , describe "update"
-            [ test "names the round as soon as the calendar resolves it" <|
+            [ test "resolves the round whichever of the URL and the calendar is second" <|
                 \_ ->
-                    loadingSpa
-                        |> Shared.roundId
-                        |> Maybe.map .name
-                        |> Expect.equal (Just "6 Hours of Spa")
+                    [ loadingSpa, loadingSpaByDeepLink ]
+                        |> List.map (Shared.roundId >> Maybe.map .name)
+                        |> Expect.equalLists
+                            [ Just "6 Hours of Spa", Just "6 Hours of Spa" ]
+            , test "loads a round reached by a deep link" <|
+                \_ ->
+                    loadingSpaByDeepLink
+                        |> deliverSummary spa
+                        |> deliverLaps spa
+                        |> Shared.race
+                        |> Expect.notEqual Nothing
+            , test "leaves a round the calendar does not list unresolved" <|
+                \_ ->
+                    -- Nothing is asked for, and there is nothing to name.
+                    fresh
+                        |> step (CalendarLoaded (Ok calendar))
+                        |> step (FetchJson_Wec { season = "2025", event = "monza_6h" })
+                        |> (\m -> ( Shared.roundId m, Shared.race m ))
+                        |> Expect.equal ( Nothing, Nothing )
             , test "shows no race until both of the round's files are in" <|
                 \_ ->
                     loadingSpa

--- a/package/tests/SharedTest.elm
+++ b/package/tests/SharedTest.elm
@@ -1,9 +1,8 @@
 module SharedTest exposing (suite)
 
-{-| Drives `Shared.update` from the outside. The states a round passes through
-are not exposed, so what a round has got to is read back through
-[`Shared.race`](Shared#race) and [`Shared.roundId`](Shared#roundId), which is
-all a page can see of it either.
+{-| Drives `Shared.update` from the outside. A round's states are not exposed,
+so how far one has got is read back through `Shared.race` and `Shared.roundId`
+-- all a page can see of it either.
 -}
 
 import Data.Wec as Wec
@@ -17,8 +16,7 @@ import Shared.Msg exposing (Msg(..))
 import Test exposing (Test, describe, test)
 
 
-{-| Two seasons apart, and one of them runs two rounds -- the pairs a stale
-response can be mistaken for.
+{-| One season of two rounds: the pair a stale response can be mistaken for.
 -}
 calendarJson : String
 calendarJson =
@@ -99,9 +97,8 @@ laps =
         |> Result.withDefault []
 
 
-{-| Delivers a fixture that may have failed to decode. A broken one leaves the
-round unchanged rather than passing an assertion by accident, and the fixture
-test below is what says so.
+{-| A fixture that failed to decode leaves the round unchanged rather than
+passing an assertion by accident. The fixture test below is what says so.
 -}
 deliverSummary : { season : Int, id : String } -> Shared.Model -> Shared.Model
 deliverSummary key model =
@@ -139,8 +136,8 @@ fresh =
     Shared.init () |> Tuple.first
 
 
-{-| Waiting on Spa's two files, reached the way a link from the index page
-reaches it: the calendar was already in when the URL arrived.
+{-| Reached the way a link from the index page reaches it: the calendar was
+already in when the URL arrived.
 -}
 loadingSpa : Shared.Model
 loadingSpa =
@@ -149,9 +146,8 @@ loadingSpa =
         |> step (FetchJson_Wec { season = "2025", event = "spa_6h" })
 
 
-{-| The same round reached the other way round, which is what a deep link does:
-the URL is known before the calendar that says where its files are. Nothing can
-be asked for until the second of the two lands.
+{-| The same round the other way round, which is what a deep link does: the URL
+is known before the calendar that says where its files are.
 -}
 loadingSpaByDeepLink : Shared.Model
 loadingSpaByDeepLink =
@@ -188,7 +184,6 @@ suite =
                         |> Expect.notEqual Nothing
             , test "leaves a round the calendar does not list unresolved" <|
                 \_ ->
-                    -- Nothing is asked for, and there is nothing to name.
                     fresh
                         |> step (CalendarLoaded (Ok calendar))
                         |> step (FetchJson_Wec { season = "2025", event = "monza_6h" })
@@ -209,9 +204,8 @@ suite =
                         |> Expect.equalLists [ True, True ]
             , test "drops a file left over from a round already navigated away from" <|
                 \_ ->
-                    -- Nothing cancels an Http.get. Untagged, Fuji's laps would
-                    -- land beside Spa's summary and the two would be assembled
-                    -- into a race that never ran.
+                    -- Untagged, Fuji's laps would land beside Spa's summary
+                    -- and be assembled into a race that never ran.
                     loadingSpa
                         |> deliverSummary spa
                         |> deliverLaps fuji
@@ -220,7 +214,6 @@ suite =
             , test "a stale pair does not complete the round that is waiting" <|
                 \_ ->
                     -- Both files of the round left behind, arriving together.
-                    -- Neither the round being waited on nor its emptiness moves.
                     loadingSpa
                         |> deliverLaps fuji
                         |> deliverSummary fuji

--- a/package/tests/SharedTest.elm
+++ b/package/tests/SharedTest.elm
@@ -1,0 +1,199 @@
+module SharedTest exposing (suite)
+
+{-| Drives `Shared.update` from the outside. The states a round passes through
+are not exposed, so what a round has got to is read back through
+[`Shared.race`](Shared#race) and [`Shared.roundId`](Shared#roundId), which is
+all a page can see of it either.
+-}
+
+import Data.Wec as Wec
+import Data.Wec.Calendar as Calendar
+import Data.Wec.Laps as WecLaps
+import Expect
+import Json.Decode as Decode
+import Motorsport.Wec.Era as Era
+import Shared
+import Shared.Msg exposing (Msg(..))
+import Test exposing (Test, describe, test)
+
+
+{-| Two seasons apart, and one of them runs two rounds -- the pairs a stale
+response can be mistaken for.
+-}
+calendarJson : String
+calendarJson =
+    """
+    { "seasons":
+        [ { "season": 2025
+          , "rounds":
+                [ { "id": "spa_6h", "name": "6 Hours of Spa", "date": "2025-05-10"
+                  , "summary": "/static/wec/2025/spa_6h.json"
+                  , "laps": "/static/wec/2025/spa_6h_laps.json"
+                  }
+                , { "id": "fuji_6h", "name": "6 Hours of Fuji", "date": "2025-09-28"
+                  , "summary": "/static/wec/2025/fuji_6h.json"
+                  , "laps": "/static/wec/2025/fuji_6h_laps.json"
+                  }
+                ]
+          }
+        ]
+    }
+    """
+
+
+summaryJson : String
+summaryJson =
+    """
+    { "name": "6 Hours of Spa"
+    , "season": 2025
+    , "date": "2025-05-10"
+    , "race": { "duration": "6:00:00.000", "timeLimit": "6:00:00.000", "lapTotal": 2 }
+    , "track":
+        { "direction": "clockwise"
+        , "sectors":
+            { "s1": { "start": 0.0, "share": 0.3 }
+            , "s2": { "start": 0.3, "share": 0.4 }
+            , "s3": { "start": 0.7, "share": 0.3 }
+            }
+        }
+    , "startingGrid":
+        { "basis": "lap1_s1"
+        , "entries":
+            [ { "position": 1
+              , "car":
+                    { "carNumber": "7", "drivers": [ { "name": "KOBAYASHI" } ]
+                    , "class": "HYPERCAR", "group": "H"
+                    , "team": "Toyota Gazoo Racing", "manufacturer": "Toyota"
+                    }
+              }
+            ]
+        }
+    }
+    """
+
+
+lapsJson : String
+lapsJson =
+    """
+    [ { "carNumber": "7", "driverName": "KOBAYASHI", "lapNumber": 1
+      , "lapTime": "1:53.000", "s1": "30.000", "s2": "45.000", "s3": "38.000"
+      , "elapsed": "1:53.000", "pitTime": ""
+      }
+    ]
+    """
+
+
+summary : Maybe Wec.Event
+summary =
+    Era.fromSeason 2025
+        |> Maybe.andThen
+            (\era ->
+                Decode.decodeString (Wec.eventDecoder era) summaryJson
+                    |> Result.toMaybe
+            )
+
+
+laps : List WecLaps.RawLap
+laps =
+    Decode.decodeString WecLaps.decoder lapsJson
+        |> Result.withDefault []
+
+
+{-| Delivers a fixture that may have failed to decode. A broken one leaves the
+round unchanged rather than passing an assertion by accident, and the fixture
+test below is what says so.
+-}
+deliverSummary : { season : Int, id : String } -> Shared.Model -> Shared.Model
+deliverSummary key model =
+    case summary of
+        Just decoded ->
+            step (JsonLoaded_Wec key (Ok decoded)) model
+
+        Nothing ->
+            model
+
+
+deliverLaps : { season : Int, id : String } -> Shared.Model -> Shared.Model
+deliverLaps key model =
+    step (LapsLoaded_Wec key (Ok laps)) model
+
+
+spa : { season : Int, id : String }
+spa =
+    { season = 2025, id = "spa_6h" }
+
+
+fuji : { season : Int, id : String }
+fuji =
+    { season = 2025, id = "fuji_6h" }
+
+
+{-| A model that has the calendar and has been asked for Spa, so it is waiting
+on Spa's two files.
+-}
+loadingSpa : Shared.Model
+loadingSpa =
+    let
+        calendar =
+            Decode.decodeString Calendar.decoder calendarJson
+                |> Result.withDefault Calendar.empty
+    in
+    Shared.init ()
+        |> Tuple.first
+        |> step (CalendarLoaded (Ok calendar))
+        |> step (FetchJson_Wec { season = "2025", event = "spa_6h" })
+
+
+step : Msg -> Shared.Model -> Shared.Model
+step msg model =
+    Shared.update msg model |> Tuple.first
+
+
+suite : Test
+suite =
+    describe "Shared"
+        [ test "the fixtures decode" <|
+            \_ ->
+                ( summary /= Nothing, List.length laps )
+                    |> Expect.equal ( True, 1 )
+        , describe "update"
+            [ test "names the round as soon as the calendar resolves it" <|
+                \_ ->
+                    loadingSpa
+                        |> Shared.roundId
+                        |> Maybe.map .name
+                        |> Expect.equal (Just "6 Hours of Spa")
+            , test "shows no race until both of the round's files are in" <|
+                \_ ->
+                    loadingSpa
+                        |> deliverSummary spa
+                        |> Shared.race
+                        |> Expect.equal Nothing
+            , test "builds the race once both are in, whichever order they arrive" <|
+                \_ ->
+                    [ loadingSpa |> deliverSummary spa |> deliverLaps spa
+                    , loadingSpa |> deliverLaps spa |> deliverSummary spa
+                    ]
+                        |> List.map (Shared.race >> (/=) Nothing)
+                        |> Expect.equalLists [ True, True ]
+            , test "drops a file left over from a round already navigated away from" <|
+                \_ ->
+                    -- Nothing cancels an Http.get. Untagged, Fuji's laps would
+                    -- land beside Spa's summary and the two would be assembled
+                    -- into a race that never ran.
+                    loadingSpa
+                        |> deliverSummary spa
+                        |> deliverLaps fuji
+                        |> Shared.race
+                        |> Expect.equal Nothing
+            , test "a stale pair does not complete the round that is waiting" <|
+                \_ ->
+                    -- Both files of the round left behind, arriving together.
+                    -- Neither the round being waited on nor its emptiness moves.
+                    loadingSpa
+                        |> deliverLaps fuji
+                        |> deliverSummary fuji
+                        |> (\m -> ( Shared.roundId m |> Maybe.map .id, Shared.race m /= Nothing ))
+                        |> Expect.equal ( Just "spa_6h", False )
+            ]
+        ]


### PR DESCRIPTION
## Why

`Shared.Model` had nine fields, seven of which described the round being shown.
They could be combined into states that are not a round, and two of those were
reachable.

**A response did not say which round it belonged to.** Nothing cancels an
`Http.get`, so navigating away from a round mid-load left its two file requests
in flight. One of them would land beside the *next* round's other file,
`finalizeWecIfReady` would see two `Just`s, and a race would be assembled from
one round's starting grid and another's laps. Entry lists overlap heavily
between rounds, so the result looks like a race — no error, no warning.

**`FetchJson_Wec` cleared the name but not the data.** `replay`, `snapshot` and
`track` were left alone, so a round loading behind another showed the previous
round's cars under the new round's name.

## What

```elm
type alias Model =
    { calendar : Calendar
    , round : Round
    }


type Round
    = NoRound
    | Waiting { season : String, event : String }
    | Loading RoundId Partial
    | Loaded RoundId Race


type Partial
    = NothingYet
    | GotSummary Wec.Event
    | GotLaps (List WecLaps.RawLap)
```

Nine fields become two. `Loading` carries no `Race`, so there is nothing stale to
show. `Partial` is three cases where two `Maybe`s were four combinations: holding
both files is not a state, it is the move to `Loaded`.

The two file responses now carry `{ season, id }`, captured when the request is
issued, and one naming any other round is dropped.

Pages read `Shared.roundId` for the name and `Shared.race` for the data — the
same split the states make, since the name is known an HTTP round trip before the
cars are. `ReplayMsg` now only reaches a `Loaded` round, so it no longer steps a
replay of no race.

`Replay.empty` and `Motorsport.Chart.Tracker.empty` existed to fill the model
this change emptied and had no remaining callers. `NoUnused.Exports` is not
enabled for the package, so nothing would have flagged them.

## Testing

`Shared` had no tests. It has eight, covering both orders the URL and the
calendar can arrive in — a click from the index page, and a deep link, where the
URL is known first and the request has to wait for the calendar that says where
the files are.

Two assert that a stale response is dropped, and two that a deep-linked round
resolves and loads. Both pairs were checked against the mutation they exist for:
removing the tag check fails the first two, removing the resume on
`CalendarLoaded` fails the other two.

VRT unchanged (`car-detail-popover`'s two failures predate this branch and
reproduce on `main`); elm-review unchanged at 8 pre-existing errors for the app
and 0 for the package.

## Note for reviewers

`elm/http` joins `package/elm.json`'s **test**-dependencies so `Shared` compiles
from the package's test suite. The package's own dependencies are untouched.
This does deepen an existing arrangement — `package/tests` already reaches into
`app/src` through `source-directories` — and if you would rather the app had its
own test runner, that is a fair thing to want instead.

## Not in scope

Making `Race` opaque so `replay` and `snapshot` cannot be written apart. Only
`raceFrom` and `stepReplay` write them today and both write both, so the type
work does not pay for itself yet.